### PR TITLE
add pronounce to the people in the code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -63,8 +63,8 @@ reported by contacting the project team at open-source@fullstaq.com ([@fullstaq-
 
 If you'd like to contact individual maintainers please contact one of the following:
 
-* Daniel Paulus - [@PaulusTM](https://github.com/PaulusTM) - d.paulus@gmail.com
-* Hongli Lai - [@FooBarWidget](https://github.com/FooBarWidget) - honglilai@gmail.com
+* Daniel Paulus [(he/him)](https://www.mypronouns.org/he-him) - [@PaulusTM](https://github.com/PaulusTM) - d.paulus@gmail.com
+* Hongli Lai [(he/him)](https://www.mypronouns.org/he-him) - [@FooBarWidget](https://github.com/FooBarWidget) - honglilai@gmail.com
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
As mentioned by @FloorD in #63 it is a good idea to add a pronounce for the people in the code of conduct. This PR implements that idea.