### PR TITLE
Upgrade Ruby 2.7 to 2.7.2 release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -108,7 +108,7 @@ jobs:
       rbenv-src-needs-downloading: ${{ steps.check_rbenv_source.outputs.absent }}
 
 
-      'ruby-src-2_7_1-needs-downloading': '${{ steps.check_ruby_source_2_7_1.outputs.absent }}'
+      'ruby-src-2_7_2-needs-downloading': '${{ steps.check_ruby_source_2_7_2.outputs.absent }}'
       'ruby-src-2_6_6-needs-downloading': '${{ steps.check_ruby_source_2_6_6.outputs.absent }}'
       'ruby-src-2_5_8-needs-downloading': '${{ steps.check_ruby_source_2_5_8.outputs.absent }}'
 
@@ -143,11 +143,11 @@ jobs:
 
       'ruby-centos_7-2_5-malloctrim-needs-building': '${{ steps.check_ruby-centos_7-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-centos_7-2_7_1-normal-needs-building': '${{ steps.check_ruby-centos_7-2_7_1-normal.outputs.absent }}'
+      'ruby-centos_7-2_7_2-normal-needs-building': '${{ steps.check_ruby-centos_7-2_7_2-normal.outputs.absent }}'
 
-      'ruby-centos_7-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-centos_7-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-centos_7-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-centos_7-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-centos_7-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-centos_7-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-centos_7-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-centos_7-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-centos_7-2_6_6-normal-needs-building': '${{ steps.check_ruby-centos_7-2_6_6-normal.outputs.absent }}'
 
@@ -181,11 +181,11 @@ jobs:
 
       'ruby-centos_8-2_5-malloctrim-needs-building': '${{ steps.check_ruby-centos_8-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-centos_8-2_7_1-normal-needs-building': '${{ steps.check_ruby-centos_8-2_7_1-normal.outputs.absent }}'
+      'ruby-centos_8-2_7_2-normal-needs-building': '${{ steps.check_ruby-centos_8-2_7_2-normal.outputs.absent }}'
 
-      'ruby-centos_8-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-centos_8-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-centos_8-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-centos_8-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-centos_8-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-centos_8-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-centos_8-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-centos_8-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-centos_8-2_6_6-normal-needs-building': '${{ steps.check_ruby-centos_8-2_6_6-normal.outputs.absent }}'
 
@@ -219,11 +219,11 @@ jobs:
 
       'ruby-debian_10-2_5-malloctrim-needs-building': '${{ steps.check_ruby-debian_10-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-debian_10-2_7_1-normal-needs-building': '${{ steps.check_ruby-debian_10-2_7_1-normal.outputs.absent }}'
+      'ruby-debian_10-2_7_2-normal-needs-building': '${{ steps.check_ruby-debian_10-2_7_2-normal.outputs.absent }}'
 
-      'ruby-debian_10-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-debian_10-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-debian_10-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-debian_10-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-debian_10-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-debian_10-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-debian_10-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-debian_10-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-debian_10-2_6_6-normal-needs-building': '${{ steps.check_ruby-debian_10-2_6_6-normal.outputs.absent }}'
 
@@ -257,11 +257,11 @@ jobs:
 
       'ruby-debian_9-2_5-malloctrim-needs-building': '${{ steps.check_ruby-debian_9-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-debian_9-2_7_1-normal-needs-building': '${{ steps.check_ruby-debian_9-2_7_1-normal.outputs.absent }}'
+      'ruby-debian_9-2_7_2-normal-needs-building': '${{ steps.check_ruby-debian_9-2_7_2-normal.outputs.absent }}'
 
-      'ruby-debian_9-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-debian_9-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-debian_9-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-debian_9-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-debian_9-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-debian_9-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-debian_9-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-debian_9-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-debian_9-2_6_6-normal-needs-building': '${{ steps.check_ruby-debian_9-2_6_6-normal.outputs.absent }}'
 
@@ -295,11 +295,11 @@ jobs:
 
       'ruby-ubuntu_18_04-2_5-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-ubuntu_18_04-2_7_1-normal-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_1-normal.outputs.absent }}'
+      'ruby-ubuntu_18_04-2_7_2-normal-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_2-normal.outputs.absent }}'
 
-      'ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-ubuntu_18_04-2_6_6-normal-needs-building': '${{ steps.check_ruby-ubuntu_18_04-2_6_6-normal.outputs.absent }}'
 
@@ -333,11 +333,11 @@ jobs:
 
       'ruby-ubuntu_20_04-2_5-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_5-malloctrim.outputs.absent }}'
 
-      'ruby-ubuntu_20_04-2_7_1-normal-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_1-normal.outputs.absent }}'
+      'ruby-ubuntu_20_04-2_7_2-normal-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_2-normal.outputs.absent }}'
 
-      'ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_1-jemalloc.outputs.absent }}'
+      'ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_2-jemalloc.outputs.absent }}'
 
