### PR TITLE
Add Ruby 3.0.0

### DIFF
--- a/.github/workflows/ci-cd-build-packages.yml
+++ b/.github/workflows/ci-cd-build-packages.yml
@@ -531,6 +531,266 @@ jobs:
 
 
 
+  build_ruby_centos_7-3_0-normal:
+    name: 'Build Ruby [centos-7/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-centos-7-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-7_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_centos_7-3_0-jemalloc:
+    name: 'Build Ruby [centos-7/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-7
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-centos-7-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-7_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_centos_7-3_0-malloctrim:
+    name: 'Build Ruby [centos-7/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-centos-7-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-7_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_centos_7-2_7-normal:
     name: 'Build Ruby [centos-7/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -1309,6 +1569,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_centos-7_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_centos_7-3_0_0-normal:
+    name: 'Build Ruby [centos-7/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-centos-7-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_centos_7-3_0_0-jemalloc:
+    name: 'Build Ruby [centos-7/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-7
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-centos-7-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_centos_7-3_0_0-malloctrim:
+    name: 'Build Ruby [centos-7/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_7
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-7]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_7.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-7];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-7;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-7'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-centos-7-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-7"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_centos_7-2_7_2-normal:
@@ -2092,6 +2612,266 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
 
 
+  build_ruby_centos_8-3_0-normal:
+    name: 'Build Ruby [centos-8/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-centos-8-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-8_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_centos_8-3_0-jemalloc:
+    name: 'Build Ruby [centos-8/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-8
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-centos-8-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-8_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_centos_8-3_0-malloctrim:
+    name: 'Build Ruby [centos-8/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-centos-8-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_centos-8_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_centos_8-2_7-normal:
     name: 'Build Ruby [centos-8/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -2870,6 +3650,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_centos-8_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_centos_8-3_0_0-normal:
+    name: 'Build Ruby [centos-8/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-centos-8-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_centos_8-3_0_0-jemalloc:
+    name: 'Build Ruby [centos-8/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-8
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-centos-8-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_centos_8-3_0_0-malloctrim:
+    name: 'Build Ruby [centos-8/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_centos_8
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [centos-8];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-centos-8-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_centos_8-2_7_2-normal:
@@ -3653,6 +4693,266 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
 
 
+  build_ruby_debian_10-3_0-normal:
+    name: 'Build Ruby [debian-10/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-debian-10-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-10_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_debian_10-3_0-jemalloc:
+    name: 'Build Ruby [debian-10/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-10
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-debian-10-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-10_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_debian_10-3_0-malloctrim:
+    name: 'Build Ruby [debian-10/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-debian-10-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-10_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_debian_10-2_7-normal:
     name: 'Build Ruby [debian-10/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -4431,6 +5731,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_debian-10_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_debian_10-3_0_0-normal:
+    name: 'Build Ruby [debian-10/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-debian-10-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_debian_10-3_0_0-jemalloc:
+    name: 'Build Ruby [debian-10/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-10
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-debian-10-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_debian_10-3_0_0-malloctrim:
+    name: 'Build Ruby [debian-10/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_10
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-10]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_10.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-10];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-10;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-10'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-debian-10-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-10"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_debian_10-2_7_2-normal:
@@ -5214,6 +6774,266 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
 
 
+  build_ruby_debian_9-3_0-normal:
+    name: 'Build Ruby [debian-9/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-debian-9-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-9_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_debian_9-3_0-jemalloc:
+    name: 'Build Ruby [debian-9/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-9
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-debian-9-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-9_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_debian_9-3_0-malloctrim:
+    name: 'Build Ruby [debian-9/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-debian-9-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_debian-9_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_debian_9-2_7-normal:
     name: 'Build Ruby [debian-9/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -5992,6 +7812,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_debian-9_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_debian_9-3_0_0-normal:
