### PR TITLE
Add source label to containers for the move to GitHub container registry

### DIFF
--- a/environments/centos-7/Dockerfile
+++ b/environments/centos-7/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/centos-8/Dockerfile
+++ b/environments/centos-8/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:8
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/debian-10/Dockerfile
+++ b/environments/debian-10/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:10
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/debian-9/Dockerfile
+++ b/environments/debian-9/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:9
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/ubuntu-18.04/Dockerfile
+++ b/environments/ubuntu-18.04/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/ubuntu-20.04/Dockerfile
+++ b/environments/ubuntu-20.04/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:20.04
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.

--- a/environments/utility/Dockerfile
+++ b/environments/utility/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+# Used to link container image to the repo: 
+# https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
+LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
 # breaking), then bump the version number in the `image_tag` file.


### PR DESCRIPTION
This are the first steps to move the containers to the GitHub Container Registry (#50).

Follows the steps described in: https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line