-      'ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_1-malloctrim.outputs.absent }}'
+      'ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_7_2-malloctrim.outputs.absent }}'
 
       'ruby-ubuntu_20_04-2_6_6-normal-needs-building': '${{ steps.check_ruby-ubuntu_20_04-2_6_6-normal.outputs.absent }}'
 
@@ -390,11 +390,11 @@ jobs:
           NAME: rbenv-src
 
 
-      - name: Determine whether Ruby source 2.7.1 needs to be downloaded
-        id: check_ruby_source_2_7_1
+      - name: Determine whether Ruby source 2.7.2 needs to be downloaded
+        id: check_ruby_source_2_7_2
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-src-2.7.1
+          NAME: ruby-src-2.7.2
       - name: Determine whether Ruby source 2.6.6 needs to be downloaded
         id: check_ruby_source_2_6_6
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
@@ -512,23 +512,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_centos-7_malloctrim
 
-      - name: Determine whether Ruby [centos-7/2.7.1/normal] needs to be built
-        id: 'check_ruby-centos_7-2_7_1-normal'
+      - name: Determine whether Ruby [centos-7/2.7.2/normal] needs to be built
+        id: 'check_ruby-centos_7-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-7_normal
+          NAME: ruby-pkg_2.7.2_centos-7_normal
 