+    name: 'Build Ruby [debian-9/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-debian-9-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_debian_9-3_0_0-jemalloc:
+    name: 'Build Ruby [debian-9/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-9
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-debian-9-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_debian_9-3_0_0-malloctrim:
+    name: 'Build Ruby [debian-9/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_debian_9
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [debian-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_9.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [debian-9];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image debian-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-9'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-debian-9-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-9"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_debian_9-2_7_2-normal:
@@ -6775,6 +8855,266 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
 
 
+  build_ruby_ubuntu_18_04-3_0-normal:
+    name: 'Build Ruby [ubuntu-18.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-ubuntu-18.04-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-18.04_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_ubuntu_18_04-3_0-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-ubuntu-18.04-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-18.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_ubuntu_18_04-3_0-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-ubuntu-18.04-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-18.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_ubuntu_18_04-2_7-normal:
     name: 'Build Ruby [ubuntu-18.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -7553,6 +9893,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_ubuntu-18.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_ubuntu_18_04-3_0_0-normal:
+    name: 'Build Ruby [ubuntu-18.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-ubuntu-18.04-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_ubuntu_18_04-3_0_0-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-ubuntu-18.04-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_ubuntu_18_04-3_0_0-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_18_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_18_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-18.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-18.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-18.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-ubuntu-18.04-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_ubuntu_18_04-2_7_2-normal:
@@ -8336,6 +10936,266 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
 
 
+  build_ruby_ubuntu_20_04-3_0-normal:
+    name: 'Build Ruby [ubuntu-20.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0-ubuntu-20.04-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-20.04_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_ubuntu_20_04-3_0-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0-ubuntu-20.04-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-20.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_ubuntu_20_04-3_0-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0-ubuntu-20.04-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0_ubuntu-20.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
   build_ruby_ubuntu_20_04-2_7-normal:
     name: 'Build Ruby [ubuntu-20.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -9114,6 +11974,266 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_2.5_ubuntu-20.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+
+  build_ruby_ubuntu_20_04-3_0_0-normal:
+    name: 'Build Ruby [ubuntu-20.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-normal
+      - name: "[normal] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-normal
+          key: v2-ruby-bin-3.0.0-ubuntu-20.04-normal
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_normal"
+          ARTIFACT_PATH: output-normal
+
+  build_ruby_ubuntu_20_04-3_0_0-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
+          ARTIFACT_PATH: .        
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-jemalloc
+      - name: "[jemalloc] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-jemalloc
+          key: v2-ruby-bin-3.0.0-ubuntu-20.04-jemalloc
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+
+  build_ruby_ubuntu_20_04-3_0_0-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - build_jemalloc_ubuntu_20_04
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_20_04.result == 'skipped'
+          && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Jemalloc [ubuntu-20.04];')
+
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: .
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image ubuntu-20.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-20.04'
+          ARTIFACT_PATH: .
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Reset & prepare workspace
+        run: mkdir cache-malloctrim
+      - name: "[malloctrim] Fetch cache"
+        uses: actions/cache@v2
+        with:
+          path: cache-malloctrim
+          key: v2-ruby-bin-3.0.0-ubuntu-20.04-malloctrim
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_REVISION: "1"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
   build_ruby_ubuntu_20_04-2_7_2-normal:
@@ -9911,6 +13031,10 @@ jobs:
 
       - build_jemalloc_centos_7
 
+      - build_ruby_centos_7-3_0-normal
+      - build_ruby_centos_7-3_0-jemalloc
+      - build_ruby_centos_7-3_0-malloctrim
+
       - build_ruby_centos_7-2_7-normal
       - build_ruby_centos_7-2_7-jemalloc
       - build_ruby_centos_7-2_7-malloctrim
@@ -9922,6 +13046,10 @@ jobs:
       - build_ruby_centos_7-2_5-normal
       - build_ruby_centos_7-2_5-jemalloc
       - build_ruby_centos_7-2_5-malloctrim
+
+      - build_ruby_centos_7-3_0_0-normal
+      - build_ruby_centos_7-3_0_0-jemalloc
+      - build_ruby_centos_7-3_0_0-malloctrim
 
       - build_ruby_centos_7-2_7_2-normal
       - build_ruby_centos_7-2_7_2-jemalloc
@@ -9937,6 +13065,10 @@ jobs:
 
       - build_jemalloc_centos_8
 
+      - build_ruby_centos_8-3_0-normal
+      - build_ruby_centos_8-3_0-jemalloc
+      - build_ruby_centos_8-3_0-malloctrim
+
       - build_ruby_centos_8-2_7-normal
       - build_ruby_centos_8-2_7-jemalloc
       - build_ruby_centos_8-2_7-malloctrim
@@ -9948,6 +13080,10 @@ jobs:
       - build_ruby_centos_8-2_5-normal
       - build_ruby_centos_8-2_5-jemalloc
       - build_ruby_centos_8-2_5-malloctrim
+
+      - build_ruby_centos_8-3_0_0-normal
+      - build_ruby_centos_8-3_0_0-jemalloc
+      - build_ruby_centos_8-3_0_0-malloctrim
 
       - build_ruby_centos_8-2_7_2-normal
       - build_ruby_centos_8-2_7_2-jemalloc
@@ -9963,6 +13099,10 @@ jobs:
 
       - build_jemalloc_debian_10
 
+      - build_ruby_debian_10-3_0-normal
+      - build_ruby_debian_10-3_0-jemalloc
+      - build_ruby_debian_10-3_0-malloctrim
+
       - build_ruby_debian_10-2_7-normal
       - build_ruby_debian_10-2_7-jemalloc
       - build_ruby_debian_10-2_7-malloctrim
@@ -9974,6 +13114,10 @@ jobs:
       - build_ruby_debian_10-2_5-normal
       - build_ruby_debian_10-2_5-jemalloc
       - build_ruby_debian_10-2_5-malloctrim
+
+      - build_ruby_debian_10-3_0_0-normal
+      - build_ruby_debian_10-3_0_0-jemalloc
+      - build_ruby_debian_10-3_0_0-malloctrim
 
       - build_ruby_debian_10-2_7_2-normal
       - build_ruby_debian_10-2_7_2-jemalloc
@@ -9989,6 +13133,10 @@ jobs:
 
       - build_jemalloc_debian_9
 
+      - build_ruby_debian_9-3_0-normal
+      - build_ruby_debian_9-3_0-jemalloc
+      - build_ruby_debian_9-3_0-malloctrim
+
       - build_ruby_debian_9-2_7-normal
       - build_ruby_debian_9-2_7-jemalloc
       - build_ruby_debian_9-2_7-malloctrim
@@ -10000,6 +13148,10 @@ jobs:
       - build_ruby_debian_9-2_5-normal
       - build_ruby_debian_9-2_5-jemalloc
       - build_ruby_debian_9-2_5-malloctrim
+
+      - build_ruby_debian_9-3_0_0-normal
+      - build_ruby_debian_9-3_0_0-jemalloc
+      - build_ruby_debian_9-3_0_0-malloctrim
 
       - build_ruby_debian_9-2_7_2-normal
       - build_ruby_debian_9-2_7_2-jemalloc
@@ -10015,6 +13167,10 @@ jobs:
 
       - build_jemalloc_ubuntu_18_04
 
+      - build_ruby_ubuntu_18_04-3_0-normal
+      - build_ruby_ubuntu_18_04-3_0-jemalloc
+      - build_ruby_ubuntu_18_04-3_0-malloctrim
+
       - build_ruby_ubuntu_18_04-2_7-normal
       - build_ruby_ubuntu_18_04-2_7-jemalloc
       - build_ruby_ubuntu_18_04-2_7-malloctrim
@@ -10026,6 +13182,10 @@ jobs:
       - build_ruby_ubuntu_18_04-2_5-normal
       - build_ruby_ubuntu_18_04-2_5-jemalloc
       - build_ruby_ubuntu_18_04-2_5-malloctrim
+
+      - build_ruby_ubuntu_18_04-3_0_0-normal
+      - build_ruby_ubuntu_18_04-3_0_0-jemalloc
+      - build_ruby_ubuntu_18_04-3_0_0-malloctrim
 
       - build_ruby_ubuntu_18_04-2_7_2-normal
       - build_ruby_ubuntu_18_04-2_7_2-jemalloc
@@ -10041,6 +13201,10 @@ jobs:
 
       - build_jemalloc_ubuntu_20_04
 
+      - build_ruby_ubuntu_20_04-3_0-normal
+      - build_ruby_ubuntu_20_04-3_0-jemalloc
+      - build_ruby_ubuntu_20_04-3_0-malloctrim
+
       - build_ruby_ubuntu_20_04-2_7-normal
       - build_ruby_ubuntu_20_04-2_7-jemalloc
       - build_ruby_ubuntu_20_04-2_7-malloctrim
@@ -10052,6 +13216,10 @@ jobs:
       - build_ruby_ubuntu_20_04-2_5-normal
       - build_ruby_ubuntu_20_04-2_5-jemalloc
       - build_ruby_ubuntu_20_04-2_5-malloctrim
+
+      - build_ruby_ubuntu_20_04-3_0_0-normal
+      - build_ruby_ubuntu_20_04-3_0_0-jemalloc
+      - build_ruby_ubuntu_20_04-3_0_0-malloctrim
 
       - build_ruby_ubuntu_20_04-2_7_2-normal
       - build_ruby_ubuntu_20_04-2_7_2-jemalloc
@@ -10173,9 +13341,99 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-7_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-7_normal
+          path: artifacts/ruby-pkg_3.0_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-7_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-7_jemalloc
+          path: artifacts/ruby-pkg_3.0_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-7_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-7_malloctrim
+          path: artifacts/ruby-pkg_3.0_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-8_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-8_normal
+          path: artifacts/ruby-pkg_3.0_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-8_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-8_jemalloc
+          path: artifacts/ruby-pkg_3.0_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-8_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_centos-8_malloctrim
+          path: artifacts/ruby-pkg_3.0_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-10_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-10_normal
+          path: artifacts/ruby-pkg_3.0_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-10_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-10_jemalloc
+          path: artifacts/ruby-pkg_3.0_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-10_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-10_malloctrim
+          path: artifacts/ruby-pkg_3.0_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-9_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-9_normal
+          path: artifacts/ruby-pkg_3.0_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-9_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-9_jemalloc
+          path: artifacts/ruby-pkg_3.0_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-9_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_debian-9_malloctrim
+          path: artifacts/ruby-pkg_3.0_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-18.04_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_3.0_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-18.04_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_3.0_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-18.04_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_3.0_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-20.04_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_3.0_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-20.04_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_3.0_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0_ubuntu-20.04_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_3.0_ubuntu-20.04_malloctrim
       - name: Archive Ruby package artifact [ruby-pkg_2.7_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
@@ -10446,6 +13704,96 @@ jobs:
         with:
           name: ruby-pkg_2.5_ubuntu-20.04_malloctrim
           path: artifacts/ruby-pkg_2.5_ubuntu-20.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-7_normal
+          path: artifacts/ruby-pkg_3.0.0_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-7_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-7_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-8_normal
+          path: artifacts/ruby-pkg_3.0.0_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-8_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_centos-8_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-10_normal
+          path: artifacts/ruby-pkg_3.0.0_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-10_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-10_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-9_normal
+          path: artifacts/ruby-pkg_3.0.0_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-9_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_debian-9_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_normal] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_jemalloc] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_malloctrim] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-pkg_3.0.0_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_malloctrim
       - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
