### PR TITLE
Added support for Debian 10 (buster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ sudo yum install fullstaq-ruby-2.6.3
 
 ### Debian/Ubuntu
 
- * Supported Debian versions: 9
+ * Supported Debian versions: 9 *(stretch)*, 10 *(buster)*
  * Supported Ubuntu versions: 18.04
  * Supported architectures: x86-64
 
@@ -451,6 +451,9 @@ deb https://apt.fullstaqruby.org ubuntu-18.04 main
 
 # Debian 9
 deb https://apt.fullstaqruby.org debian-9 main
+
+# Debian 10
+deb https://apt.fullstaqruby.org debian-10 main
 ~~~
 
 Then run:

--- a/config.yml
+++ b/config.yml
@@ -96,4 +96,5 @@ distributions: all
 # distributions:
 #   - centos-7
 #   - debian-9
+#   - debian-10
 #   - ubuntu-18.04

--- a/environments/debian-10/Dockerfile
+++ b/environments/debian-10/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:10
+
+# If you make a change and you want to force users to re-pull the image
+# (e.g. when your change adds a feature that our scripts rely on, or is
+# breaking), then bump the version number in the `image_tag` file.
+
+RUN set -x && \
+    apt update && \
+    apt install -y autoconf bison bzip2 build-essential \
+        dpkg-dev curl ca-certificates ccache \
+        libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+    \
+    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.2/activatecontaineruid-0.9.2-x86_64-linux.gz && \
+    gunzip /sbin/activatecontaineruid.gz && \
+    chmod +x,+s /sbin/activatecontaineruid && \
+    mkdir /etc/activatecontaineruid && \
+    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    \
+    addgroup --gid 9999 builder && \
+    adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
+    usermod -L builder && \
+    apt clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+USER builder
+ENTRYPOINT ["/sbin/activatecontaineruid"]

--- a/environments/debian-10/image_tag
+++ b/environments/debian-10/image_tag
@@ -1,0 +1,4 @@
+# Bump this version whenever you've made a change and you want
+# to force users to re-pull the image (e.g. when your change adds
+# a feature that our scripts rely on, or is breaking).
+1


### PR DESCRIPTION
Fixes #16 

I just needed to rename `libgdbm4` to `libgdbm6`, then everything was compiled and packaged without any problems.

I also updated the README to include the debian release names: 9 *(stretch)*, 10 *(buster)*