-      - name: Determine whether Ruby [centos-7/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-centos_7-2_7_1-jemalloc'
+      - name: Determine whether Ruby [centos-7/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-centos_7-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-7_jemalloc
+          NAME: ruby-pkg_2.7.2_centos-7_jemalloc
 
-      - name: Determine whether Ruby [centos-7/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-centos_7-2_7_1-malloctrim'
+      - name: Determine whether Ruby [centos-7/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-centos_7-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-7_malloctrim
+          NAME: ruby-pkg_2.7.2_centos-7_malloctrim
 
       - name: Determine whether Ruby [centos-7/2.6.6/normal] needs to be built
         id: 'check_ruby-centos_7-2_6_6-normal'
@@ -626,23 +626,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_centos-8_malloctrim
 
-      - name: Determine whether Ruby [centos-8/2.7.1/normal] needs to be built
-        id: 'check_ruby-centos_8-2_7_1-normal'
+      - name: Determine whether Ruby [centos-8/2.7.2/normal] needs to be built
+        id: 'check_ruby-centos_8-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-8_normal
+          NAME: ruby-pkg_2.7.2_centos-8_normal
 
-      - name: Determine whether Ruby [centos-8/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-centos_8-2_7_1-jemalloc'
+      - name: Determine whether Ruby [centos-8/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-centos_8-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-8_jemalloc
+          NAME: ruby-pkg_2.7.2_centos-8_jemalloc
 
-      - name: Determine whether Ruby [centos-8/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-centos_8-2_7_1-malloctrim'
+      - name: Determine whether Ruby [centos-8/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-centos_8-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_centos-8_malloctrim
+          NAME: ruby-pkg_2.7.2_centos-8_malloctrim
 
       - name: Determine whether Ruby [centos-8/2.6.6/normal] needs to be built
         id: 'check_ruby-centos_8-2_6_6-normal'
@@ -740,23 +740,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_debian-10_malloctrim
 
-      - name: Determine whether Ruby [debian-10/2.7.1/normal] needs to be built
-        id: 'check_ruby-debian_10-2_7_1-normal'
+      - name: Determine whether Ruby [debian-10/2.7.2/normal] needs to be built
+        id: 'check_ruby-debian_10-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-10_normal
+          NAME: ruby-pkg_2.7.2_debian-10_normal
 
-      - name: Determine whether Ruby [debian-10/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-debian_10-2_7_1-jemalloc'
+      - name: Determine whether Ruby [debian-10/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-debian_10-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-10_jemalloc
+          NAME: ruby-pkg_2.7.2_debian-10_jemalloc
 
-      - name: Determine whether Ruby [debian-10/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-debian_10-2_7_1-malloctrim'
+      - name: Determine whether Ruby [debian-10/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-debian_10-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-10_malloctrim
+          NAME: ruby-pkg_2.7.2_debian-10_malloctrim
 
       - name: Determine whether Ruby [debian-10/2.6.6/normal] needs to be built
         id: 'check_ruby-debian_10-2_6_6-normal'
@@ -854,23 +854,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_debian-9_malloctrim
 
-      - name: Determine whether Ruby [debian-9/2.7.1/normal] needs to be built
-        id: 'check_ruby-debian_9-2_7_1-normal'
+      - name: Determine whether Ruby [debian-9/2.7.2/normal] needs to be built
+        id: 'check_ruby-debian_9-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-9_normal
+          NAME: ruby-pkg_2.7.2_debian-9_normal
 
-      - name: Determine whether Ruby [debian-9/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-debian_9-2_7_1-jemalloc'
+      - name: Determine whether Ruby [debian-9/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-debian_9-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-9_jemalloc
+          NAME: ruby-pkg_2.7.2_debian-9_jemalloc
 
-      - name: Determine whether Ruby [debian-9/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-debian_9-2_7_1-malloctrim'
+      - name: Determine whether Ruby [debian-9/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-debian_9-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_debian-9_malloctrim
+          NAME: ruby-pkg_2.7.2_debian-9_malloctrim
 
       - name: Determine whether Ruby [debian-9/2.6.6/normal] needs to be built
         id: 'check_ruby-debian_9-2_6_6-normal'
@@ -968,23 +968,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_ubuntu-18.04_malloctrim
 
-      - name: Determine whether Ruby [ubuntu-18.04/2.7.1/normal] needs to be built
-        id: 'check_ruby-ubuntu_18_04-2_7_1-normal'
+      - name: Determine whether Ruby [ubuntu-18.04/2.7.2/normal] needs to be built
+        id: 'check_ruby-ubuntu_18_04-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-18.04_normal
+          NAME: ruby-pkg_2.7.2_ubuntu-18.04_normal
 
-      - name: Determine whether Ruby [ubuntu-18.04/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-ubuntu_18_04-2_7_1-jemalloc'
+      - name: Determine whether Ruby [ubuntu-18.04/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-ubuntu_18_04-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+          NAME: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
 
-      - name: Determine whether Ruby [ubuntu-18.04/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-ubuntu_18_04-2_7_1-malloctrim'
+      - name: Determine whether Ruby [ubuntu-18.04/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-ubuntu_18_04-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+          NAME: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
 
       - name: Determine whether Ruby [ubuntu-18.04/2.6.6/normal] needs to be built
         id: 'check_ruby-ubuntu_18_04-2_6_6-normal'
@@ -1082,23 +1082,23 @@ jobs:
         env:
           NAME: ruby-pkg_2.5_ubuntu-20.04_malloctrim
 
-      - name: Determine whether Ruby [ubuntu-20.04/2.7.1/normal] needs to be built
-        id: 'check_ruby-ubuntu_20_04-2_7_1-normal'
+      - name: Determine whether Ruby [ubuntu-20.04/2.7.2/normal] needs to be built
+        id: 'check_ruby-ubuntu_20_04-2_7_2-normal'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-20.04_normal
+          NAME: ruby-pkg_2.7.2_ubuntu-20.04_normal
 
-      - name: Determine whether Ruby [ubuntu-20.04/2.7.1/jemalloc] needs to be built
-        id: 'check_ruby-ubuntu_20_04-2_7_1-jemalloc'
+      - name: Determine whether Ruby [ubuntu-20.04/2.7.2/jemalloc] needs to be built
+        id: 'check_ruby-ubuntu_20_04-2_7_2-jemalloc'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+          NAME: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
 
-      - name: Determine whether Ruby [ubuntu-20.04/2.7.1/malloctrim] needs to be built
-        id: 'check_ruby-ubuntu_20_04-2_7_1-malloctrim'
+      - name: Determine whether Ruby [ubuntu-20.04/2.7.2/malloctrim] needs to be built
+        id: 'check_ruby-ubuntu_20_04-2_7_2-malloctrim'
         run: ./internal-scripts/ci-cd/determine-necessary-jobs/check-artifact-exists.rb
         env:
-          NAME: ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+          NAME: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
 
       - name: Determine whether Ruby [ubuntu-20.04/2.6.6/normal] needs to be built
         id: 'check_ruby-ubuntu_20_04-2_6_6-normal'
@@ -1409,12 +1409,12 @@ jobs:
   ### Sources ###
 
 
-  download_ruby_source_2_7_1:
-    name: Download Ruby source [2.7.1]
+  download_ruby_source_2_7_2:
+    name: Download Ruby source [2.7.2]
     needs:
       - determine_necessary_jobs
     runs-on: ubuntu-18.04
-    if: needs.determine_necessary_jobs.outputs.ruby-src-2_7_1-needs-downloading == 'true'
+    if: needs.determine_necessary_jobs.outputs.ruby-src-2_7_2-needs-downloading == 'true'
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1427,18 +1427,18 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-2.7.1
+          key: v3-ruby-src-2.7.2
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 2.7.1
+          RUBY_VERSION: 2.7.2
 
       - name: Archive artifact
         uses: ./.github/actions/upload-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: output
   download_ruby_source_2_6_6:
     name: Download Ruby source [2.6.6]
@@ -2052,7 +2052,7 @@ jobs:
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -2080,7 +2080,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -2139,7 +2139,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7-normal-needs-building == 'true'"
@@ -2184,7 +2184,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7-jemalloc-needs-building == 'true'"
@@ -2223,7 +2223,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7-malloctrim-needs-building == 'true'"
@@ -2240,7 +2240,7 @@ jobs:
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -2428,7 +2428,7 @@ jobs:
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -2608,15 +2608,15 @@ jobs:
           name: "ruby-pkg_2.5_centos-7_malloctrim"
           path: output
 
-  build_ruby_packages_centos_7-2_7_1:
-    name: 'Build Ruby packages [centos-7/2.7.1]'
+  build_ruby_packages_centos_7-2_7_2:
+    name: 'Build Ruby packages [centos-7/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_centos_7'
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -2627,11 +2627,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -2644,7 +2644,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -2675,125 +2675,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-7-normal
+          key: ruby-bin-2.7.2-centos-7-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-7_normal"
+          name: "ruby-pkg_2.7.2_centos-7_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-centos-7
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-7-jemalloc
+          key: ruby-bin-2.7.2-centos-7-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-7_jemalloc"
+          name: "ruby-pkg_2.7.2_centos-7_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-7-malloctrim
+          key: ruby-bin-2.7.2-centos-7-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_7-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-7_malloctrim"
+          name: "ruby-pkg_2.7.2_centos-7_malloctrim"
           path: output
 
   build_ruby_packages_centos_7-2_6_6:
@@ -2804,7 +2804,7 @@ jobs:
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -2992,7 +2992,7 @@ jobs:
       - 'build_docker_image_centos_7'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -3181,7 +3181,7 @@ jobs:
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -3209,7 +3209,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -3268,7 +3268,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7-normal-needs-building == 'true'"
@@ -3313,7 +3313,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7-jemalloc-needs-building == 'true'"
@@ -3352,7 +3352,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7-malloctrim-needs-building == 'true'"
@@ -3369,7 +3369,7 @@ jobs:
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -3557,7 +3557,7 @@ jobs:
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -3737,15 +3737,15 @@ jobs:
           name: "ruby-pkg_2.5_centos-8_malloctrim"
           path: output
 
-  build_ruby_packages_centos_8-2_7_1:
-    name: 'Build Ruby packages [centos-8/2.7.1]'
+  build_ruby_packages_centos_8-2_7_2:
+    name: 'Build Ruby packages [centos-8/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_centos_8'
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -3756,11 +3756,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -3773,7 +3773,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -3804,125 +3804,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-8-normal
+          key: ruby-bin-2.7.2-centos-8-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-8_normal"
+          name: "ruby-pkg_2.7.2_centos-8_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-centos-8
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-8-jemalloc
+          key: ruby-bin-2.7.2-centos-8-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-8_jemalloc"
+          name: "ruby-pkg_2.7.2_centos-8_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-centos-8-malloctrim
+          key: ruby-bin-2.7.2-centos-8-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-centos_8-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_centos-8_malloctrim"
+          name: "ruby-pkg_2.7.2_centos-8_malloctrim"
           path: output
 
   build_ruby_packages_centos_8-2_6_6:
@@ -3933,7 +3933,7 @@ jobs:
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4121,7 +4121,7 @@ jobs:
       - 'build_docker_image_centos_8'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4310,7 +4310,7 @@ jobs:
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4338,7 +4338,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -4397,7 +4397,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7-normal-needs-building == 'true'"
@@ -4442,7 +4442,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7-jemalloc-needs-building == 'true'"
@@ -4481,7 +4481,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7-malloctrim-needs-building == 'true'"
@@ -4498,7 +4498,7 @@ jobs:
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4686,7 +4686,7 @@ jobs:
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4866,15 +4866,15 @@ jobs:
           name: "ruby-pkg_2.5_debian-10_malloctrim"
           path: output
 
-  build_ruby_packages_debian_10-2_7_1:
-    name: 'Build Ruby packages [debian-10/2.7.1]'
+  build_ruby_packages_debian_10-2_7_2:
+    name: 'Build Ruby packages [debian-10/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_debian_10'
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -4885,11 +4885,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -4902,7 +4902,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -4933,125 +4933,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-10-normal
+          key: ruby-bin-2.7.2-debian-10-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-10_normal"
+          name: "ruby-pkg_2.7.2_debian-10_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-debian-10
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-10-jemalloc
+          key: ruby-bin-2.7.2-debian-10-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-10_jemalloc"
+          name: "ruby-pkg_2.7.2_debian-10_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-10-malloctrim
+          key: ruby-bin-2.7.2-debian-10-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_10-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-10_malloctrim"
+          name: "ruby-pkg_2.7.2_debian-10_malloctrim"
           path: output
 
   build_ruby_packages_debian_10-2_6_6:
@@ -5062,7 +5062,7 @@ jobs:
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -5250,7 +5250,7 @@ jobs:
       - 'build_docker_image_debian_10'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -5439,7 +5439,7 @@ jobs:
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -5467,7 +5467,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -5526,7 +5526,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7-normal-needs-building == 'true'"
@@ -5571,7 +5571,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7-jemalloc-needs-building == 'true'"
@@ -5610,7 +5610,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7-malloctrim-needs-building == 'true'"
@@ -5627,7 +5627,7 @@ jobs:
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -5815,7 +5815,7 @@ jobs:
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -5995,15 +5995,15 @@ jobs:
           name: "ruby-pkg_2.5_debian-9_malloctrim"
           path: output
 
-  build_ruby_packages_debian_9-2_7_1:
-    name: 'Build Ruby packages [debian-9/2.7.1]'
+  build_ruby_packages_debian_9-2_7_2:
+    name: 'Build Ruby packages [debian-9/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_debian_9'
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -6014,11 +6014,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -6031,7 +6031,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -6062,125 +6062,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-9-normal
+          key: ruby-bin-2.7.2-debian-9-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-9_normal"
+          name: "ruby-pkg_2.7.2_debian-9_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-debian-9
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-9-jemalloc
+          key: ruby-bin-2.7.2-debian-9-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-9_jemalloc"
+          name: "ruby-pkg_2.7.2_debian-9_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-debian-9-malloctrim
+          key: ruby-bin-2.7.2-debian-9-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-debian_9-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_debian-9_malloctrim"
+          name: "ruby-pkg_2.7.2_debian-9_malloctrim"
           path: output
 
   build_ruby_packages_debian_9-2_6_6:
@@ -6191,7 +6191,7 @@ jobs:
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -6379,7 +6379,7 @@ jobs:
       - 'build_docker_image_debian_9'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -6568,7 +6568,7 @@ jobs:
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -6596,7 +6596,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -6655,7 +6655,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7-normal-needs-building == 'true'"
@@ -6700,7 +6700,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7-jemalloc-needs-building == 'true'"
@@ -6739,7 +6739,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7-malloctrim-needs-building == 'true'"
@@ -6756,7 +6756,7 @@ jobs:
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -6944,7 +6944,7 @@ jobs:
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -7124,15 +7124,15 @@ jobs:
           name: "ruby-pkg_2.5_ubuntu-18.04_malloctrim"
           path: output
 
-  build_ruby_packages_ubuntu_18_04-2_7_1:
-    name: 'Build Ruby packages [ubuntu-18.04/2.7.1]'
+  build_ruby_packages_ubuntu_18_04-2_7_2:
+    name: 'Build Ruby packages [ubuntu-18.04/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_ubuntu_18_04'
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -7143,11 +7143,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -7160,7 +7160,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -7191,125 +7191,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-18.04-normal
+          key: ruby-bin-2.7.2-ubuntu-18.04-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-18.04_normal"
+          name: "ruby-pkg_2.7.2_ubuntu-18.04_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-ubuntu-18.04
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-18.04-jemalloc
+          key: ruby-bin-2.7.2-ubuntu-18.04-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-18.04_jemalloc"
+          name: "ruby-pkg_2.7.2_ubuntu-18.04_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-18.04-malloctrim
+          key: ruby-bin-2.7.2-ubuntu-18.04-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_18_04-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-18.04_malloctrim"
+          name: "ruby-pkg_2.7.2_ubuntu-18.04_malloctrim"
           path: output
 
   build_ruby_packages_ubuntu_18_04-2_6_6:
@@ -7320,7 +7320,7 @@ jobs:
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -7508,7 +7508,7 @@ jobs:
       - 'build_docker_image_ubuntu_18_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -7697,7 +7697,7 @@ jobs:
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -7725,7 +7725,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -7784,7 +7784,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[normal] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7-normal-needs-building == 'true'"
@@ -7829,7 +7829,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7-jemalloc-needs-building == 'true'"
@@ -7868,7 +7868,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
         if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7-malloctrim-needs-building == 'true'"
@@ -7885,7 +7885,7 @@ jobs:
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -8073,7 +8073,7 @@ jobs:
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -8253,15 +8253,15 @@ jobs:
           name: "ruby-pkg_2.5_ubuntu-20.04_malloctrim"
           path: output
 
-  build_ruby_packages_ubuntu_20_04-2_7_1:
-    name: 'Build Ruby packages [ubuntu-20.04/2.7.1]'
+  build_ruby_packages_ubuntu_20_04-2_7_2:
+    name: 'Build Ruby packages [ubuntu-20.04/2.7.2]'
     needs:
       - 'determine_necessary_jobs'
       - 'build_jemalloc_binary_ubuntu_20_04'
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -8272,11 +8272,11 @@ jobs:
     if: |
       (
 
-        needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'
+        needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'
 
-        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'
+        || needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'
 
       )
       && !failure() && !cancelled()
@@ -8289,7 +8289,7 @@ jobs:
       - name: Fetch Ruby source
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: .
 
       - name: Download Docker image necessary for building
@@ -8320,125 +8320,125 @@ jobs:
       
 
       - name: "[normal] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[normal] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-20.04-normal
+          key: ruby-bin-2.7.2-ubuntu-20.04-normal
 
       - name: "[normal] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[normal] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[normal] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-normal-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-normal-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-20.04_normal"
+          name: "ruby-pkg_2.7.2_ubuntu-20.04_normal"
           path: output
       
       - name: Fetch Jemalloc binary
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/download-artifact
         with:
           name: jemalloc-bin-ubuntu-20.04
           path: .          
 
       - name: "[jemalloc] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[jemalloc] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-20.04-jemalloc
+          key: ruby-bin-2.7.2-ubuntu-20.04-jemalloc
 
       - name: "[jemalloc] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[jemalloc] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[jemalloc] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-jemalloc-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-jemalloc-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-20.04_jemalloc"
+          name: "ruby-pkg_2.7.2_ubuntu-20.04_jemalloc"
           path: output
       
 
       - name: "[malloctrim] Reset & prepare workspace"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'"
         run: |
           rm -rf cache output ruby-bin.tar.gz
           mkdir -p cache
       - name: "[malloctrim] Fetch cache"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'"
         uses: actions/cache@v1
         with:
           path: cache
-          key: ruby-bin-2.7.1-ubuntu-20.04-malloctrim
+          key: ruby-bin-2.7.2-ubuntu-20.04-malloctrim
 
       - name: "[malloctrim] Build binaries"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
 
       - name: "[malloctrim] Build package"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'"
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.1"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: "[malloctrim] Archive package artifact to Google Cloud"
-        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_1-malloctrim-needs-building == 'true'"
+        if: "needs.determine_necessary_jobs.outputs.ruby-ubuntu_20_04-2_7_2-malloctrim-needs-building == 'true'"
         uses: ./.github/actions/upload-artifact
         with:
-          name: "ruby-pkg_2.7.1_ubuntu-20.04_malloctrim"
+          name: "ruby-pkg_2.7.2_ubuntu-20.04_malloctrim"
           path: output
 
   build_ruby_packages_ubuntu_20_04-2_6_6:
@@ -8449,7 +8449,7 @@ jobs:
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -8637,7 +8637,7 @@ jobs:
       - 'build_docker_image_ubuntu_20_04'
       - 'build_docker_image_utility'
 
-      - 'download_ruby_source_2_7_1'
+      - 'download_ruby_source_2_7_2'
 
       - 'download_ruby_source_2_6_6'
 
@@ -8831,7 +8831,7 @@ jobs:
       - build_rbenv_deb
       - build_rbenv_rpm
 
-      - download_ruby_source_2_7_1
+      - download_ruby_source_2_7_2
 
       - download_ruby_source_2_6_6
 
@@ -8846,7 +8846,7 @@ jobs:
 
       - build_ruby_packages_centos_7-2_5
 
-      - build_ruby_packages_centos_7-2_7_1
+      - build_ruby_packages_centos_7-2_7_2
 
       - build_ruby_packages_centos_7-2_6_6
 
@@ -8860,7 +8860,7 @@ jobs:
 
       - build_ruby_packages_centos_8-2_5
 
-      - build_ruby_packages_centos_8-2_7_1
+      - build_ruby_packages_centos_8-2_7_2
 
       - build_ruby_packages_centos_8-2_6_6
 
@@ -8874,7 +8874,7 @@ jobs:
 
       - build_ruby_packages_debian_10-2_5
 
-      - build_ruby_packages_debian_10-2_7_1
+      - build_ruby_packages_debian_10-2_7_2
 
       - build_ruby_packages_debian_10-2_6_6
 
@@ -8888,7 +8888,7 @@ jobs:
 
       - build_ruby_packages_debian_9-2_5
 
-      - build_ruby_packages_debian_9-2_7_1
+      - build_ruby_packages_debian_9-2_7_2
 
       - build_ruby_packages_debian_9-2_6_6
 
@@ -8902,7 +8902,7 @@ jobs:
 
       - build_ruby_packages_ubuntu_18_04-2_5
 
-      - build_ruby_packages_ubuntu_18_04-2_7_1
+      - build_ruby_packages_ubuntu_18_04-2_7_2
 
       - build_ruby_packages_ubuntu_18_04-2_6_6
 
@@ -8916,7 +8916,7 @@ jobs:
 
       - build_ruby_packages_ubuntu_20_04-2_5
 
-      - build_ruby_packages_ubuntu_20_04-2_7_1
+      - build_ruby_packages_ubuntu_20_04-2_7_2
 
       - build_ruby_packages_ubuntu_20_04-2_6_6
 
@@ -9104,15 +9104,15 @@ jobs:
         run: rm -rf artifacts
 
 
-      - name: Download Ruby source artifact [2.7.1] from Google Cloud
+      - name: Download Ruby source artifact [2.7.2] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: artifacts
-      - name: Archive Ruby source artifact [2.7.1] to Github
+      - name: Archive Ruby source artifact [2.7.2] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-2.7.1
+          name: ruby-src-2.7.2
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
@@ -9864,219 +9864,219 @@ jobs:
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-7_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-7_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_normal
+          name: ruby-pkg_2.7.2_centos-7_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-7_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-7_normal
+          name: ruby-pkg_2.7.2_centos-7_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-7_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-7_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_jemalloc
+          name: ruby-pkg_2.7.2_centos-7_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-7_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-7_jemalloc
+          name: ruby-pkg_2.7.2_centos-7_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-7_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-7_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_malloctrim
+          name: ruby-pkg_2.7.2_centos-7_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-7_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-7_malloctrim
+          name: ruby-pkg_2.7.2_centos-7_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-8_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-8_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_normal
+          name: ruby-pkg_2.7.2_centos-8_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-8_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-8_normal
+          name: ruby-pkg_2.7.2_centos-8_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-8_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-8_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_jemalloc
+          name: ruby-pkg_2.7.2_centos-8_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-8_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-8_jemalloc
+          name: ruby-pkg_2.7.2_centos-8_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_centos-8_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_centos-8_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_malloctrim
+          name: ruby-pkg_2.7.2_centos-8_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_centos-8_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_centos-8_malloctrim
+          name: ruby-pkg_2.7.2_centos-8_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-10_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-10_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_normal
+          name: ruby-pkg_2.7.2_debian-10_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-10_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-10_normal
+          name: ruby-pkg_2.7.2_debian-10_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-10_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-10_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_jemalloc
+          name: ruby-pkg_2.7.2_debian-10_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-10_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-10_jemalloc
+          name: ruby-pkg_2.7.2_debian-10_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-10_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-10_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_malloctrim
+          name: ruby-pkg_2.7.2_debian-10_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-10_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-10_malloctrim
+          name: ruby-pkg_2.7.2_debian-10_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-9_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-9_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_normal
+          name: ruby-pkg_2.7.2_debian-9_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-9_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-9_normal
+          name: ruby-pkg_2.7.2_debian-9_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-9_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-9_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_jemalloc
+          name: ruby-pkg_2.7.2_debian-9_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-9_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-9_jemalloc
+          name: ruby-pkg_2.7.2_debian-9_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_debian-9_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_debian-9_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_malloctrim
+          name: ruby-pkg_2.7.2_debian-9_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_debian-9_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_debian-9_malloctrim
+          name: ruby-pkg_2.7.2_debian-9_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-18.04_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-18.04_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-18.04_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_normal] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_normal] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-20.04_normal
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-20.04_normal
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_jemalloc] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_jemalloc] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
-      - name: Download Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_malloctrim] from Google Cloud
+      - name: Download Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_malloctrim] from Google Cloud
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
           path: artifacts
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.1_ubuntu-20.04_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
           path: artifacts
       - name: Clear artifacts directory
         run: rm -rf artifacts
@@ -10691,7 +10691,7 @@ jobs:
 
       - build_ruby_packages_centos_7-2_5
 
-      - build_ruby_packages_centos_7-2_7_1
+      - build_ruby_packages_centos_7-2_7_2
 
       - build_ruby_packages_centos_7-2_6_6
 
@@ -10704,7 +10704,7 @@ jobs:
 
       - build_ruby_packages_centos_8-2_5
 
-      - build_ruby_packages_centos_8-2_7_1
+      - build_ruby_packages_centos_8-2_7_2
 
       - build_ruby_packages_centos_8-2_6_6
 
@@ -10717,7 +10717,7 @@ jobs:
 
       - build_ruby_packages_debian_10-2_5
 
-      - build_ruby_packages_debian_10-2_7_1
+      - build_ruby_packages_debian_10-2_7_2
 
       - build_ruby_packages_debian_10-2_6_6
 
@@ -10730,7 +10730,7 @@ jobs:
 
       - build_ruby_packages_debian_9-2_5
 
-      - build_ruby_packages_debian_9-2_7_1
+      - build_ruby_packages_debian_9-2_7_2
 
       - build_ruby_packages_debian_9-2_6_6
 
@@ -10743,7 +10743,7 @@ jobs:
 
       - build_ruby_packages_ubuntu_18_04-2_5
 
-      - build_ruby_packages_ubuntu_18_04-2_7_1
+      - build_ruby_packages_ubuntu_18_04-2_7_2
 
       - build_ruby_packages_ubuntu_18_04-2_6_6
 
@@ -10756,7 +10756,7 @@ jobs:
 
       - build_ruby_packages_ubuntu_20_04-2_5
 
-      - build_ruby_packages_ubuntu_20_04-2_7_1
+      - build_ruby_packages_ubuntu_20_04-2_7_2
 
       - build_ruby_packages_ubuntu_20_04-2_6_6
 
@@ -11046,95 +11046,95 @@ jobs:
         with:
           name: ruby-pkg_2.5_ubuntu-20.04_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-7_normal
+      - name: Fetch ruby-pkg_2.7.2_centos-7_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_normal
+          name: ruby-pkg_2.7.2_centos-7_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-7_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_centos-7_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_jemalloc
+          name: ruby-pkg_2.7.2_centos-7_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-7_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_centos-7_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_malloctrim
+          name: ruby-pkg_2.7.2_centos-7_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-8_normal
+      - name: Fetch ruby-pkg_2.7.2_centos-8_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_normal
+          name: ruby-pkg_2.7.2_centos-8_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-8_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_centos-8_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_jemalloc
+          name: ruby-pkg_2.7.2_centos-8_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_centos-8_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_centos-8_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_malloctrim
+          name: ruby-pkg_2.7.2_centos-8_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-10_normal
+      - name: Fetch ruby-pkg_2.7.2_debian-10_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_normal
+          name: ruby-pkg_2.7.2_debian-10_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-10_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_debian-10_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_jemalloc
+          name: ruby-pkg_2.7.2_debian-10_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-10_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_debian-10_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_malloctrim
+          name: ruby-pkg_2.7.2_debian-10_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-9_normal
+      - name: Fetch ruby-pkg_2.7.2_debian-9_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_normal
+          name: ruby-pkg_2.7.2_debian-9_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-9_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_debian-9_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_jemalloc
+          name: ruby-pkg_2.7.2_debian-9_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_debian-9_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_debian-9_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_malloctrim
+          name: ruby-pkg_2.7.2_debian-9_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_normal
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-18.04_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_normal
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-20.04_normal
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
           path: ruby-pkgs
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
           path: ruby-pkgs
       - name: Fetch ruby-pkg_2.6.6_centos-7_normal
         uses: ./.github/actions/download-artifact
@@ -11403,8 +11403,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11414,9 +11414,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -11454,8 +11454,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11465,9 +11465,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -11505,8 +11505,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11516,9 +11516,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -11556,8 +11556,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11567,9 +11567,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -11607,8 +11607,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11618,9 +11618,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -11658,8 +11658,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -11669,9 +11669,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12016,95 +12016,95 @@ jobs:
         with:
           name: ruby-pkg_2.5_ubuntu-20.04_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-7_normal
+      - name: Fetch ruby-pkg_2.7.2_centos-7_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_normal
+          name: ruby-pkg_2.7.2_centos-7_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-7_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_centos-7_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_jemalloc
+          name: ruby-pkg_2.7.2_centos-7_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-7_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_centos-7_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-7_malloctrim
+          name: ruby-pkg_2.7.2_centos-7_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-8_normal
+      - name: Fetch ruby-pkg_2.7.2_centos-8_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_normal
+          name: ruby-pkg_2.7.2_centos-8_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-8_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_centos-8_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_jemalloc
+          name: ruby-pkg_2.7.2_centos-8_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_centos-8_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_centos-8_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_centos-8_malloctrim
+          name: ruby-pkg_2.7.2_centos-8_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-10_normal
+      - name: Fetch ruby-pkg_2.7.2_debian-10_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_normal
+          name: ruby-pkg_2.7.2_debian-10_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-10_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_debian-10_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_jemalloc
+          name: ruby-pkg_2.7.2_debian-10_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-10_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_debian-10_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-10_malloctrim
+          name: ruby-pkg_2.7.2_debian-10_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-9_normal
+      - name: Fetch ruby-pkg_2.7.2_debian-9_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_normal
+          name: ruby-pkg_2.7.2_debian-9_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-9_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_debian-9_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_jemalloc
+          name: ruby-pkg_2.7.2_debian-9_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_debian-9_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_debian-9_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_debian-9_malloctrim
+          name: ruby-pkg_2.7.2_debian-9_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_normal
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-18.04_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-18.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_normal
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_normal
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_normal
+          name: ruby-pkg_2.7.2_ubuntu-20.04_normal
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_jemalloc
+          name: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
           path: .
-      - name: Fetch ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+      - name: Fetch ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
         uses: ./.github/actions/download-artifact
         with:
-          name: ruby-pkg_2.7.1_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
           path: .
       - name: Fetch ruby-pkg_2.6.6_centos-7_normal
         uses: ./.github/actions/download-artifact
@@ -12357,8 +12357,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12368,9 +12368,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12408,8 +12408,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12419,9 +12419,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12459,8 +12459,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12470,9 +12470,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12510,8 +12510,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12521,9 +12521,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12561,8 +12561,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12572,9 +12572,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6
@@ -12612,8 +12612,8 @@ jobs:
       matrix:
         ruby_package_version: 
         - minor_version: 2.7
-          full_version: 2.7.1
-          package_revision: 2
+          full_version: 2.7.2
+          package_revision: 3
           id: 2.7
         - minor_version: 2.6
           full_version: 2.6.6
@@ -12623,9 +12623,9 @@ jobs:
           full_version: 2.5.8
           package_revision: 5
           id: 2.5
-        - full_version: 2.7.1
-          package_revision: 1
-          id: 2.7.1
+        - full_version: 2.7.2
+          package_revision: 2
+          id: 2.7.2
         - full_version: 2.6.6
           package_revision: 2
           id: 2.6.6

--- a/config.yml
+++ b/config.yml
@@ -26,8 +26,8 @@ ruby:
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
     - minor_version: 2.7
-      full_version: 2.7.1
-      package_revision: 2
+      full_version: 2.7.2
+      package_revision: 3
     - minor_version: 2.6
       full_version: 2.6.6
       package_revision: 6
@@ -38,8 +38,8 @@ ruby:
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
-    - full_version: 2.7.1
-      package_revision: 1
+    - full_version: 2.7.2
+      package_revision: 2
     - full_version: 2.6.6
       package_revision: 2
     - full_version: 2.5.8


### PR DESCRIPTION
Ruby Core have released Ruby 2.7.2, and with a wave of excitement I'd like to help Fullstaq have this version available for all to install. https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/

From looking at the instructions in `dev-handbook/add-new-ruby-version.md` I think these are the only config changes required to start building these packages.

(PS: This project is awesome, and I _love_ the included documentation. Really easy to get a sense of how it hangs together and works. Thank you very much for creating this project 👏.)