@@ -10774,6 +14122,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_centos_7-3_0-normal.result != 'success'
+              && (needs.build_ruby_centos_7-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/normal];')))
+            || (needs.build_ruby_centos_7-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/jemalloc];')))
+            || (needs.build_ruby_centos_7-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0/malloctrim];')))
             || (needs.build_ruby_centos_7-2_7-normal.result != 'success'
               && (needs.build_ruby_centos_7-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7/normal];')))
@@ -10801,6 +14158,15 @@ jobs:
             || (needs.build_ruby_centos_7-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_centos_7-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.5/malloctrim];')))
+            || (needs.build_ruby_centos_7-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/normal];')))
+            || (needs.build_ruby_centos_7-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/jemalloc];')))
+            || (needs.build_ruby_centos_7-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/malloctrim];')))
             || (needs.build_ruby_centos_7-2_7_2-normal.result != 'success'
               && (needs.build_ruby_centos_7-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/normal];')))
@@ -10832,6 +14198,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_centos_8-3_0-normal.result != 'success'
+              && (needs.build_ruby_centos_8-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/normal];')))
+            || (needs.build_ruby_centos_8-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/jemalloc];')))
+            || (needs.build_ruby_centos_8-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0/malloctrim];')))
             || (needs.build_ruby_centos_8-2_7-normal.result != 'success'
               && (needs.build_ruby_centos_8-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7/normal];')))
@@ -10859,6 +14234,15 @@ jobs:
             || (needs.build_ruby_centos_8-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_centos_8-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.5/malloctrim];')))
+            || (needs.build_ruby_centos_8-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/normal];')))
+            || (needs.build_ruby_centos_8-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/jemalloc];')))
+            || (needs.build_ruby_centos_8-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/malloctrim];')))
             || (needs.build_ruby_centos_8-2_7_2-normal.result != 'success'
               && (needs.build_ruby_centos_8-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/normal];')))
@@ -10890,6 +14274,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_debian_10-3_0-normal.result != 'success'
+              && (needs.build_ruby_debian_10-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/normal];')))
+            || (needs.build_ruby_debian_10-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/jemalloc];')))
+            || (needs.build_ruby_debian_10-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0/malloctrim];')))
             || (needs.build_ruby_debian_10-2_7-normal.result != 'success'
               && (needs.build_ruby_debian_10-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7/normal];')))
@@ -10917,6 +14310,15 @@ jobs:
             || (needs.build_ruby_debian_10-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_debian_10-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.5/malloctrim];')))
+            || (needs.build_ruby_debian_10-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/normal];')))
+            || (needs.build_ruby_debian_10-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/jemalloc];')))
+            || (needs.build_ruby_debian_10-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/malloctrim];')))
             || (needs.build_ruby_debian_10-2_7_2-normal.result != 'success'
               && (needs.build_ruby_debian_10-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/normal];')))
@@ -10948,6 +14350,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_debian_9-3_0-normal.result != 'success'
+              && (needs.build_ruby_debian_9-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/normal];')))
+            || (needs.build_ruby_debian_9-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/jemalloc];')))
+            || (needs.build_ruby_debian_9-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0/malloctrim];')))
             || (needs.build_ruby_debian_9-2_7-normal.result != 'success'
               && (needs.build_ruby_debian_9-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7/normal];')))
@@ -10975,6 +14386,15 @@ jobs:
             || (needs.build_ruby_debian_9-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_debian_9-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.5/malloctrim];')))
+            || (needs.build_ruby_debian_9-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/normal];')))
+            || (needs.build_ruby_debian_9-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/jemalloc];')))
+            || (needs.build_ruby_debian_9-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/malloctrim];')))
             || (needs.build_ruby_debian_9-2_7_2-normal.result != 'success'
               && (needs.build_ruby_debian_9-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/normal];')))
@@ -11006,6 +14426,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_ubuntu_18_04-3_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_18_04-2_7-normal.result != 'success'
               && (needs.build_ruby_ubuntu_18_04-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7/normal];')))
@@ -11033,6 +14462,15 @@ jobs:
             || (needs.build_ruby_ubuntu_18_04-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_18_04-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.5/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_18_04-2_7_2-normal.result != 'success'
               && (needs.build_ruby_ubuntu_18_04-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/normal];')))
@@ -11064,6 +14502,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_ubuntu_20_04-3_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_20_04-2_7-normal.result != 'success'
               && (needs.build_ruby_ubuntu_20_04-2_7-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7/normal];')))
@@ -11091,6 +14538,15 @@ jobs:
             || (needs.build_ruby_ubuntu_20_04-2_5-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_20_04-2_5-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.5/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_0-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_20_04-2_7_2-normal.result != 'success'
               && (needs.build_ruby_ubuntu_20_04-2_7_2-normal.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/normal];')))

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -351,6 +351,37 @@ jobs:
   ### Sources ###
 
 
+  download_ruby_source_3_0_0:
+    name: Download Ruby source [3.0.0]
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.0;')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Fetch cache
+        id: fetch_cache
+        uses: actions/cache@v1
+        with:
+          path: output
+          key: v3-ruby-src-3.0.0
+
+      - name: Download
+        run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
+        if: steps.fetch_cache.outputs.cache-hit != 'true'
+        env:
+          RUBY_VERSION: 3.0.0
+
+      - name: Archive artifact
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: output
   download_ruby_source_2_7_2:
     name: Download Ruby source [2.7.2]
     runs-on: ubuntu-20.04
@@ -496,6 +527,7 @@ jobs:
       - build_docker_image_ubuntu_18_04
       - build_docker_image_ubuntu_20_04
       - build_docker_image_utility
+      - download_ruby_source_3_0_0
       - download_ruby_source_2_7_2
       - download_ruby_source_2_6_6
       - download_ruby_source_2_5_8
@@ -619,6 +651,17 @@ jobs:
           path: artifacts
 
 
+      - name: Download Ruby source artifact [3.0.0] from Google Cloud
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_PATH: artifacts
+          CLEAR: true
+      - name: Archive Ruby source artifact [3.0.0] to Github
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-src-3.0.0
+          path: artifacts
       - name: Download Ruby source artifact [2.7.2] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -701,6 +744,9 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.download_ruby_source_3_0_0.result != 'success'
+              && (needs.download_ruby_source_3_0_0.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.0;')))
             || (needs.download_ruby_source_2_7_2.result != 'success'
               && (needs.download_ruby_source_2_7_2.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.2;')))

--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -92,7 +92,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -149,6 +149,111 @@ jobs:
 
 
 
+  test_centos_7-3_0-normal:
+    name: 'Test [centos-7/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_centos_7-3_0-jemalloc:
+    name: 'Test [centos-7/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_centos_7-3_0-malloctrim:
+    name: 'Test [centos-7/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_centos_7-2_7-normal:
     name: 'Test [centos-7/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -463,6 +568,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-centos-7_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_centos_7-3_0_0-normal:
+    name: 'Test [centos-7/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_centos_7-3_0_0-jemalloc:
+    name: 'Test [centos-7/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_centos_7-3_0_0-malloctrim:
+    name: 'Test [centos-7/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_centos_7-2_7_2-normal:
     name: 'Test [centos-7/2.7.2/normal]'
@@ -780,6 +990,111 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-7_2.5.8_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
+  test_centos_8-3_0-normal:
+    name: 'Test [centos-8/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_centos_8-3_0-jemalloc:
+    name: 'Test [centos-8/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_centos_8-3_0-malloctrim:
+    name: 'Test [centos-8/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_centos_8-2_7-normal:
     name: 'Test [centos-8/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -1094,6 +1409,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_centos_8-3_0_0-normal:
+    name: 'Test [centos-8/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_centos_8-3_0_0-jemalloc:
+    name: 'Test [centos-8/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_centos_8-3_0_0-malloctrim:
+    name: 'Test [centos-8/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_centos_8-2_7_2-normal:
     name: 'Test [centos-8/2.7.2/normal]'
@@ -1411,6 +1831,111 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-8_2.5.8_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
+  test_debian_10-3_0-normal:
+    name: 'Test [debian-10/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_debian_10-3_0-jemalloc:
+    name: 'Test [debian-10/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_debian_10-3_0-malloctrim:
+    name: 'Test [debian-10/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_debian_10-2_7-normal:
     name: 'Test [debian-10/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -1725,6 +2250,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-debian-10_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_debian_10-3_0_0-normal:
+    name: 'Test [debian-10/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_debian_10-3_0_0-jemalloc:
+    name: 'Test [debian-10/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_debian_10-3_0_0-malloctrim:
+    name: 'Test [debian-10/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_debian_10-2_7_2-normal:
     name: 'Test [debian-10/2.7.2/normal]'
@@ -2042,6 +2672,111 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-10_2.5.8_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
+  test_debian_9-3_0-normal:
+    name: 'Test [debian-9/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_debian_9-3_0-jemalloc:
+    name: 'Test [debian-9/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_debian_9-3_0-malloctrim:
+    name: 'Test [debian-9/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_debian_9-2_7-normal:
     name: 'Test [debian-9/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -2356,6 +3091,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-debian-9_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_debian_9-3_0_0-normal:
+    name: 'Test [debian-9/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_debian_9-3_0_0-jemalloc:
+    name: 'Test [debian-9/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_debian_9-3_0_0-malloctrim:
+    name: 'Test [debian-9/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_debian_9-2_7_2-normal:
     name: 'Test [debian-9/2.7.2/normal]'
@@ -2673,6 +3513,111 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-9_2.5.8_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
+  test_ubuntu_18_04-3_0-normal:
+    name: 'Test [ubuntu-18.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_ubuntu_18_04-3_0-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_ubuntu_18_04-3_0-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_ubuntu_18_04-2_7-normal:
     name: 'Test [ubuntu-18.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -2987,6 +3932,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_ubuntu_18_04-3_0_0-normal:
+    name: 'Test [ubuntu-18.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_ubuntu_18_04-3_0_0-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_ubuntu_18_04-3_0_0-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_ubuntu_18_04-2_7_2-normal:
     name: 'Test [ubuntu-18.04/2.7.2/normal]'
@@ -3304,6 +4354,111 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.5.8_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
+  test_ubuntu_20_04-3_0-normal:
+    name: 'Test [ubuntu-20.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_ubuntu_20_04-3_0-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_ubuntu_20_04-3_0-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
   test_ubuntu_20_04-2_7-normal:
     name: 'Test [ubuntu-20.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -3618,6 +4773,111 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+  test_ubuntu_20_04-3_0_0-normal:
+    name: 'Test [ubuntu-20.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+  test_ubuntu_20_04-3_0_0-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+  test_ubuntu_20_04-3_0_0-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
   test_ubuntu_20_04-2_7_2-normal:
     name: 'Test [ubuntu-20.04/2.7.2/normal]'
@@ -3944,6 +5204,9 @@ jobs:
     needs:
       - determine_necessary_jobs
       - publish
+      - test_centos_7-3_0-normal
+      - test_centos_7-3_0-jemalloc
+      - test_centos_7-3_0-malloctrim
       - test_centos_7-2_7-normal
       - test_centos_7-2_7-jemalloc
       - test_centos_7-2_7-malloctrim
@@ -3953,6 +5216,9 @@ jobs:
       - test_centos_7-2_5-normal
       - test_centos_7-2_5-jemalloc
       - test_centos_7-2_5-malloctrim
+      - test_centos_7-3_0_0-normal
+      - test_centos_7-3_0_0-jemalloc
+      - test_centos_7-3_0_0-malloctrim
       - test_centos_7-2_7_2-normal
       - test_centos_7-2_7_2-jemalloc
       - test_centos_7-2_7_2-malloctrim
@@ -3962,6 +5228,9 @@ jobs:
       - test_centos_7-2_5_8-normal
       - test_centos_7-2_5_8-jemalloc
       - test_centos_7-2_5_8-malloctrim
+      - test_centos_8-3_0-normal
+      - test_centos_8-3_0-jemalloc
+      - test_centos_8-3_0-malloctrim
       - test_centos_8-2_7-normal
       - test_centos_8-2_7-jemalloc
       - test_centos_8-2_7-malloctrim
@@ -3971,6 +5240,9 @@ jobs:
       - test_centos_8-2_5-normal
       - test_centos_8-2_5-jemalloc
       - test_centos_8-2_5-malloctrim
+      - test_centos_8-3_0_0-normal
+      - test_centos_8-3_0_0-jemalloc
+      - test_centos_8-3_0_0-malloctrim
       - test_centos_8-2_7_2-normal
       - test_centos_8-2_7_2-jemalloc
       - test_centos_8-2_7_2-malloctrim
@@ -3980,6 +5252,9 @@ jobs:
       - test_centos_8-2_5_8-normal
       - test_centos_8-2_5_8-jemalloc
       - test_centos_8-2_5_8-malloctrim
+      - test_debian_10-3_0-normal
+      - test_debian_10-3_0-jemalloc
+      - test_debian_10-3_0-malloctrim
       - test_debian_10-2_7-normal
       - test_debian_10-2_7-jemalloc
       - test_debian_10-2_7-malloctrim
@@ -3989,6 +5264,9 @@ jobs:
       - test_debian_10-2_5-normal
       - test_debian_10-2_5-jemalloc
       - test_debian_10-2_5-malloctrim
+      - test_debian_10-3_0_0-normal
+      - test_debian_10-3_0_0-jemalloc
+      - test_debian_10-3_0_0-malloctrim
       - test_debian_10-2_7_2-normal
       - test_debian_10-2_7_2-jemalloc
       - test_debian_10-2_7_2-malloctrim
@@ -3998,6 +5276,9 @@ jobs:
       - test_debian_10-2_5_8-normal
       - test_debian_10-2_5_8-jemalloc
       - test_debian_10-2_5_8-malloctrim
+      - test_debian_9-3_0-normal
+      - test_debian_9-3_0-jemalloc
+      - test_debian_9-3_0-malloctrim
       - test_debian_9-2_7-normal
       - test_debian_9-2_7-jemalloc
       - test_debian_9-2_7-malloctrim
@@ -4007,6 +5288,9 @@ jobs:
       - test_debian_9-2_5-normal
       - test_debian_9-2_5-jemalloc
       - test_debian_9-2_5-malloctrim
+      - test_debian_9-3_0_0-normal
+      - test_debian_9-3_0_0-jemalloc
+      - test_debian_9-3_0_0-malloctrim
       - test_debian_9-2_7_2-normal
       - test_debian_9-2_7_2-jemalloc
       - test_debian_9-2_7_2-malloctrim
@@ -4016,6 +5300,9 @@ jobs:
       - test_debian_9-2_5_8-normal
       - test_debian_9-2_5_8-jemalloc
       - test_debian_9-2_5_8-malloctrim
+      - test_ubuntu_18_04-3_0-normal
+      - test_ubuntu_18_04-3_0-jemalloc
+      - test_ubuntu_18_04-3_0-malloctrim
       - test_ubuntu_18_04-2_7-normal
       - test_ubuntu_18_04-2_7-jemalloc
       - test_ubuntu_18_04-2_7-malloctrim
@@ -4025,6 +5312,9 @@ jobs:
       - test_ubuntu_18_04-2_5-normal
       - test_ubuntu_18_04-2_5-jemalloc
       - test_ubuntu_18_04-2_5-malloctrim
+      - test_ubuntu_18_04-3_0_0-normal
+      - test_ubuntu_18_04-3_0_0-jemalloc
+      - test_ubuntu_18_04-3_0_0-malloctrim
       - test_ubuntu_18_04-2_7_2-normal
       - test_ubuntu_18_04-2_7_2-jemalloc
       - test_ubuntu_18_04-2_7_2-malloctrim
@@ -4034,6 +5324,9 @@ jobs:
       - test_ubuntu_18_04-2_5_8-normal
       - test_ubuntu_18_04-2_5_8-jemalloc
       - test_ubuntu_18_04-2_5_8-malloctrim
+      - test_ubuntu_20_04-3_0-normal
+      - test_ubuntu_20_04-3_0-jemalloc
+      - test_ubuntu_20_04-3_0-malloctrim
       - test_ubuntu_20_04-2_7-normal
       - test_ubuntu_20_04-2_7-jemalloc
       - test_ubuntu_20_04-2_7-malloctrim
@@ -4043,6 +5336,9 @@ jobs:
       - test_ubuntu_20_04-2_5-normal
       - test_ubuntu_20_04-2_5-jemalloc
       - test_ubuntu_20_04-2_5-malloctrim
+      - test_ubuntu_20_04-3_0_0-normal
+      - test_ubuntu_20_04-3_0_0-jemalloc
+      - test_ubuntu_20_04-3_0_0-malloctrim
       - test_ubuntu_20_04-2_7_2-normal
       - test_ubuntu_20_04-2_7_2-jemalloc
       - test_ubuntu_20_04-2_7_2-malloctrim
@@ -4066,6 +5362,27 @@ jobs:
         run: 'false'
         if: needs.determine_necessary_jobs.result != 'success'
 
+      - name: Check whether 'Test [centos-7/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0-normal.result != 'success'
+          && (needs.test_centos_7-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/normal];'))
+      - name: Check whether 'Test [centos-7/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0/malloctrim];'))
       - name: Check whether 'Test [centos-7/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4129,6 +5446,27 @@ jobs:
           && needs.test_centos_7-2_5-malloctrim.result != 'success'
           && (needs.test_centos_7-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.5/malloctrim];'))
+      - name: Check whether 'Test [centos-7/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0_0-normal.result != 'success'
+          && (needs.test_centos_7-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_7-3_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-7/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4192,6 +5530,27 @@ jobs:
           && needs.test_centos_7-2_5_8-malloctrim.result != 'success'
           && (needs.test_centos_7-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0-normal.result != 'success'
+          && (needs.test_centos_8-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/normal];'))
+      - name: Check whether 'Test [centos-8/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4255,6 +5614,27 @@ jobs:
           && needs.test_centos_8-2_5-malloctrim.result != 'success'
           && (needs.test_centos_8-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.5/malloctrim];'))
+      - name: Check whether 'Test [centos-8/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0_0-normal.result != 'success'
+          && (needs.test_centos_8-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-3_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4318,6 +5698,27 @@ jobs:
           && needs.test_centos_8-2_5_8-malloctrim.result != 'success'
           && (needs.test_centos_8-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0-normal.result != 'success'
+          && (needs.test_debian_10-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/normal];'))
+      - name: Check whether 'Test [debian-10/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0/malloctrim];'))
       - name: Check whether 'Test [debian-10/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4381,6 +5782,27 @@ jobs:
           && needs.test_debian_10-2_5-malloctrim.result != 'success'
           && (needs.test_debian_10-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.5/malloctrim];'))
+      - name: Check whether 'Test [debian-10/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0_0-normal.result != 'success'
+          && (needs.test_debian_10-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_10-3_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-10/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4444,6 +5866,27 @@ jobs:
           && needs.test_debian_10-2_5_8-malloctrim.result != 'success'
           && (needs.test_debian_10-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0-normal.result != 'success'
+          && (needs.test_debian_9-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/normal];'))
+      - name: Check whether 'Test [debian-9/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0/malloctrim];'))
       - name: Check whether 'Test [debian-9/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4507,6 +5950,27 @@ jobs:
           && needs.test_debian_9-2_5-malloctrim.result != 'success'
           && (needs.test_debian_9-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.5/malloctrim];'))
+      - name: Check whether 'Test [debian-9/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0_0-normal.result != 'success'
+          && (needs.test_debian_9-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_9-3_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-9/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4570,6 +6034,27 @@ jobs:
           && needs.test_debian_9-2_5_8-malloctrim.result != 'success'
           && (needs.test_debian_9-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4633,6 +6118,27 @@ jobs:
           && needs.test_ubuntu_18_04-2_5-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4696,6 +6202,27 @@ jobs:
           && needs.test_ubuntu_18_04-2_5_8-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4759,6 +6286,27 @@ jobs:
           && needs.test_ubuntu_20_04-2_5-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/2.7.2/normal]' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -92,7 +92,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_2.5_centos-7_normal ruby-pkg_2.5_centos-7_jemalloc ruby-pkg_2.5_centos-7_malloctrim ruby-pkg_2.5_centos-8_normal ruby-pkg_2.5_centos-8_jemalloc ruby-pkg_2.5_centos-8_malloctrim ruby-pkg_2.5_debian-10_normal ruby-pkg_2.5_debian-10_jemalloc ruby-pkg_2.5_debian-10_malloctrim ruby-pkg_2.5_debian-9_normal ruby-pkg_2.5_debian-9_jemalloc ruby-pkg_2.5_debian-9_malloctrim ruby-pkg_2.5_ubuntu-18.04_normal ruby-pkg_2.5_ubuntu-18.04_jemalloc ruby-pkg_2.5_ubuntu-18.04_malloctrim ruby-pkg_2.5_ubuntu-20.04_normal ruby-pkg_2.5_ubuntu-20.04_jemalloc ruby-pkg_2.5_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim ruby-pkg_2.5.8_centos-7_normal ruby-pkg_2.5.8_centos-7_jemalloc ruby-pkg_2.5.8_centos-7_malloctrim ruby-pkg_2.5.8_centos-8_normal ruby-pkg_2.5.8_centos-8_jemalloc ruby-pkg_2.5.8_centos-8_malloctrim ruby-pkg_2.5.8_debian-10_normal ruby-pkg_2.5.8_debian-10_jemalloc ruby-pkg_2.5.8_debian-10_malloctrim ruby-pkg_2.5.8_debian-9_normal ruby-pkg_2.5.8_debian-9_jemalloc ruby-pkg_2.5.8_debian-9_malloctrim ruby-pkg_2.5.8_ubuntu-18.04_normal ruby-pkg_2.5.8_ubuntu-18.04_jemalloc ruby-pkg_2.5.8_ubuntu-18.04_malloctrim ruby-pkg_2.5.8_ubuntu-20.04_normal ruby-pkg_2.5.8_ubuntu-20.04_jemalloc ruby-pkg_2.5.8_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -161,6 +161,108 @@ jobs:
   ### Run tests ###
 
 
+
+  test_centos_7-3_0-normal:
+    name: 'Test [centos-7/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_centos_7-3_0-jemalloc:
+    name: 'Test [centos-7/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_centos_7-3_0-malloctrim:
+    name: 'Test [centos-7/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
 
   test_centos_7-2_7-normal:
     name: 'Test [centos-7/2.7/normal]'
@@ -466,6 +568,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-centos-7_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_centos_7-3_0_0-normal:
+    name: 'Test [centos-7/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_centos_7-3_0_0-jemalloc:
+    name: 'Test [centos-7/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_centos_7-3_0_0-malloctrim:
+    name: 'Test [centos-7/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-7"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:7"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_centos_7-2_7_2-normal:
@@ -775,6 +979,108 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
 
 
+  test_centos_8-3_0-normal:
+    name: 'Test [centos-8/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_centos_8-3_0-jemalloc:
+    name: 'Test [centos-8/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_centos_8-3_0-malloctrim:
+    name: 'Test [centos-8/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
   test_centos_8-2_7-normal:
     name: 'Test [centos-8/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -1079,6 +1385,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-centos-8_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_centos_8-3_0_0-normal:
+    name: 'Test [centos-8/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_centos_8-3_0_0-jemalloc:
+    name: 'Test [centos-8/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_centos_8-3_0_0-malloctrim:
+    name: 'Test [centos-8/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "centos:8"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_centos_8-2_7_2-normal:
@@ -1388,6 +1796,108 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
 
 
+  test_debian_10-3_0-normal:
+    name: 'Test [debian-10/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_debian_10-3_0-jemalloc:
+    name: 'Test [debian-10/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_debian_10-3_0-malloctrim:
+    name: 'Test [debian-10/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
   test_debian_10-2_7-normal:
     name: 'Test [debian-10/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -1692,6 +2202,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-debian-10_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_debian_10-3_0_0-normal:
+    name: 'Test [debian-10/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_debian_10-3_0_0-jemalloc:
+    name: 'Test [debian-10/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_debian_10-3_0_0-malloctrim:
+    name: 'Test [debian-10/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-10"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:10"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_10-2_7_2-normal:
@@ -2001,6 +2613,108 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
 
 
+  test_debian_9-3_0-normal:
+    name: 'Test [debian-9/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_debian_9-3_0-jemalloc:
+    name: 'Test [debian-9/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_debian_9-3_0-malloctrim:
+    name: 'Test [debian-9/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
   test_debian_9-2_7-normal:
     name: 'Test [debian-9/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -2305,6 +3019,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-debian-9_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_debian_9-3_0_0-normal:
+    name: 'Test [debian-9/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_debian_9-3_0_0-jemalloc:
+    name: 'Test [debian-9/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_debian_9-3_0_0-malloctrim:
+    name: 'Test [debian-9/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-9"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:9"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_9-2_7_2-normal:
@@ -2614,6 +3430,108 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
 
 
+  test_ubuntu_18_04-3_0-normal:
+    name: 'Test [ubuntu-18.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_ubuntu_18_04-3_0-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_ubuntu_18_04-3_0-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
   test_ubuntu_18_04-2_7-normal:
     name: 'Test [ubuntu-18.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -2918,6 +3836,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_ubuntu_18_04-3_0_0-normal:
+    name: 'Test [ubuntu-18.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_ubuntu_18_04-3_0_0-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_ubuntu_18_04-3_0_0-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-18.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:18.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_18_04-2_7_2-normal:
@@ -3227,6 +4247,108 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
 
 
+  test_ubuntu_20_04-3_0-normal:
+    name: 'Test [ubuntu-20.04/3.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_ubuntu_20_04-3_0-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_ubuntu_20_04-3_0-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
   test_ubuntu_20_04-2_7-normal:
     name: 'Test [ubuntu-20.04/2.7/normal]'
     runs-on: ubuntu-20.04
@@ -3531,6 +4653,108 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.5_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+
+  test_ubuntu_20_04-3_0_0-normal:
+    name: 'Test [ubuntu-20.04/3.0.0/normal]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/normal];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_normal
+          ARTIFACT_PATH: mark-normal
+
+  test_ubuntu_20_04-3_0_0-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.0/jemalloc]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/jemalloc];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+
+  test_ubuntu_20_04-3_0_0-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.0/malloctrim]'
+    runs-on: ubuntu-20.04
+    needs:
+      - determine_necessary_jobs
+      - publish
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/malloctrim];')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to Google Cloud
+        uses: ./.github/actions/gcloud-login
+        with:
+          private_key: ${{ secrets.GCLOUD_KEY }}
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-20.04"
+          RUBY_PACKAGE_ID: "3.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:20.04"
+          APT_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-apt-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+          YUM_REPO_URL: https://dl.bintray.com/fullstaq/fullstaq-ruby-yum-ci-${{ env.CI_ARTIFACTS_RUN_NUMBER }}
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_20_04-2_7_2-normal:
@@ -3848,6 +5072,9 @@ jobs:
     needs:
       - determine_necessary_jobs
       - publish
+      - test_centos_7-3_0-normal
+      - test_centos_7-3_0-jemalloc
+      - test_centos_7-3_0-malloctrim
       - test_centos_7-2_7-normal
       - test_centos_7-2_7-jemalloc
       - test_centos_7-2_7-malloctrim
@@ -3857,6 +5084,9 @@ jobs:
       - test_centos_7-2_5-normal
       - test_centos_7-2_5-jemalloc
       - test_centos_7-2_5-malloctrim
+      - test_centos_7-3_0_0-normal
+      - test_centos_7-3_0_0-jemalloc
+      - test_centos_7-3_0_0-malloctrim
       - test_centos_7-2_7_2-normal
       - test_centos_7-2_7_2-jemalloc
       - test_centos_7-2_7_2-malloctrim
@@ -3866,6 +5096,9 @@ jobs:
       - test_centos_7-2_5_8-normal
       - test_centos_7-2_5_8-jemalloc
       - test_centos_7-2_5_8-malloctrim
+      - test_centos_8-3_0-normal
+      - test_centos_8-3_0-jemalloc
+      - test_centos_8-3_0-malloctrim
       - test_centos_8-2_7-normal
       - test_centos_8-2_7-jemalloc
       - test_centos_8-2_7-malloctrim
@@ -3875,6 +5108,9 @@ jobs:
       - test_centos_8-2_5-normal
       - test_centos_8-2_5-jemalloc
       - test_centos_8-2_5-malloctrim
+      - test_centos_8-3_0_0-normal
+      - test_centos_8-3_0_0-jemalloc
+      - test_centos_8-3_0_0-malloctrim
       - test_centos_8-2_7_2-normal
       - test_centos_8-2_7_2-jemalloc
       - test_centos_8-2_7_2-malloctrim
@@ -3884,6 +5120,9 @@ jobs:
       - test_centos_8-2_5_8-normal
       - test_centos_8-2_5_8-jemalloc
       - test_centos_8-2_5_8-malloctrim
+      - test_debian_10-3_0-normal
+      - test_debian_10-3_0-jemalloc
+      - test_debian_10-3_0-malloctrim
       - test_debian_10-2_7-normal
       - test_debian_10-2_7-jemalloc
       - test_debian_10-2_7-malloctrim
@@ -3893,6 +5132,9 @@ jobs:
       - test_debian_10-2_5-normal
       - test_debian_10-2_5-jemalloc
       - test_debian_10-2_5-malloctrim
+      - test_debian_10-3_0_0-normal
+      - test_debian_10-3_0_0-jemalloc
+      - test_debian_10-3_0_0-malloctrim
       - test_debian_10-2_7_2-normal
       - test_debian_10-2_7_2-jemalloc
       - test_debian_10-2_7_2-malloctrim
@@ -3902,6 +5144,9 @@ jobs:
       - test_debian_10-2_5_8-normal
       - test_debian_10-2_5_8-jemalloc
       - test_debian_10-2_5_8-malloctrim
+      - test_debian_9-3_0-normal
+      - test_debian_9-3_0-jemalloc
+      - test_debian_9-3_0-malloctrim
       - test_debian_9-2_7-normal
       - test_debian_9-2_7-jemalloc
       - test_debian_9-2_7-malloctrim
@@ -3911,6 +5156,9 @@ jobs:
       - test_debian_9-2_5-normal
       - test_debian_9-2_5-jemalloc
       - test_debian_9-2_5-malloctrim
+      - test_debian_9-3_0_0-normal
+      - test_debian_9-3_0_0-jemalloc
+      - test_debian_9-3_0_0-malloctrim
       - test_debian_9-2_7_2-normal
       - test_debian_9-2_7_2-jemalloc
       - test_debian_9-2_7_2-malloctrim
@@ -3920,6 +5168,9 @@ jobs:
       - test_debian_9-2_5_8-normal
       - test_debian_9-2_5_8-jemalloc
       - test_debian_9-2_5_8-malloctrim
+      - test_ubuntu_18_04-3_0-normal
+      - test_ubuntu_18_04-3_0-jemalloc
+      - test_ubuntu_18_04-3_0-malloctrim
       - test_ubuntu_18_04-2_7-normal
       - test_ubuntu_18_04-2_7-jemalloc
       - test_ubuntu_18_04-2_7-malloctrim
@@ -3929,6 +5180,9 @@ jobs:
       - test_ubuntu_18_04-2_5-normal
       - test_ubuntu_18_04-2_5-jemalloc
       - test_ubuntu_18_04-2_5-malloctrim
+      - test_ubuntu_18_04-3_0_0-normal
+      - test_ubuntu_18_04-3_0_0-jemalloc
+      - test_ubuntu_18_04-3_0_0-malloctrim
       - test_ubuntu_18_04-2_7_2-normal
       - test_ubuntu_18_04-2_7_2-jemalloc
       - test_ubuntu_18_04-2_7_2-malloctrim
@@ -3938,6 +5192,9 @@ jobs:
       - test_ubuntu_18_04-2_5_8-normal
       - test_ubuntu_18_04-2_5_8-jemalloc
       - test_ubuntu_18_04-2_5_8-malloctrim
+      - test_ubuntu_20_04-3_0-normal
+      - test_ubuntu_20_04-3_0-jemalloc
+      - test_ubuntu_20_04-3_0-malloctrim
       - test_ubuntu_20_04-2_7-normal
       - test_ubuntu_20_04-2_7-jemalloc
       - test_ubuntu_20_04-2_7-malloctrim
@@ -3947,6 +5204,9 @@ jobs:
       - test_ubuntu_20_04-2_5-normal
       - test_ubuntu_20_04-2_5-jemalloc
       - test_ubuntu_20_04-2_5-malloctrim
+      - test_ubuntu_20_04-3_0_0-normal
+      - test_ubuntu_20_04-3_0_0-jemalloc
+      - test_ubuntu_20_04-3_0_0-malloctrim
       - test_ubuntu_20_04-2_7_2-normal
       - test_ubuntu_20_04-2_7_2-jemalloc
       - test_ubuntu_20_04-2_7_2-malloctrim
@@ -3969,6 +5229,24 @@ jobs:
         run: 'false'
         if: needs.determine_necessary_jobs.result != 'success'
 
+      - name: Check whether 'Test [centos-7/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0-normal.result != 'success'
+          && (needs.test_centos_7-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/normal];'))
+      - name: Check whether 'Test [centos-7/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0/malloctrim];'))
       - name: Check whether 'Test [centos-7/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4023,6 +5301,24 @@ jobs:
           needs.test_centos_7-2_5-malloctrim.result != 'success'
           && (needs.test_centos_7-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.5/malloctrim];'))
+      - name: Check whether 'Test [centos-7/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0_0-normal.result != 'success'
+          && (needs.test_centos_7-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_7-3_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-7/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4077,6 +5373,24 @@ jobs:
           needs.test_centos_7-2_5_8-malloctrim.result != 'success'
           && (needs.test_centos_7-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0-normal.result != 'success'
+          && (needs.test_centos_8-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/normal];'))
+      - name: Check whether 'Test [centos-8/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4131,6 +5445,24 @@ jobs:
           needs.test_centos_8-2_5-malloctrim.result != 'success'
           && (needs.test_centos_8-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.5/malloctrim];'))
+      - name: Check whether 'Test [centos-8/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0_0-normal.result != 'success'
+          && (needs.test_centos_8-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-3_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4185,6 +5517,24 @@ jobs:
           needs.test_centos_8-2_5_8-malloctrim.result != 'success'
           && (needs.test_centos_8-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0-normal.result != 'success'
+          && (needs.test_debian_10-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/normal];'))
+      - name: Check whether 'Test [debian-10/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0/malloctrim];'))
       - name: Check whether 'Test [debian-10/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4239,6 +5589,24 @@ jobs:
           needs.test_debian_10-2_5-malloctrim.result != 'success'
           && (needs.test_debian_10-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.5/malloctrim];'))
+      - name: Check whether 'Test [debian-10/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0_0-normal.result != 'success'
+          && (needs.test_debian_10-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_10-3_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-10/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4293,6 +5661,24 @@ jobs:
           needs.test_debian_10-2_5_8-malloctrim.result != 'success'
           && (needs.test_debian_10-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0-normal.result != 'success'
+          && (needs.test_debian_9-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/normal];'))
+      - name: Check whether 'Test [debian-9/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0/malloctrim];'))
       - name: Check whether 'Test [debian-9/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4347,6 +5733,24 @@ jobs:
           needs.test_debian_9-2_5-malloctrim.result != 'success'
           && (needs.test_debian_9-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.5/malloctrim];'))
+      - name: Check whether 'Test [debian-9/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0_0-normal.result != 'success'
+          && (needs.test_debian_9-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_9-3_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-9/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4401,6 +5805,24 @@ jobs:
           needs.test_debian_9-2_5_8-malloctrim.result != 'success'
           && (needs.test_debian_9-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4455,6 +5877,24 @@ jobs:
           needs.test_ubuntu_18_04-2_5-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/2.7.2/normal]' did not fail
         run: 'false'
         if: |
@@ -4509,6 +5949,24 @@ jobs:
           needs.test_ubuntu_18_04-2_5_8-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_5_8-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.5.8/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/2.7/normal]' did not fail
         run: 'false'
         if: |
@@ -4563,6 +6021,24 @@ jobs:
           needs.test_ubuntu_20_04-2_5-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_5-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/2.7.2/normal]' did not fail
         run: 'false'
         if: |

--- a/config.yml
+++ b/config.yml
@@ -25,6 +25,9 @@ ruby:
   ## NOTE: if you change an existing `full_version` value,
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
+    - minor_version: 3.0
+      full_version: 3.0.0
+      package_revision: 1
     - minor_version: 2.7
       full_version: 2.7.2
       package_revision: 3
@@ -38,6 +41,8 @@ ruby:
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
+    - full_version: 3.0.0
+      package_revision: 1
     - full_version: 2.7.2
       package_revision: 2
     - full_version: 2.6.6


### PR DESCRIPTION
December 25th means a new Ruby version: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

Added what I think are the correct edits to `config.yml` and updated all the ci configuration for Ruby 3.0.0. Also built a Debian 9 package locally and ran the tests against it - all passed. 🎉 

_(I was tempted to remove Ruby 2.5 so there's only 3 minor revisions built, but according to [ruby-lang](https://www.ruby-lang.org/en/downloads/) it's still in security maintenance mode, so I left it alone.)_