### PR TITLE
Upgrades Ruby to 3.0.1, 2.7.3, and 2.6.7 releases

### DIFF
--- a/.github/workflows/ci-cd-build-packages.yml
+++ b/.github/workflows/ci-cd-build-packages.yml
@@ -556,7 +556,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -608,7 +608,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -641,7 +641,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -698,7 +698,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -731,7 +731,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -783,7 +783,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -816,7 +816,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -868,7 +868,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -901,7 +901,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -958,7 +958,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -991,7 +991,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1043,7 +1043,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1076,7 +1076,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1128,7 +1128,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1161,7 +1161,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1218,7 +1218,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1251,7 +1251,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1303,7 +1303,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1311,15 +1311,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-3_0_0-normal:
-    name: 'Build Ruby [centos-7/3.0.0/normal]'
+  build_ruby_centos_7-3_0_1-normal:
+    name: 'Build Ruby [centos-7/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1336,7 +1336,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1371,14 +1371,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-centos-7-normal
+          key: v2-ruby-bin-3.0.1-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1387,24 +1387,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-3_0_0-jemalloc:
-    name: 'Build Ruby [centos-7/3.0.0/jemalloc]'
+  build_ruby_centos_7-3_0_1-jemalloc:
+    name: 'Build Ruby [centos-7/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1421,7 +1421,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1461,14 +1461,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-centos-7-jemalloc
+          key: v2-ruby-bin-3.0.1-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1477,24 +1477,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-3_0_0-malloctrim:
-    name: 'Build Ruby [centos-7/3.0.0/malloctrim]'
+  build_ruby_centos_7-3_0_1-malloctrim:
+    name: 'Build Ruby [centos-7/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1511,7 +1511,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1546,14 +1546,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-centos-7-malloctrim
+          key: v2-ruby-bin-3.0.1-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1562,24 +1562,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-2_7_2-normal:
-    name: 'Build Ruby [centos-7/2.7.2/normal]'
+  build_ruby_centos_7-2_7_3-normal:
+    name: 'Build Ruby [centos-7/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1596,7 +1596,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1631,14 +1631,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-centos-7-normal
+          key: v2-ruby-bin-2.7.3-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1647,24 +1647,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-2_7_2-jemalloc:
-    name: 'Build Ruby [centos-7/2.7.2/jemalloc]'
+  build_ruby_centos_7-2_7_3-jemalloc:
+    name: 'Build Ruby [centos-7/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1681,7 +1681,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1721,14 +1721,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-centos-7-jemalloc
+          key: v2-ruby-bin-2.7.3-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1737,24 +1737,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-2_7_2-malloctrim:
-    name: 'Build Ruby [centos-7/2.7.2/malloctrim]'
+  build_ruby_centos_7-2_7_3-malloctrim:
+    name: 'Build Ruby [centos-7/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1771,7 +1771,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1806,14 +1806,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-centos-7-malloctrim
+          key: v2-ruby-bin-2.7.3-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1822,24 +1822,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-2_6_6-normal:
-    name: 'Build Ruby [centos-7/2.6.6/normal]'
+  build_ruby_centos_7-2_6_7-normal:
+    name: 'Build Ruby [centos-7/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1856,7 +1856,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1891,14 +1891,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-centos-7-normal
+          key: v2-ruby-bin-2.6.7-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1907,24 +1907,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-2_6_6-jemalloc:
-    name: 'Build Ruby [centos-7/2.6.6/jemalloc]'
+  build_ruby_centos_7-2_6_7-jemalloc:
+    name: 'Build Ruby [centos-7/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1941,7 +1941,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1981,14 +1981,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-centos-7-jemalloc
+          key: v2-ruby-bin-2.6.7-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1997,24 +1997,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-2_6_6-malloctrim:
-    name: 'Build Ruby [centos-7/2.6.6/malloctrim]'
+  build_ruby_centos_7-2_6_7-malloctrim:
+    name: 'Build Ruby [centos-7/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -2031,7 +2031,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2066,14 +2066,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-centos-7-malloctrim
+          key: v2-ruby-bin-2.6.7-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2082,13 +2082,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -2117,7 +2117,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2169,7 +2169,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2202,7 +2202,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2259,7 +2259,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2292,7 +2292,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2344,7 +2344,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2377,7 +2377,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2429,7 +2429,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2462,7 +2462,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2519,7 +2519,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2552,7 +2552,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2604,7 +2604,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2637,7 +2637,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2689,7 +2689,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2722,7 +2722,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2779,7 +2779,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2812,7 +2812,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2864,7 +2864,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2872,15 +2872,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-3_0_0-normal:
-    name: 'Build Ruby [centos-8/3.0.0/normal]'
+  build_ruby_centos_8-3_0_1-normal:
+    name: 'Build Ruby [centos-8/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -2897,7 +2897,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2932,14 +2932,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-centos-8-normal
+          key: v2-ruby-bin-3.0.1-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2948,24 +2948,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-3_0_0-jemalloc:
-    name: 'Build Ruby [centos-8/3.0.0/jemalloc]'
+  build_ruby_centos_8-3_0_1-jemalloc:
+    name: 'Build Ruby [centos-8/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -2982,7 +2982,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3022,14 +3022,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-centos-8-jemalloc
+          key: v2-ruby-bin-3.0.1-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3038,24 +3038,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-3_0_0-malloctrim:
-    name: 'Build Ruby [centos-8/3.0.0/malloctrim]'
+  build_ruby_centos_8-3_0_1-malloctrim:
+    name: 'Build Ruby [centos-8/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3072,7 +3072,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3107,14 +3107,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-centos-8-malloctrim
+          key: v2-ruby-bin-3.0.1-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3123,24 +3123,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-2_7_2-normal:
-    name: 'Build Ruby [centos-8/2.7.2/normal]'
+  build_ruby_centos_8-2_7_3-normal:
+    name: 'Build Ruby [centos-8/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3157,7 +3157,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3192,14 +3192,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-centos-8-normal
+          key: v2-ruby-bin-2.7.3-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3208,24 +3208,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-2_7_2-jemalloc:
-    name: 'Build Ruby [centos-8/2.7.2/jemalloc]'
+  build_ruby_centos_8-2_7_3-jemalloc:
+    name: 'Build Ruby [centos-8/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3242,7 +3242,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3282,14 +3282,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-centos-8-jemalloc
+          key: v2-ruby-bin-2.7.3-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3298,24 +3298,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-2_7_2-malloctrim:
-    name: 'Build Ruby [centos-8/2.7.2/malloctrim]'
+  build_ruby_centos_8-2_7_3-malloctrim:
+    name: 'Build Ruby [centos-8/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3332,7 +3332,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3367,14 +3367,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-centos-8-malloctrim
+          key: v2-ruby-bin-2.7.3-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3383,24 +3383,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-2_6_6-normal:
-    name: 'Build Ruby [centos-8/2.6.6/normal]'
+  build_ruby_centos_8-2_6_7-normal:
+    name: 'Build Ruby [centos-8/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3417,7 +3417,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3452,14 +3452,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-centos-8-normal
+          key: v2-ruby-bin-2.6.7-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3468,24 +3468,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-2_6_6-jemalloc:
-    name: 'Build Ruby [centos-8/2.6.6/jemalloc]'
+  build_ruby_centos_8-2_6_7-jemalloc:
+    name: 'Build Ruby [centos-8/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3502,7 +3502,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3542,14 +3542,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-centos-8-jemalloc
+          key: v2-ruby-bin-2.6.7-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3558,24 +3558,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-2_6_6-malloctrim:
-    name: 'Build Ruby [centos-8/2.6.6/malloctrim]'
+  build_ruby_centos_8-2_6_7-malloctrim:
+    name: 'Build Ruby [centos-8/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -3592,7 +3592,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3627,14 +3627,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-centos-8-malloctrim
+          key: v2-ruby-bin-2.6.7-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3643,13 +3643,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -3678,7 +3678,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3730,7 +3730,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -3763,7 +3763,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3820,7 +3820,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -3853,7 +3853,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3905,7 +3905,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -3938,7 +3938,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3990,7 +3990,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4023,7 +4023,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4080,7 +4080,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4113,7 +4113,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4165,7 +4165,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4198,7 +4198,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4250,7 +4250,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4283,7 +4283,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4340,7 +4340,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4373,7 +4373,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4425,7 +4425,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -4433,15 +4433,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-3_0_0-normal:
-    name: 'Build Ruby [debian-10/3.0.0/normal]'
+  build_ruby_debian_10-3_0_1-normal:
+    name: 'Build Ruby [debian-10/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4458,7 +4458,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4493,14 +4493,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-debian-10-normal
+          key: v2-ruby-bin-3.0.1-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4509,24 +4509,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-3_0_0-jemalloc:
-    name: 'Build Ruby [debian-10/3.0.0/jemalloc]'
+  build_ruby_debian_10-3_0_1-jemalloc:
+    name: 'Build Ruby [debian-10/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4543,7 +4543,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4583,14 +4583,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-debian-10-jemalloc
+          key: v2-ruby-bin-3.0.1-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4599,24 +4599,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-3_0_0-malloctrim:
-    name: 'Build Ruby [debian-10/3.0.0/malloctrim]'
+  build_ruby_debian_10-3_0_1-malloctrim:
+    name: 'Build Ruby [debian-10/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4633,7 +4633,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4668,14 +4668,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-debian-10-malloctrim
+          key: v2-ruby-bin-3.0.1-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4684,24 +4684,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-2_7_2-normal:
-    name: 'Build Ruby [debian-10/2.7.2/normal]'
+  build_ruby_debian_10-2_7_3-normal:
+    name: 'Build Ruby [debian-10/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4718,7 +4718,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4753,14 +4753,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-debian-10-normal
+          key: v2-ruby-bin-2.7.3-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4769,24 +4769,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-2_7_2-jemalloc:
-    name: 'Build Ruby [debian-10/2.7.2/jemalloc]'
+  build_ruby_debian_10-2_7_3-jemalloc:
+    name: 'Build Ruby [debian-10/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4803,7 +4803,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4843,14 +4843,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-debian-10-jemalloc
+          key: v2-ruby-bin-2.7.3-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4859,24 +4859,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-2_7_2-malloctrim:
-    name: 'Build Ruby [debian-10/2.7.2/malloctrim]'
+  build_ruby_debian_10-2_7_3-malloctrim:
+    name: 'Build Ruby [debian-10/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4893,7 +4893,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -4928,14 +4928,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-debian-10-malloctrim
+          key: v2-ruby-bin-2.7.3-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -4944,24 +4944,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-2_6_6-normal:
-    name: 'Build Ruby [debian-10/2.6.6/normal]'
+  build_ruby_debian_10-2_6_7-normal:
+    name: 'Build Ruby [debian-10/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -4978,7 +4978,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5013,14 +5013,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-debian-10-normal
+          key: v2-ruby-bin-2.6.7-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -5029,24 +5029,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-2_6_6-jemalloc:
-    name: 'Build Ruby [debian-10/2.6.6/jemalloc]'
+  build_ruby_debian_10-2_6_7-jemalloc:
+    name: 'Build Ruby [debian-10/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -5063,7 +5063,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5103,14 +5103,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-debian-10-jemalloc
+          key: v2-ruby-bin-2.6.7-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -5119,24 +5119,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-2_6_6-malloctrim:
-    name: 'Build Ruby [debian-10/2.6.6/malloctrim]'
+  build_ruby_debian_10-2_6_7-malloctrim:
+    name: 'Build Ruby [debian-10/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -5153,7 +5153,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5188,14 +5188,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-debian-10-malloctrim
+          key: v2-ruby-bin-2.6.7-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -5204,13 +5204,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -5239,7 +5239,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5291,7 +5291,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5324,7 +5324,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5381,7 +5381,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5414,7 +5414,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5466,7 +5466,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5499,7 +5499,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5551,7 +5551,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5584,7 +5584,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5641,7 +5641,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5674,7 +5674,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5726,7 +5726,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5759,7 +5759,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5811,7 +5811,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5844,7 +5844,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5901,7 +5901,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5934,7 +5934,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -5986,7 +5986,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -5994,15 +5994,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-3_0_0-normal:
-    name: 'Build Ruby [debian-9/3.0.0/normal]'
+  build_ruby_debian_9-3_0_1-normal:
+    name: 'Build Ruby [debian-9/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6019,7 +6019,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6054,14 +6054,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-debian-9-normal
+          key: v2-ruby-bin-3.0.1-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6070,24 +6070,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-3_0_0-jemalloc:
-    name: 'Build Ruby [debian-9/3.0.0/jemalloc]'
+  build_ruby_debian_9-3_0_1-jemalloc:
+    name: 'Build Ruby [debian-9/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6104,7 +6104,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6144,14 +6144,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-debian-9-jemalloc
+          key: v2-ruby-bin-3.0.1-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6160,24 +6160,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-3_0_0-malloctrim:
-    name: 'Build Ruby [debian-9/3.0.0/malloctrim]'
+  build_ruby_debian_9-3_0_1-malloctrim:
+    name: 'Build Ruby [debian-9/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6194,7 +6194,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6229,14 +6229,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-debian-9-malloctrim
+          key: v2-ruby-bin-3.0.1-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6245,24 +6245,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-2_7_2-normal:
-    name: 'Build Ruby [debian-9/2.7.2/normal]'
+  build_ruby_debian_9-2_7_3-normal:
+    name: 'Build Ruby [debian-9/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6279,7 +6279,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6314,14 +6314,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-debian-9-normal
+          key: v2-ruby-bin-2.7.3-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6330,24 +6330,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-2_7_2-jemalloc:
-    name: 'Build Ruby [debian-9/2.7.2/jemalloc]'
+  build_ruby_debian_9-2_7_3-jemalloc:
+    name: 'Build Ruby [debian-9/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6364,7 +6364,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6404,14 +6404,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-debian-9-jemalloc
+          key: v2-ruby-bin-2.7.3-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6420,24 +6420,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-2_7_2-malloctrim:
-    name: 'Build Ruby [debian-9/2.7.2/malloctrim]'
+  build_ruby_debian_9-2_7_3-malloctrim:
+    name: 'Build Ruby [debian-9/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6454,7 +6454,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6489,14 +6489,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-debian-9-malloctrim
+          key: v2-ruby-bin-2.7.3-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6505,24 +6505,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-2_6_6-normal:
-    name: 'Build Ruby [debian-9/2.6.6/normal]'
+  build_ruby_debian_9-2_6_7-normal:
+    name: 'Build Ruby [debian-9/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6539,7 +6539,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6574,14 +6574,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-debian-9-normal
+          key: v2-ruby-bin-2.6.7-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6590,24 +6590,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-2_6_6-jemalloc:
-    name: 'Build Ruby [debian-9/2.6.6/jemalloc]'
+  build_ruby_debian_9-2_6_7-jemalloc:
+    name: 'Build Ruby [debian-9/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6624,7 +6624,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6664,14 +6664,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-debian-9-jemalloc
+          key: v2-ruby-bin-2.6.7-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6680,24 +6680,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-2_6_6-malloctrim:
-    name: 'Build Ruby [debian-9/2.6.6/malloctrim]'
+  build_ruby_debian_9-2_6_7-malloctrim:
+    name: 'Build Ruby [debian-9/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -6714,7 +6714,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6749,14 +6749,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-debian-9-malloctrim
+          key: v2-ruby-bin-2.6.7-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -6765,13 +6765,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -6800,7 +6800,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6852,7 +6852,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -6885,7 +6885,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -6942,7 +6942,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -6975,7 +6975,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7027,7 +7027,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7060,7 +7060,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7112,7 +7112,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7145,7 +7145,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7202,7 +7202,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7235,7 +7235,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7287,7 +7287,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7320,7 +7320,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7372,7 +7372,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7405,7 +7405,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7462,7 +7462,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7495,7 +7495,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7547,7 +7547,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -7555,15 +7555,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-3_0_0-normal:
-    name: 'Build Ruby [ubuntu-18.04/3.0.0/normal]'
+  build_ruby_ubuntu_18_04-3_0_1-normal:
+    name: 'Build Ruby [ubuntu-18.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -7580,7 +7580,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7615,14 +7615,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-ubuntu-18.04-normal
+          key: v2-ruby-bin-3.0.1-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -7631,24 +7631,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-3_0_0-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/3.0.0/jemalloc]'
+  build_ruby_ubuntu_18_04-3_0_1-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -7665,7 +7665,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7705,14 +7705,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-3.0.1-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -7721,24 +7721,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-3_0_0-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/3.0.0/malloctrim]'
+  build_ruby_ubuntu_18_04-3_0_1-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -7755,7 +7755,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7790,14 +7790,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-3.0.1-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -7806,24 +7806,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-2_7_2-normal:
-    name: 'Build Ruby [ubuntu-18.04/2.7.2/normal]'
+  build_ruby_ubuntu_18_04-2_7_3-normal:
+    name: 'Build Ruby [ubuntu-18.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -7840,7 +7840,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7875,14 +7875,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-ubuntu-18.04-normal
+          key: v2-ruby-bin-2.7.3-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -7891,24 +7891,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-2_7_2-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/2.7.2/jemalloc]'
+  build_ruby_ubuntu_18_04-2_7_3-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -7925,7 +7925,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -7965,14 +7965,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-2.7.3-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -7981,24 +7981,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-2_7_2-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/2.7.2/malloctrim]'
+  build_ruby_ubuntu_18_04-2_7_3-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -8015,7 +8015,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8050,14 +8050,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-2.7.3-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -8066,24 +8066,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-2_6_6-normal:
-    name: 'Build Ruby [ubuntu-18.04/2.6.6/normal]'
+  build_ruby_ubuntu_18_04-2_6_7-normal:
+    name: 'Build Ruby [ubuntu-18.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -8100,7 +8100,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8135,14 +8135,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-ubuntu-18.04-normal
+          key: v2-ruby-bin-2.6.7-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -8151,24 +8151,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-2_6_6-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/2.6.6/jemalloc]'
+  build_ruby_ubuntu_18_04-2_6_7-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -8185,7 +8185,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8225,14 +8225,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-2.6.7-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -8241,24 +8241,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-2_6_6-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/2.6.6/malloctrim]'
+  build_ruby_ubuntu_18_04-2_6_7-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -8275,7 +8275,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8310,14 +8310,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-2.6.7-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -8326,13 +8326,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -8361,7 +8361,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8413,7 +8413,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8446,7 +8446,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8503,7 +8503,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8536,7 +8536,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8588,7 +8588,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8621,7 +8621,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8673,7 +8673,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8706,7 +8706,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8763,7 +8763,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8796,7 +8796,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8848,7 +8848,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "3"
+          RUBY_PACKAGE_REVISION: "4"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8881,7 +8881,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -8933,7 +8933,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -8966,7 +8966,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9023,7 +9023,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -9056,7 +9056,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9108,7 +9108,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -9116,15 +9116,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-3_0_0-normal:
-    name: 'Build Ruby [ubuntu-20.04/3.0.0/normal]'
+  build_ruby_ubuntu_20_04-3_0_1-normal:
+    name: 'Build Ruby [ubuntu-20.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9141,7 +9141,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9176,14 +9176,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.0-ubuntu-20.04-normal
+          key: v2-ruby-bin-3.0.1-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9192,24 +9192,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-3_0_0-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/3.0.0/jemalloc]'
+  build_ruby_ubuntu_20_04-3_0_1-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9226,7 +9226,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9266,14 +9266,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.0-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-3.0.1-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9282,24 +9282,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-3_0_0-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/3.0.0/malloctrim]'
+  build_ruby_ubuntu_20_04-3_0_1-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9316,7 +9316,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9351,14 +9351,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.0-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-3.0.1-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9367,24 +9367,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.0"
-          RUBY_PACKAGE_REVISION: "1"
+          RUBY_PACKAGE_VERSION_ID: "3.0.1"
+          RUBY_PACKAGE_REVISION: "2"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.0_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.1_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-2_7_2-normal:
-    name: 'Build Ruby [ubuntu-20.04/2.7.2/normal]'
+  build_ruby_ubuntu_20_04-2_7_3-normal:
+    name: 'Build Ruby [ubuntu-20.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9401,7 +9401,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9436,14 +9436,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.2-ubuntu-20.04-normal
+          key: v2-ruby-bin-2.7.3-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9452,24 +9452,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-2_7_2-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/2.7.2/jemalloc]'
+  build_ruby_ubuntu_20_04-2_7_3-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9486,7 +9486,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9526,14 +9526,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.2-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-2.7.3-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9542,24 +9542,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-2_7_2-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/2.7.2/malloctrim]'
+  build_ruby_ubuntu_20_04-2_7_3-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9576,7 +9576,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9611,14 +9611,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.2-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-2.7.3-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9627,24 +9627,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.2"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.7.3"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.2_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.3_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-2_6_6-normal:
-    name: 'Build Ruby [ubuntu-20.04/2.6.6/normal]'
+  build_ruby_ubuntu_20_04-2_6_7-normal:
+    name: 'Build Ruby [ubuntu-20.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9661,7 +9661,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9696,14 +9696,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.6-ubuntu-20.04-normal
+          key: v2-ruby-bin-2.6.7-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9712,24 +9712,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-2_6_6-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/2.6.6/jemalloc]'
+  build_ruby_ubuntu_20_04-2_6_7-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9746,7 +9746,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9786,14 +9786,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.6-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-2.6.7-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9802,24 +9802,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-2_6_6-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/2.6.6/malloctrim]'
+  build_ruby_ubuntu_20_04-2_6_7-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -9836,7 +9836,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -9871,14 +9871,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.6-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-2.6.7-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -9887,13 +9887,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.6"
-          RUBY_PACKAGE_REVISION: "2"
+          RUBY_PACKAGE_VERSION_ID: "2.6.7"
+          RUBY_PACKAGE_REVISION: "3"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.6_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.7_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -9923,17 +9923,17 @@ jobs:
       - build_ruby_centos_7-2_6-jemalloc
       - build_ruby_centos_7-2_6-malloctrim
 
-      - build_ruby_centos_7-3_0_0-normal
-      - build_ruby_centos_7-3_0_0-jemalloc
-      - build_ruby_centos_7-3_0_0-malloctrim
+      - build_ruby_centos_7-3_0_1-normal
+      - build_ruby_centos_7-3_0_1-jemalloc
+      - build_ruby_centos_7-3_0_1-malloctrim
 
-      - build_ruby_centos_7-2_7_2-normal
-      - build_ruby_centos_7-2_7_2-jemalloc
-      - build_ruby_centos_7-2_7_2-malloctrim
+      - build_ruby_centos_7-2_7_3-normal
+      - build_ruby_centos_7-2_7_3-jemalloc
+      - build_ruby_centos_7-2_7_3-malloctrim
 
-      - build_ruby_centos_7-2_6_6-normal
-      - build_ruby_centos_7-2_6_6-jemalloc
-      - build_ruby_centos_7-2_6_6-malloctrim
+      - build_ruby_centos_7-2_6_7-normal
+      - build_ruby_centos_7-2_6_7-jemalloc
+      - build_ruby_centos_7-2_6_7-malloctrim
 
       - build_jemalloc_centos_8
 
@@ -9949,17 +9949,17 @@ jobs:
       - build_ruby_centos_8-2_6-jemalloc
       - build_ruby_centos_8-2_6-malloctrim
 
-      - build_ruby_centos_8-3_0_0-normal
-      - build_ruby_centos_8-3_0_0-jemalloc
-      - build_ruby_centos_8-3_0_0-malloctrim
+      - build_ruby_centos_8-3_0_1-normal
+      - build_ruby_centos_8-3_0_1-jemalloc
+      - build_ruby_centos_8-3_0_1-malloctrim
 
-      - build_ruby_centos_8-2_7_2-normal
-      - build_ruby_centos_8-2_7_2-jemalloc
-      - build_ruby_centos_8-2_7_2-malloctrim
+      - build_ruby_centos_8-2_7_3-normal
+      - build_ruby_centos_8-2_7_3-jemalloc
+      - build_ruby_centos_8-2_7_3-malloctrim
 
-      - build_ruby_centos_8-2_6_6-normal
-      - build_ruby_centos_8-2_6_6-jemalloc
-      - build_ruby_centos_8-2_6_6-malloctrim
+      - build_ruby_centos_8-2_6_7-normal
+      - build_ruby_centos_8-2_6_7-jemalloc
+      - build_ruby_centos_8-2_6_7-malloctrim
 
       - build_jemalloc_debian_10
 
@@ -9975,17 +9975,17 @@ jobs:
       - build_ruby_debian_10-2_6-jemalloc
       - build_ruby_debian_10-2_6-malloctrim
 
-      - build_ruby_debian_10-3_0_0-normal
-      - build_ruby_debian_10-3_0_0-jemalloc
-      - build_ruby_debian_10-3_0_0-malloctrim
+      - build_ruby_debian_10-3_0_1-normal
+      - build_ruby_debian_10-3_0_1-jemalloc
+      - build_ruby_debian_10-3_0_1-malloctrim
 
-      - build_ruby_debian_10-2_7_2-normal
-      - build_ruby_debian_10-2_7_2-jemalloc
-      - build_ruby_debian_10-2_7_2-malloctrim
+      - build_ruby_debian_10-2_7_3-normal
+      - build_ruby_debian_10-2_7_3-jemalloc
+      - build_ruby_debian_10-2_7_3-malloctrim
 
-      - build_ruby_debian_10-2_6_6-normal
-      - build_ruby_debian_10-2_6_6-jemalloc
-      - build_ruby_debian_10-2_6_6-malloctrim
+      - build_ruby_debian_10-2_6_7-normal
+      - build_ruby_debian_10-2_6_7-jemalloc
+      - build_ruby_debian_10-2_6_7-malloctrim
 
       - build_jemalloc_debian_9
 
@@ -10001,17 +10001,17 @@ jobs:
       - build_ruby_debian_9-2_6-jemalloc
       - build_ruby_debian_9-2_6-malloctrim
 
-      - build_ruby_debian_9-3_0_0-normal
-      - build_ruby_debian_9-3_0_0-jemalloc
-      - build_ruby_debian_9-3_0_0-malloctrim
+      - build_ruby_debian_9-3_0_1-normal
+      - build_ruby_debian_9-3_0_1-jemalloc
+      - build_ruby_debian_9-3_0_1-malloctrim
 
-      - build_ruby_debian_9-2_7_2-normal
-      - build_ruby_debian_9-2_7_2-jemalloc
-      - build_ruby_debian_9-2_7_2-malloctrim
+      - build_ruby_debian_9-2_7_3-normal
+      - build_ruby_debian_9-2_7_3-jemalloc
+      - build_ruby_debian_9-2_7_3-malloctrim
 
-      - build_ruby_debian_9-2_6_6-normal
-      - build_ruby_debian_9-2_6_6-jemalloc
-      - build_ruby_debian_9-2_6_6-malloctrim
+      - build_ruby_debian_9-2_6_7-normal
+      - build_ruby_debian_9-2_6_7-jemalloc
+      - build_ruby_debian_9-2_6_7-malloctrim
 
       - build_jemalloc_ubuntu_18_04
 
@@ -10027,17 +10027,17 @@ jobs:
       - build_ruby_ubuntu_18_04-2_6-jemalloc
       - build_ruby_ubuntu_18_04-2_6-malloctrim
 
-      - build_ruby_ubuntu_18_04-3_0_0-normal
-      - build_ruby_ubuntu_18_04-3_0_0-jemalloc
-      - build_ruby_ubuntu_18_04-3_0_0-malloctrim
+      - build_ruby_ubuntu_18_04-3_0_1-normal
+      - build_ruby_ubuntu_18_04-3_0_1-jemalloc
+      - build_ruby_ubuntu_18_04-3_0_1-malloctrim
 
-      - build_ruby_ubuntu_18_04-2_7_2-normal
-      - build_ruby_ubuntu_18_04-2_7_2-jemalloc
-      - build_ruby_ubuntu_18_04-2_7_2-malloctrim
+      - build_ruby_ubuntu_18_04-2_7_3-normal
+      - build_ruby_ubuntu_18_04-2_7_3-jemalloc
+      - build_ruby_ubuntu_18_04-2_7_3-malloctrim
 
-      - build_ruby_ubuntu_18_04-2_6_6-normal
-      - build_ruby_ubuntu_18_04-2_6_6-jemalloc
-      - build_ruby_ubuntu_18_04-2_6_6-malloctrim
+      - build_ruby_ubuntu_18_04-2_6_7-normal
+      - build_ruby_ubuntu_18_04-2_6_7-jemalloc
+      - build_ruby_ubuntu_18_04-2_6_7-malloctrim
 
       - build_jemalloc_ubuntu_20_04
 
@@ -10053,17 +10053,17 @@ jobs:
       - build_ruby_ubuntu_20_04-2_6-jemalloc
       - build_ruby_ubuntu_20_04-2_6-malloctrim
 
-      - build_ruby_ubuntu_20_04-3_0_0-normal
-      - build_ruby_ubuntu_20_04-3_0_0-jemalloc
-      - build_ruby_ubuntu_20_04-3_0_0-malloctrim
+      - build_ruby_ubuntu_20_04-3_0_1-normal
+      - build_ruby_ubuntu_20_04-3_0_1-jemalloc
+      - build_ruby_ubuntu_20_04-3_0_1-malloctrim
 
-      - build_ruby_ubuntu_20_04-2_7_2-normal
-      - build_ruby_ubuntu_20_04-2_7_2-jemalloc
-      - build_ruby_ubuntu_20_04-2_7_2-malloctrim
+      - build_ruby_ubuntu_20_04-2_7_3-normal
+      - build_ruby_ubuntu_20_04-2_7_3-jemalloc
+      - build_ruby_ubuntu_20_04-2_7_3-malloctrim
 
-      - build_ruby_ubuntu_20_04-2_6_6-normal
-      - build_ruby_ubuntu_20_04-2_6_6-jemalloc
-      - build_ruby_ubuntu_20_04-2_6_6-malloctrim
+      - build_ruby_ubuntu_20_04-2_6_7-normal
+      - build_ruby_ubuntu_20_04-2_6_7-jemalloc
+      - build_ruby_ubuntu_20_04-2_6_7-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -10173,7 +10173,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.1_centos-7_normal ruby-pkg_3.0.1_centos-7_jemalloc ruby-pkg_3.0.1_centos-7_malloctrim ruby-pkg_3.0.1_centos-8_normal ruby-pkg_3.0.1_centos-8_jemalloc ruby-pkg_3.0.1_centos-8_malloctrim ruby-pkg_3.0.1_debian-10_normal ruby-pkg_3.0.1_debian-10_jemalloc ruby-pkg_3.0.1_debian-10_malloctrim ruby-pkg_3.0.1_debian-9_normal ruby-pkg_3.0.1_debian-9_jemalloc ruby-pkg_3.0.1_debian-9_malloctrim ruby-pkg_3.0.1_ubuntu-18.04_normal ruby-pkg_3.0.1_ubuntu-18.04_jemalloc ruby-pkg_3.0.1_ubuntu-18.04_malloctrim ruby-pkg_3.0.1_ubuntu-20.04_normal ruby-pkg_3.0.1_ubuntu-20.04_jemalloc ruby-pkg_3.0.1_ubuntu-20.04_malloctrim ruby-pkg_2.7.3_centos-7_normal ruby-pkg_2.7.3_centos-7_jemalloc ruby-pkg_2.7.3_centos-7_malloctrim ruby-pkg_2.7.3_centos-8_normal ruby-pkg_2.7.3_centos-8_jemalloc ruby-pkg_2.7.3_centos-8_malloctrim ruby-pkg_2.7.3_debian-10_normal ruby-pkg_2.7.3_debian-10_jemalloc ruby-pkg_2.7.3_debian-10_malloctrim ruby-pkg_2.7.3_debian-9_normal ruby-pkg_2.7.3_debian-9_jemalloc ruby-pkg_2.7.3_debian-9_malloctrim ruby-pkg_2.7.3_ubuntu-18.04_normal ruby-pkg_2.7.3_ubuntu-18.04_jemalloc ruby-pkg_2.7.3_ubuntu-18.04_malloctrim ruby-pkg_2.7.3_ubuntu-20.04_normal ruby-pkg_2.7.3_ubuntu-20.04_jemalloc ruby-pkg_2.7.3_ubuntu-20.04_malloctrim ruby-pkg_2.6.7_centos-7_normal ruby-pkg_2.6.7_centos-7_jemalloc ruby-pkg_2.6.7_centos-7_malloctrim ruby-pkg_2.6.7_centos-8_normal ruby-pkg_2.6.7_centos-8_jemalloc ruby-pkg_2.6.7_centos-8_malloctrim ruby-pkg_2.6.7_debian-10_normal ruby-pkg_2.6.7_debian-10_jemalloc ruby-pkg_2.6.7_debian-10_malloctrim ruby-pkg_2.6.7_debian-9_normal ruby-pkg_2.6.7_debian-9_jemalloc ruby-pkg_2.6.7_debian-9_malloctrim ruby-pkg_2.6.7_ubuntu-18.04_normal ruby-pkg_2.6.7_ubuntu-18.04_jemalloc ruby-pkg_2.6.7_ubuntu-18.04_malloctrim ruby-pkg_2.6.7_ubuntu-20.04_normal ruby-pkg_2.6.7_ubuntu-20.04_jemalloc ruby-pkg_2.6.7_ubuntu-20.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
       - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-7_normal] to Github
@@ -10446,276 +10446,276 @@ jobs:
         with:
           name: ruby-pkg_2.6_ubuntu-20.04_malloctrim
           path: artifacts/ruby-pkg_2.6_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-7_normal
-          path: artifacts/ruby-pkg_3.0.0_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_jemalloc] to Github
+          name: ruby-pkg_3.0.1_centos-7_normal
+          path: artifacts/ruby-pkg_3.0.1_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-7_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-7_malloctrim] to Github
+          name: ruby-pkg_3.0.1_centos-7_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-7_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_normal] to Github
+          name: ruby-pkg_3.0.1_centos-7_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-8_normal
-          path: artifacts/ruby-pkg_3.0.0_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_jemalloc] to Github
+          name: ruby-pkg_3.0.1_centos-8_normal
+          path: artifacts/ruby-pkg_3.0.1_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-8_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_centos-8_malloctrim] to Github
+          name: ruby-pkg_3.0.1_centos-8_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_normal] to Github
+          name: ruby-pkg_3.0.1_centos-8_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-10_normal
-          path: artifacts/ruby-pkg_3.0.0_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_jemalloc] to Github
+          name: ruby-pkg_3.0.1_debian-10_normal
+          path: artifacts/ruby-pkg_3.0.1_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-10_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-10_malloctrim] to Github
+          name: ruby-pkg_3.0.1_debian-10_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-10_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_normal] to Github
+          name: ruby-pkg_3.0.1_debian-10_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-9_normal
-          path: artifacts/ruby-pkg_3.0.0_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_jemalloc] to Github
+          name: ruby-pkg_3.0.1_debian-9_normal
+          path: artifacts/ruby-pkg_3.0.1_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-9_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_debian-9_malloctrim] to Github
+          name: ruby-pkg_3.0.1_debian-9_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_debian-9_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_3.0.1_debian-9_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_3.0.1_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_3.0.1_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_3.0.1_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_3.0.1_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.0_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_3.0.1_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.1_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.0_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_3.0.0_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_normal] to Github
+          name: ruby-pkg_3.0.1_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.1_ubuntu-20.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-7_normal
-          path: artifacts/ruby-pkg_2.7.2_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_jemalloc] to Github
+          name: ruby-pkg_2.7.3_centos-7_normal
+          path: artifacts/ruby-pkg_2.7.3_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-7_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-7_malloctrim] to Github
+          name: ruby-pkg_2.7.3_centos-7_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-7_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_normal] to Github
+          name: ruby-pkg_2.7.3_centos-7_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-8_normal
-          path: artifacts/ruby-pkg_2.7.2_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_jemalloc] to Github
+          name: ruby-pkg_2.7.3_centos-8_normal
+          path: artifacts/ruby-pkg_2.7.3_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-8_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_centos-8_malloctrim] to Github
+          name: ruby-pkg_2.7.3_centos-8_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_centos-8_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_normal] to Github
+          name: ruby-pkg_2.7.3_centos-8_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-10_normal
-          path: artifacts/ruby-pkg_2.7.2_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_jemalloc] to Github
+          name: ruby-pkg_2.7.3_debian-10_normal
+          path: artifacts/ruby-pkg_2.7.3_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-10_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-10_malloctrim] to Github
+          name: ruby-pkg_2.7.3_debian-10_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-10_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_normal] to Github
+          name: ruby-pkg_2.7.3_debian-10_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-9_normal
-          path: artifacts/ruby-pkg_2.7.2_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_jemalloc] to Github
+          name: ruby-pkg_2.7.3_debian-9_normal
+          path: artifacts/ruby-pkg_2.7.3_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-9_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_debian-9_malloctrim] to Github
+          name: ruby-pkg_2.7.3_debian-9_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_debian-9_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_2.7.3_debian-9_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_2.7.3_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_2.7.3_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_2.7.3_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_2.7.3_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.2_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_2.7.3_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.3_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_2.7.2_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-7_normal] to Github
+          name: ruby-pkg_2.7.3_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_2.7.3_ubuntu-20.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-7_normal
-          path: artifacts/ruby-pkg_2.6.6_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-7_jemalloc] to Github
+          name: ruby-pkg_2.6.7_centos-7_normal
+          path: artifacts/ruby-pkg_2.6.7_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-7_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-7_malloctrim] to Github
+          name: ruby-pkg_2.6.7_centos-7_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-7_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-8_normal] to Github
+          name: ruby-pkg_2.6.7_centos-7_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-8_normal
-          path: artifacts/ruby-pkg_2.6.6_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-8_jemalloc] to Github
+          name: ruby-pkg_2.6.7_centos-8_normal
+          path: artifacts/ruby-pkg_2.6.7_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-8_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_centos-8_malloctrim] to Github
+          name: ruby-pkg_2.6.7_centos-8_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_centos-8_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-10_normal] to Github
+          name: ruby-pkg_2.6.7_centos-8_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-10_normal
-          path: artifacts/ruby-pkg_2.6.6_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-10_jemalloc] to Github
+          name: ruby-pkg_2.6.7_debian-10_normal
+          path: artifacts/ruby-pkg_2.6.7_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-10_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-10_malloctrim] to Github
+          name: ruby-pkg_2.6.7_debian-10_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-10_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-9_normal] to Github
+          name: ruby-pkg_2.6.7_debian-10_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-9_normal
-          path: artifacts/ruby-pkg_2.6.6_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-9_jemalloc] to Github
+          name: ruby-pkg_2.6.7_debian-9_normal
+          path: artifacts/ruby-pkg_2.6.7_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-9_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_debian-9_malloctrim] to Github
+          name: ruby-pkg_2.6.7_debian-9_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_debian-9_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_2.6.7_debian-9_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_2.6.7_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_2.6.7_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_2.6.7_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_2.6.7_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.6_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_2.6.7_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.7_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.6_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_2.6.6_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.6.7_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_2.6.7_ubuntu-20.04_malloctrim
 
 
       ### Check whether dependent jobs failed ###
@@ -10801,33 +10801,33 @@ jobs:
             || (needs.build_ruby_centos_7-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_centos_7-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6/malloctrim];')))
-            || (needs.build_ruby_centos_7-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/normal];')))
-            || (needs.build_ruby_centos_7-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/jemalloc];')))
-            || (needs.build_ruby_centos_7-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.0/malloctrim];')))
-            || (needs.build_ruby_centos_7-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/normal];')))
-            || (needs.build_ruby_centos_7-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/jemalloc];')))
-            || (needs.build_ruby_centos_7-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.2/malloctrim];')))
-            || (needs.build_ruby_centos_7-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/normal];')))
-            || (needs.build_ruby_centos_7-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/jemalloc];')))
-            || (needs.build_ruby_centos_7-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.6/malloctrim];')))
+            || (needs.build_ruby_centos_7-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/normal];')))
+            || (needs.build_ruby_centos_7-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/jemalloc];')))
+            || (needs.build_ruby_centos_7-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.1/malloctrim];')))
+            || (needs.build_ruby_centos_7-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/normal];')))
+            || (needs.build_ruby_centos_7-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/jemalloc];')))
+            || (needs.build_ruby_centos_7-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.3/malloctrim];')))
+            || (needs.build_ruby_centos_7-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/normal];')))
+            || (needs.build_ruby_centos_7-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/jemalloc];')))
+            || (needs.build_ruby_centos_7-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.7/malloctrim];')))
       - name: Check whether 'Build Ruby [centos-8]' did not fail
         run: 'false'
         if: |
@@ -10859,33 +10859,33 @@ jobs:
             || (needs.build_ruby_centos_8-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_centos_8-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6/malloctrim];')))
-            || (needs.build_ruby_centos_8-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/normal];')))
-            || (needs.build_ruby_centos_8-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.0/malloctrim];')))
-            || (needs.build_ruby_centos_8-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/normal];')))
-            || (needs.build_ruby_centos_8-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/jemalloc];')))
-            || (needs.build_ruby_centos_8-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.2/malloctrim];')))
-            || (needs.build_ruby_centos_8-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/normal];')))
-            || (needs.build_ruby_centos_8-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/jemalloc];')))
-            || (needs.build_ruby_centos_8-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.6/malloctrim];')))
+            || (needs.build_ruby_centos_8-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/normal];')))
+            || (needs.build_ruby_centos_8-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/jemalloc];')))
+            || (needs.build_ruby_centos_8-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.1/malloctrim];')))
+            || (needs.build_ruby_centos_8-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/normal];')))
+            || (needs.build_ruby_centos_8-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/jemalloc];')))
+            || (needs.build_ruby_centos_8-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.3/malloctrim];')))
+            || (needs.build_ruby_centos_8-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/normal];')))
+            || (needs.build_ruby_centos_8-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/jemalloc];')))
+            || (needs.build_ruby_centos_8-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.7/malloctrim];')))
       - name: Check whether 'Build Ruby [debian-10]' did not fail
         run: 'false'
         if: |
@@ -10917,33 +10917,33 @@ jobs:
             || (needs.build_ruby_debian_10-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_debian_10-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6/malloctrim];')))
-            || (needs.build_ruby_debian_10-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/normal];')))
-            || (needs.build_ruby_debian_10-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/jemalloc];')))
-            || (needs.build_ruby_debian_10-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.0/malloctrim];')))
-            || (needs.build_ruby_debian_10-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/normal];')))
-            || (needs.build_ruby_debian_10-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/jemalloc];')))
-            || (needs.build_ruby_debian_10-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.2/malloctrim];')))
-            || (needs.build_ruby_debian_10-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/normal];')))
-            || (needs.build_ruby_debian_10-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/jemalloc];')))
-            || (needs.build_ruby_debian_10-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.6/malloctrim];')))
+            || (needs.build_ruby_debian_10-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/normal];')))
+            || (needs.build_ruby_debian_10-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/jemalloc];')))
+            || (needs.build_ruby_debian_10-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.1/malloctrim];')))
+            || (needs.build_ruby_debian_10-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/normal];')))
+            || (needs.build_ruby_debian_10-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/jemalloc];')))
+            || (needs.build_ruby_debian_10-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.3/malloctrim];')))
+            || (needs.build_ruby_debian_10-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/normal];')))
+            || (needs.build_ruby_debian_10-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/jemalloc];')))
+            || (needs.build_ruby_debian_10-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.7/malloctrim];')))
       - name: Check whether 'Build Ruby [debian-9]' did not fail
         run: 'false'
         if: |
@@ -10975,33 +10975,33 @@ jobs:
             || (needs.build_ruby_debian_9-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_debian_9-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6/malloctrim];')))
-            || (needs.build_ruby_debian_9-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/normal];')))
-            || (needs.build_ruby_debian_9-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/jemalloc];')))
-            || (needs.build_ruby_debian_9-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.0/malloctrim];')))
-            || (needs.build_ruby_debian_9-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/normal];')))
-            || (needs.build_ruby_debian_9-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/jemalloc];')))
-            || (needs.build_ruby_debian_9-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.2/malloctrim];')))
-            || (needs.build_ruby_debian_9-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/normal];')))
-            || (needs.build_ruby_debian_9-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/jemalloc];')))
-            || (needs.build_ruby_debian_9-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.6/malloctrim];')))
+            || (needs.build_ruby_debian_9-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/normal];')))
+            || (needs.build_ruby_debian_9-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/jemalloc];')))
+            || (needs.build_ruby_debian_9-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.1/malloctrim];')))
+            || (needs.build_ruby_debian_9-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/normal];')))
+            || (needs.build_ruby_debian_9-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/jemalloc];')))
+            || (needs.build_ruby_debian_9-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.3/malloctrim];')))
+            || (needs.build_ruby_debian_9-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/normal];')))
+            || (needs.build_ruby_debian_9-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/jemalloc];')))
+            || (needs.build_ruby_debian_9-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.7/malloctrim];')))
       - name: Check whether 'Build Ruby [ubuntu-18.04]' did not fail
         run: 'false'
         if: |
@@ -11033,33 +11033,33 @@ jobs:
             || (needs.build_ruby_ubuntu_18_04-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.0/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.6/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.1/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.3/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.7/malloctrim];')))
       - name: Check whether 'Build Ruby [ubuntu-20.04]' did not fail
         run: 'false'
         if: |
@@ -11091,33 +11091,33 @@ jobs:
             || (needs.build_ruby_ubuntu_20_04-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_0-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_0-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.0/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_2-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_2-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_2-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_6-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_6-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_6-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_6-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_6-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_6-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.6/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_1-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_1-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_1-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_1-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_1-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_1-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.1/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_3-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_3-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_3-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.3/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_7-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_7-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_7-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_7-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_7-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_7-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.7/malloctrim];')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -351,12 +351,12 @@ jobs:
   ### Sources ###
 
 
-  download_ruby_source_3_0_0:
-    name: Download Ruby source [3.0.0]
+  download_ruby_source_3_0_1:
+    name: Download Ruby source [3.0.1]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.0;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.1;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -369,25 +369,25 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-3.0.0
+          key: v3-ruby-src-3.0.1
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 3.0.0
+          RUBY_VERSION: 3.0.1
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: output
-  download_ruby_source_2_7_2:
-    name: Download Ruby source [2.7.2]
+  download_ruby_source_2_7_3:
+    name: Download Ruby source [2.7.3]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.2;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.3;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -400,25 +400,25 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-2.7.2
+          key: v3-ruby-src-2.7.3
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 2.7.2
+          RUBY_VERSION: 2.7.3
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: output
-  download_ruby_source_2_6_6:
-    name: Download Ruby source [2.6.6]
+  download_ruby_source_2_6_7:
+    name: Download Ruby source [2.6.7]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.6;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.7;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -431,18 +431,18 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-2.6.6
+          key: v3-ruby-src-2.6.7
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 2.6.6
+          RUBY_VERSION: 2.6.7
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: output
 
 
@@ -496,9 +496,9 @@ jobs:
       - build_docker_image_ubuntu_18_04
       - build_docker_image_ubuntu_20_04
       - build_docker_image_utility
-      - download_ruby_source_3_0_0
-      - download_ruby_source_2_7_2
-      - download_ruby_source_2_6_6
+      - download_ruby_source_3_0_1
+      - download_ruby_source_2_7_3
+      - download_ruby_source_2_6_7
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -619,38 +619,38 @@ jobs:
           path: artifacts
 
 
-      - name: Download Ruby source artifact [3.0.0] from Google Cloud
+      - name: Download Ruby source artifact [3.0.1] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.0
+          ARTIFACT_NAME: ruby-src-3.0.1
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [3.0.0] to Github
+      - name: Archive Ruby source artifact [3.0.1] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-3.0.0
+          name: ruby-src-3.0.1
           path: artifacts
-      - name: Download Ruby source artifact [2.7.2] from Google Cloud
+      - name: Download Ruby source artifact [2.7.3] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.2
+          ARTIFACT_NAME: ruby-src-2.7.3
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [2.7.2] to Github
+      - name: Archive Ruby source artifact [2.7.3] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-2.7.2
+          name: ruby-src-2.7.3
           path: artifacts
-      - name: Download Ruby source artifact [2.6.6] from Google Cloud
+      - name: Download Ruby source artifact [2.6.7] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.6
+          ARTIFACT_NAME: ruby-src-2.6.7
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [2.6.6] to Github
+      - name: Archive Ruby source artifact [2.6.7] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-2.6.6
+          name: ruby-src-2.6.7
           path: artifacts
 
 
@@ -701,15 +701,15 @@ jobs:
         run: 'false'
         if: |
           false
-            || (needs.download_ruby_source_3_0_0.result != 'success'
-              && (needs.download_ruby_source_3_0_0.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.0;')))
-            || (needs.download_ruby_source_2_7_2.result != 'success'
-              && (needs.download_ruby_source_2_7_2.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.2;')))
-            || (needs.download_ruby_source_2_6_6.result != 'success'
-              && (needs.download_ruby_source_2_6_6.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.6;')))
+            || (needs.download_ruby_source_3_0_1.result != 'success'
+              && (needs.download_ruby_source_3_0_1.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.1;')))
+            || (needs.download_ruby_source_2_7_3.result != 'success'
+              && (needs.download_ruby_source_2_7_3.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.3;')))
+            || (needs.download_ruby_source_2_6_7.result != 'success'
+              && (needs.download_ruby_source_2_6_7.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.7;')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -92,7 +92,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.1_centos-7_normal ruby-pkg_3.0.1_centos-7_jemalloc ruby-pkg_3.0.1_centos-7_malloctrim ruby-pkg_3.0.1_centos-8_normal ruby-pkg_3.0.1_centos-8_jemalloc ruby-pkg_3.0.1_centos-8_malloctrim ruby-pkg_3.0.1_debian-10_normal ruby-pkg_3.0.1_debian-10_jemalloc ruby-pkg_3.0.1_debian-10_malloctrim ruby-pkg_3.0.1_debian-9_normal ruby-pkg_3.0.1_debian-9_jemalloc ruby-pkg_3.0.1_debian-9_malloctrim ruby-pkg_3.0.1_ubuntu-18.04_normal ruby-pkg_3.0.1_ubuntu-18.04_jemalloc ruby-pkg_3.0.1_ubuntu-18.04_malloctrim ruby-pkg_3.0.1_ubuntu-20.04_normal ruby-pkg_3.0.1_ubuntu-20.04_jemalloc ruby-pkg_3.0.1_ubuntu-20.04_malloctrim ruby-pkg_2.7.3_centos-7_normal ruby-pkg_2.7.3_centos-7_jemalloc ruby-pkg_2.7.3_centos-7_malloctrim ruby-pkg_2.7.3_centos-8_normal ruby-pkg_2.7.3_centos-8_jemalloc ruby-pkg_2.7.3_centos-8_malloctrim ruby-pkg_2.7.3_debian-10_normal ruby-pkg_2.7.3_debian-10_jemalloc ruby-pkg_2.7.3_debian-10_malloctrim ruby-pkg_2.7.3_debian-9_normal ruby-pkg_2.7.3_debian-9_jemalloc ruby-pkg_2.7.3_debian-9_malloctrim ruby-pkg_2.7.3_ubuntu-18.04_normal ruby-pkg_2.7.3_ubuntu-18.04_jemalloc ruby-pkg_2.7.3_ubuntu-18.04_malloctrim ruby-pkg_2.7.3_ubuntu-20.04_normal ruby-pkg_2.7.3_ubuntu-20.04_jemalloc ruby-pkg_2.7.3_ubuntu-20.04_malloctrim ruby-pkg_2.6.7_centos-7_normal ruby-pkg_2.6.7_centos-7_jemalloc ruby-pkg_2.6.7_centos-7_malloctrim ruby-pkg_2.6.7_centos-8_normal ruby-pkg_2.6.7_centos-8_jemalloc ruby-pkg_2.6.7_centos-8_malloctrim ruby-pkg_2.6.7_debian-10_normal ruby-pkg_2.6.7_debian-10_jemalloc ruby-pkg_2.6.7_debian-10_malloctrim ruby-pkg_2.6.7_debian-9_normal ruby-pkg_2.6.7_debian-9_jemalloc ruby-pkg_2.6.7_debian-9_malloctrim ruby-pkg_2.6.7_ubuntu-18.04_normal ruby-pkg_2.6.7_ubuntu-18.04_jemalloc ruby-pkg_2.6.7_ubuntu-18.04_malloctrim ruby-pkg_2.6.7_ubuntu-20.04_normal ruby-pkg_2.6.7_ubuntu-20.04_jemalloc ruby-pkg_2.6.7_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -464,15 +464,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-7_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-3_0_0-normal:
-    name: 'Test [centos-7/3.0.0/normal]'
+  test_centos_7-3_0_1-normal:
+    name: 'Test [centos-7/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -484,7 +484,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -497,17 +497,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-3_0_0-jemalloc:
-    name: 'Test [centos-7/3.0.0/jemalloc]'
+  test_centos_7-3_0_1-jemalloc:
+    name: 'Test [centos-7/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -519,7 +519,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -532,17 +532,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-3_0_0-malloctrim:
-    name: 'Test [centos-7/3.0.0/malloctrim]'
+  test_centos_7-3_0_1-malloctrim:
+    name: 'Test [centos-7/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -554,7 +554,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -567,17 +567,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-2_7_2-normal:
-    name: 'Test [centos-7/2.7.2/normal]'
+  test_centos_7-2_7_3-normal:
+    name: 'Test [centos-7/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -589,7 +589,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -602,17 +602,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-2_7_2-jemalloc:
-    name: 'Test [centos-7/2.7.2/jemalloc]'
+  test_centos_7-2_7_3-jemalloc:
+    name: 'Test [centos-7/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -624,7 +624,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -637,17 +637,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-2_7_2-malloctrim:
-    name: 'Test [centos-7/2.7.2/malloctrim]'
+  test_centos_7-2_7_3-malloctrim:
+    name: 'Test [centos-7/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -659,7 +659,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -672,17 +672,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-2_6_6-normal:
-    name: 'Test [centos-7/2.6.6/normal]'
+  test_centos_7-2_6_7-normal:
+    name: 'Test [centos-7/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -694,7 +694,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -707,17 +707,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-2_6_6-jemalloc:
-    name: 'Test [centos-7/2.6.6/jemalloc]'
+  test_centos_7-2_6_7-jemalloc:
+    name: 'Test [centos-7/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -729,7 +729,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -742,17 +742,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-2_6_6-malloctrim:
-    name: 'Test [centos-7/2.6.6/malloctrim]'
+  test_centos_7-2_6_7-malloctrim:
+    name: 'Test [centos-7/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -764,7 +764,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -777,7 +777,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_centos_8-3_0-normal:
@@ -1095,15 +1095,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-3_0_0-normal:
-    name: 'Test [centos-8/3.0.0/normal]'
+  test_centos_8-3_0_1-normal:
+    name: 'Test [centos-8/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1115,7 +1115,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1128,17 +1128,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-3_0_0-jemalloc:
-    name: 'Test [centos-8/3.0.0/jemalloc]'
+  test_centos_8-3_0_1-jemalloc:
+    name: 'Test [centos-8/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1150,7 +1150,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1163,17 +1163,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-3_0_0-malloctrim:
-    name: 'Test [centos-8/3.0.0/malloctrim]'
+  test_centos_8-3_0_1-malloctrim:
+    name: 'Test [centos-8/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1185,7 +1185,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1198,17 +1198,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-2_7_2-normal:
-    name: 'Test [centos-8/2.7.2/normal]'
+  test_centos_8-2_7_3-normal:
+    name: 'Test [centos-8/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1220,7 +1220,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1233,17 +1233,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-2_7_2-jemalloc:
-    name: 'Test [centos-8/2.7.2/jemalloc]'
+  test_centos_8-2_7_3-jemalloc:
+    name: 'Test [centos-8/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1255,7 +1255,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1268,17 +1268,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-2_7_2-malloctrim:
-    name: 'Test [centos-8/2.7.2/malloctrim]'
+  test_centos_8-2_7_3-malloctrim:
+    name: 'Test [centos-8/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1290,7 +1290,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1303,17 +1303,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-2_6_6-normal:
-    name: 'Test [centos-8/2.6.6/normal]'
+  test_centos_8-2_6_7-normal:
+    name: 'Test [centos-8/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1325,7 +1325,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1338,17 +1338,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-2_6_6-jemalloc:
-    name: 'Test [centos-8/2.6.6/jemalloc]'
+  test_centos_8-2_6_7-jemalloc:
+    name: 'Test [centos-8/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1360,7 +1360,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1373,17 +1373,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-2_6_6-malloctrim:
-    name: 'Test [centos-8/2.6.6/malloctrim]'
+  test_centos_8-2_6_7-malloctrim:
+    name: 'Test [centos-8/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1395,7 +1395,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1408,7 +1408,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_10-3_0-normal:
@@ -1726,15 +1726,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-10_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-3_0_0-normal:
-    name: 'Test [debian-10/3.0.0/normal]'
+  test_debian_10-3_0_1-normal:
+    name: 'Test [debian-10/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1746,7 +1746,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1759,17 +1759,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-3_0_0-jemalloc:
-    name: 'Test [debian-10/3.0.0/jemalloc]'
+  test_debian_10-3_0_1-jemalloc:
+    name: 'Test [debian-10/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1781,7 +1781,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1794,17 +1794,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-3_0_0-malloctrim:
-    name: 'Test [debian-10/3.0.0/malloctrim]'
+  test_debian_10-3_0_1-malloctrim:
+    name: 'Test [debian-10/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1816,7 +1816,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1829,17 +1829,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-2_7_2-normal:
-    name: 'Test [debian-10/2.7.2/normal]'
+  test_debian_10-2_7_3-normal:
+    name: 'Test [debian-10/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1851,7 +1851,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1864,17 +1864,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-2_7_2-jemalloc:
-    name: 'Test [debian-10/2.7.2/jemalloc]'
+  test_debian_10-2_7_3-jemalloc:
+    name: 'Test [debian-10/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1886,7 +1886,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1899,17 +1899,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-2_7_2-malloctrim:
-    name: 'Test [debian-10/2.7.2/malloctrim]'
+  test_debian_10-2_7_3-malloctrim:
+    name: 'Test [debian-10/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1921,7 +1921,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1934,17 +1934,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-2_6_6-normal:
-    name: 'Test [debian-10/2.6.6/normal]'
+  test_debian_10-2_6_7-normal:
+    name: 'Test [debian-10/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1956,7 +1956,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1969,17 +1969,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-2_6_6-jemalloc:
-    name: 'Test [debian-10/2.6.6/jemalloc]'
+  test_debian_10-2_6_7-jemalloc:
+    name: 'Test [debian-10/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1991,7 +1991,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2004,17 +2004,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-2_6_6-malloctrim:
-    name: 'Test [debian-10/2.6.6/malloctrim]'
+  test_debian_10-2_6_7-malloctrim:
+    name: 'Test [debian-10/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2026,7 +2026,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2039,7 +2039,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_9-3_0-normal:
@@ -2357,15 +2357,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-9_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-3_0_0-normal:
-    name: 'Test [debian-9/3.0.0/normal]'
+  test_debian_9-3_0_1-normal:
+    name: 'Test [debian-9/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2377,7 +2377,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2390,17 +2390,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-3_0_0-jemalloc:
-    name: 'Test [debian-9/3.0.0/jemalloc]'
+  test_debian_9-3_0_1-jemalloc:
+    name: 'Test [debian-9/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2412,7 +2412,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2425,17 +2425,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-3_0_0-malloctrim:
-    name: 'Test [debian-9/3.0.0/malloctrim]'
+  test_debian_9-3_0_1-malloctrim:
+    name: 'Test [debian-9/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2447,7 +2447,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2460,17 +2460,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-2_7_2-normal:
-    name: 'Test [debian-9/2.7.2/normal]'
+  test_debian_9-2_7_3-normal:
+    name: 'Test [debian-9/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2482,7 +2482,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2495,17 +2495,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-2_7_2-jemalloc:
-    name: 'Test [debian-9/2.7.2/jemalloc]'
+  test_debian_9-2_7_3-jemalloc:
+    name: 'Test [debian-9/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2517,7 +2517,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2530,17 +2530,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-2_7_2-malloctrim:
-    name: 'Test [debian-9/2.7.2/malloctrim]'
+  test_debian_9-2_7_3-malloctrim:
+    name: 'Test [debian-9/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2552,7 +2552,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2565,17 +2565,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-2_6_6-normal:
-    name: 'Test [debian-9/2.6.6/normal]'
+  test_debian_9-2_6_7-normal:
+    name: 'Test [debian-9/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2587,7 +2587,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2600,17 +2600,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-2_6_6-jemalloc:
-    name: 'Test [debian-9/2.6.6/jemalloc]'
+  test_debian_9-2_6_7-jemalloc:
+    name: 'Test [debian-9/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2622,7 +2622,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2635,17 +2635,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-2_6_6-malloctrim:
-    name: 'Test [debian-9/2.6.6/malloctrim]'
+  test_debian_9-2_6_7-malloctrim:
+    name: 'Test [debian-9/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2657,7 +2657,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2670,7 +2670,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_18_04-3_0-normal:
@@ -2988,15 +2988,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-3_0_0-normal:
-    name: 'Test [ubuntu-18.04/3.0.0/normal]'
+  test_ubuntu_18_04-3_0_1-normal:
+    name: 'Test [ubuntu-18.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3008,7 +3008,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3021,17 +3021,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-3_0_0-jemalloc:
-    name: 'Test [ubuntu-18.04/3.0.0/jemalloc]'
+  test_ubuntu_18_04-3_0_1-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3043,7 +3043,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3056,17 +3056,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-3_0_0-malloctrim:
-    name: 'Test [ubuntu-18.04/3.0.0/malloctrim]'
+  test_ubuntu_18_04-3_0_1-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3078,7 +3078,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3091,17 +3091,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-2_7_2-normal:
-    name: 'Test [ubuntu-18.04/2.7.2/normal]'
+  test_ubuntu_18_04-2_7_3-normal:
+    name: 'Test [ubuntu-18.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3113,7 +3113,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3126,17 +3126,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-2_7_2-jemalloc:
-    name: 'Test [ubuntu-18.04/2.7.2/jemalloc]'
+  test_ubuntu_18_04-2_7_3-jemalloc:
+    name: 'Test [ubuntu-18.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3148,7 +3148,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3161,17 +3161,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-2_7_2-malloctrim:
-    name: 'Test [ubuntu-18.04/2.7.2/malloctrim]'
+  test_ubuntu_18_04-2_7_3-malloctrim:
+    name: 'Test [ubuntu-18.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3183,7 +3183,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3196,17 +3196,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-2_6_6-normal:
-    name: 'Test [ubuntu-18.04/2.6.6/normal]'
+  test_ubuntu_18_04-2_6_7-normal:
+    name: 'Test [ubuntu-18.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3218,7 +3218,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3231,17 +3231,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-2_6_6-jemalloc:
-    name: 'Test [ubuntu-18.04/2.6.6/jemalloc]'
+  test_ubuntu_18_04-2_6_7-jemalloc:
+    name: 'Test [ubuntu-18.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3253,7 +3253,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3266,17 +3266,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-2_6_6-malloctrim:
-    name: 'Test [ubuntu-18.04/2.6.6/malloctrim]'
+  test_ubuntu_18_04-2_6_7-malloctrim:
+    name: 'Test [ubuntu-18.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3288,7 +3288,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3301,7 +3301,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_20_04-3_0-normal:
@@ -3619,15 +3619,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-3_0_0-normal:
-    name: 'Test [ubuntu-20.04/3.0.0/normal]'
+  test_ubuntu_20_04-3_0_1-normal:
+    name: 'Test [ubuntu-20.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3639,7 +3639,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3652,17 +3652,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.1_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-3_0_0-jemalloc:
-    name: 'Test [ubuntu-20.04/3.0.0/jemalloc]'
+  test_ubuntu_20_04-3_0_1-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3674,7 +3674,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3687,17 +3687,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-3_0_0-malloctrim:
-    name: 'Test [ubuntu-20.04/3.0.0/malloctrim]'
+  test_ubuntu_20_04-3_0_1-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3709,7 +3709,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3722,17 +3722,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-2_7_2-normal:
-    name: 'Test [ubuntu-20.04/2.7.2/normal]'
+  test_ubuntu_20_04-2_7_3-normal:
+    name: 'Test [ubuntu-20.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3744,7 +3744,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3757,17 +3757,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.2_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.3_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-2_7_2-jemalloc:
-    name: 'Test [ubuntu-20.04/2.7.2/jemalloc]'
+  test_ubuntu_20_04-2_7_3-jemalloc:
+    name: 'Test [ubuntu-20.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3779,7 +3779,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3792,17 +3792,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-2_7_2-malloctrim:
-    name: 'Test [ubuntu-20.04/2.7.2/malloctrim]'
+  test_ubuntu_20_04-2_7_3-malloctrim:
+    name: 'Test [ubuntu-20.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3814,7 +3814,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3827,17 +3827,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-2_6_6-normal:
-    name: 'Test [ubuntu-20.04/2.6.6/normal]'
+  test_ubuntu_20_04-2_6_7-normal:
+    name: 'Test [ubuntu-20.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3849,7 +3849,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3862,17 +3862,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.6_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.7_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-2_6_6-jemalloc:
-    name: 'Test [ubuntu-20.04/2.6.6/jemalloc]'
+  test_ubuntu_20_04-2_6_7-jemalloc:
+    name: 'Test [ubuntu-20.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3884,7 +3884,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3897,17 +3897,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-2_6_6-malloctrim:
-    name: 'Test [ubuntu-20.04/2.6.6/malloctrim]'
+  test_ubuntu_20_04-2_6_7-malloctrim:
+    name: 'Test [ubuntu-20.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3919,7 +3919,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3932,7 +3932,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -3953,15 +3953,15 @@ jobs:
       - test_centos_7-2_6-normal
       - test_centos_7-2_6-jemalloc
       - test_centos_7-2_6-malloctrim
-      - test_centos_7-3_0_0-normal
-      - test_centos_7-3_0_0-jemalloc
-      - test_centos_7-3_0_0-malloctrim
-      - test_centos_7-2_7_2-normal
-      - test_centos_7-2_7_2-jemalloc
-      - test_centos_7-2_7_2-malloctrim
-      - test_centos_7-2_6_6-normal
-      - test_centos_7-2_6_6-jemalloc
-      - test_centos_7-2_6_6-malloctrim
+      - test_centos_7-3_0_1-normal
+      - test_centos_7-3_0_1-jemalloc
+      - test_centos_7-3_0_1-malloctrim
+      - test_centos_7-2_7_3-normal
+      - test_centos_7-2_7_3-jemalloc
+      - test_centos_7-2_7_3-malloctrim
+      - test_centos_7-2_6_7-normal
+      - test_centos_7-2_6_7-jemalloc
+      - test_centos_7-2_6_7-malloctrim
       - test_centos_8-3_0-normal
       - test_centos_8-3_0-jemalloc
       - test_centos_8-3_0-malloctrim
@@ -3971,15 +3971,15 @@ jobs:
       - test_centos_8-2_6-normal
       - test_centos_8-2_6-jemalloc
       - test_centos_8-2_6-malloctrim
-      - test_centos_8-3_0_0-normal
-      - test_centos_8-3_0_0-jemalloc
-      - test_centos_8-3_0_0-malloctrim
-      - test_centos_8-2_7_2-normal
-      - test_centos_8-2_7_2-jemalloc
-      - test_centos_8-2_7_2-malloctrim
-      - test_centos_8-2_6_6-normal
-      - test_centos_8-2_6_6-jemalloc
-      - test_centos_8-2_6_6-malloctrim
+      - test_centos_8-3_0_1-normal
+      - test_centos_8-3_0_1-jemalloc
+      - test_centos_8-3_0_1-malloctrim
+      - test_centos_8-2_7_3-normal
+      - test_centos_8-2_7_3-jemalloc
+      - test_centos_8-2_7_3-malloctrim
+      - test_centos_8-2_6_7-normal
+      - test_centos_8-2_6_7-jemalloc
+      - test_centos_8-2_6_7-malloctrim
       - test_debian_10-3_0-normal
       - test_debian_10-3_0-jemalloc
       - test_debian_10-3_0-malloctrim
@@ -3989,15 +3989,15 @@ jobs:
       - test_debian_10-2_6-normal
       - test_debian_10-2_6-jemalloc
       - test_debian_10-2_6-malloctrim
-      - test_debian_10-3_0_0-normal
-      - test_debian_10-3_0_0-jemalloc
-      - test_debian_10-3_0_0-malloctrim
-      - test_debian_10-2_7_2-normal
-      - test_debian_10-2_7_2-jemalloc
-      - test_debian_10-2_7_2-malloctrim
-      - test_debian_10-2_6_6-normal
-      - test_debian_10-2_6_6-jemalloc
-      - test_debian_10-2_6_6-malloctrim
+      - test_debian_10-3_0_1-normal
+      - test_debian_10-3_0_1-jemalloc
+      - test_debian_10-3_0_1-malloctrim
+      - test_debian_10-2_7_3-normal
+      - test_debian_10-2_7_3-jemalloc
+      - test_debian_10-2_7_3-malloctrim
+      - test_debian_10-2_6_7-normal
+      - test_debian_10-2_6_7-jemalloc
+      - test_debian_10-2_6_7-malloctrim
       - test_debian_9-3_0-normal
       - test_debian_9-3_0-jemalloc
       - test_debian_9-3_0-malloctrim
@@ -4007,15 +4007,15 @@ jobs:
       - test_debian_9-2_6-normal
       - test_debian_9-2_6-jemalloc
       - test_debian_9-2_6-malloctrim
-      - test_debian_9-3_0_0-normal
-      - test_debian_9-3_0_0-jemalloc
-      - test_debian_9-3_0_0-malloctrim
-      - test_debian_9-2_7_2-normal
-      - test_debian_9-2_7_2-jemalloc
-      - test_debian_9-2_7_2-malloctrim
-      - test_debian_9-2_6_6-normal
-      - test_debian_9-2_6_6-jemalloc
-      - test_debian_9-2_6_6-malloctrim
+      - test_debian_9-3_0_1-normal
+      - test_debian_9-3_0_1-jemalloc
+      - test_debian_9-3_0_1-malloctrim
+      - test_debian_9-2_7_3-normal
+      - test_debian_9-2_7_3-jemalloc
+      - test_debian_9-2_7_3-malloctrim
+      - test_debian_9-2_6_7-normal
+      - test_debian_9-2_6_7-jemalloc
+      - test_debian_9-2_6_7-malloctrim
       - test_ubuntu_18_04-3_0-normal
       - test_ubuntu_18_04-3_0-jemalloc
       - test_ubuntu_18_04-3_0-malloctrim
@@ -4025,15 +4025,15 @@ jobs:
       - test_ubuntu_18_04-2_6-normal
       - test_ubuntu_18_04-2_6-jemalloc
       - test_ubuntu_18_04-2_6-malloctrim
-      - test_ubuntu_18_04-3_0_0-normal
-      - test_ubuntu_18_04-3_0_0-jemalloc
-      - test_ubuntu_18_04-3_0_0-malloctrim
-      - test_ubuntu_18_04-2_7_2-normal
-      - test_ubuntu_18_04-2_7_2-jemalloc
-      - test_ubuntu_18_04-2_7_2-malloctrim
-      - test_ubuntu_18_04-2_6_6-normal
-      - test_ubuntu_18_04-2_6_6-jemalloc
-      - test_ubuntu_18_04-2_6_6-malloctrim
+      - test_ubuntu_18_04-3_0_1-normal
+      - test_ubuntu_18_04-3_0_1-jemalloc
+      - test_ubuntu_18_04-3_0_1-malloctrim
+      - test_ubuntu_18_04-2_7_3-normal
+      - test_ubuntu_18_04-2_7_3-jemalloc
+      - test_ubuntu_18_04-2_7_3-malloctrim
+      - test_ubuntu_18_04-2_6_7-normal
+      - test_ubuntu_18_04-2_6_7-jemalloc
+      - test_ubuntu_18_04-2_6_7-malloctrim
       - test_ubuntu_20_04-3_0-normal
       - test_ubuntu_20_04-3_0-jemalloc
       - test_ubuntu_20_04-3_0-malloctrim
@@ -4043,15 +4043,15 @@ jobs:
       - test_ubuntu_20_04-2_6-normal
       - test_ubuntu_20_04-2_6-jemalloc
       - test_ubuntu_20_04-2_6-malloctrim
-      - test_ubuntu_20_04-3_0_0-normal
-      - test_ubuntu_20_04-3_0_0-jemalloc
-      - test_ubuntu_20_04-3_0_0-malloctrim
-      - test_ubuntu_20_04-2_7_2-normal
-      - test_ubuntu_20_04-2_7_2-jemalloc
-      - test_ubuntu_20_04-2_7_2-malloctrim
-      - test_ubuntu_20_04-2_6_6-normal
-      - test_ubuntu_20_04-2_6_6-jemalloc
-      - test_ubuntu_20_04-2_6_6-malloctrim
+      - test_ubuntu_20_04-3_0_1-normal
+      - test_ubuntu_20_04-3_0_1-jemalloc
+      - test_ubuntu_20_04-3_0_1-malloctrim
+      - test_ubuntu_20_04-2_7_3-normal
+      - test_ubuntu_20_04-2_7_3-jemalloc
+      - test_ubuntu_20_04-2_7_3-malloctrim
+      - test_ubuntu_20_04-2_6_7-normal
+      - test_ubuntu_20_04-2_6_7-jemalloc
+      - test_ubuntu_20_04-2_6_7-malloctrim
     if: 'always()'
     steps:
       - uses: actions/checkout@v2
@@ -4129,69 +4129,69 @@ jobs:
           && needs.test_centos_7-2_6-malloctrim.result != 'success'
           && (needs.test_centos_7-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-7/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-7/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_0-normal.result != 'success'
-          && (needs.test_centos_7-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/normal];'))
-      - name: Check whether 'Test [centos-7/3.0.0/jemalloc]' did not fail
+          && needs.test_centos_7-3_0_1-normal.result != 'success'
+          && (needs.test_centos_7-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_7-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-7/3.0.0/malloctrim]' did not fail
+          && needs.test_centos_7-3_0_1-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_7-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.7.2/normal]' did not fail
+          && needs.test_centos_7-3_0_1-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_2-normal.result != 'success'
-          && (needs.test_centos_7-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/normal];'))
-      - name: Check whether 'Test [centos-7/2.7.2/jemalloc]' did not fail
+          && needs.test_centos_7-2_7_3-normal.result != 'success'
+          && (needs.test_centos_7-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/normal];'))
+      - name: Check whether 'Test [centos-7/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_2-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.7.2/malloctrim]' did not fail
+          && needs.test_centos_7-2_7_3-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_2-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.6.6/normal]' did not fail
+          && needs.test_centos_7-2_7_3-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_6-normal.result != 'success'
-          && (needs.test_centos_7-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/normal];'))
-      - name: Check whether 'Test [centos-7/2.6.6/jemalloc]' did not fail
+          && needs.test_centos_7-2_6_7-normal.result != 'success'
+          && (needs.test_centos_7-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/normal];'))
+      - name: Check whether 'Test [centos-7/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_6-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.6.6/malloctrim]' did not fail
+          && needs.test_centos_7-2_6_7-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_6-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.6/malloctrim];'))
+          && needs.test_centos_7-2_6_7-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.7/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4255,69 +4255,69 @@ jobs:
           && needs.test_centos_8-2_6-malloctrim.result != 'success'
           && (needs.test_centos_8-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-8/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-8/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_0-normal.result != 'success'
-          && (needs.test_centos_8-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/normal];'))
-      - name: Check whether 'Test [centos-8/3.0.0/jemalloc]' did not fail
+          && needs.test_centos_8-3_0_1-normal.result != 'success'
+          && (needs.test_centos_8-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_8-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.0.0/malloctrim]' did not fail
+          && needs.test_centos_8-3_0_1-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.7.2/normal]' did not fail
+          && needs.test_centos_8-3_0_1-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_2-normal.result != 'success'
-          && (needs.test_centos_8-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/normal];'))
-      - name: Check whether 'Test [centos-8/2.7.2/jemalloc]' did not fail
+          && needs.test_centos_8-2_7_3-normal.result != 'success'
+          && (needs.test_centos_8-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/normal];'))
+      - name: Check whether 'Test [centos-8/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_2-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.7.2/malloctrim]' did not fail
+          && needs.test_centos_8-2_7_3-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_2-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.6.6/normal]' did not fail
+          && needs.test_centos_8-2_7_3-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_6-normal.result != 'success'
-          && (needs.test_centos_8-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/normal];'))
-      - name: Check whether 'Test [centos-8/2.6.6/jemalloc]' did not fail
+          && needs.test_centos_8-2_6_7-normal.result != 'success'
+          && (needs.test_centos_8-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/normal];'))
+      - name: Check whether 'Test [centos-8/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_6-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.6.6/malloctrim]' did not fail
+          && needs.test_centos_8-2_6_7-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_6-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.6/malloctrim];'))
+          && needs.test_centos_8-2_6_7-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.7/malloctrim];'))
       - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4381,69 +4381,69 @@ jobs:
           && needs.test_debian_10-2_6-malloctrim.result != 'success'
           && (needs.test_debian_10-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-10/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-10/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_0-normal.result != 'success'
-          && (needs.test_debian_10-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/normal];'))
-      - name: Check whether 'Test [debian-10/3.0.0/jemalloc]' did not fail
+          && needs.test_debian_10-3_0_1-normal.result != 'success'
+          && (needs.test_debian_10-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_10-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-10/3.0.0/malloctrim]' did not fail
+          && needs.test_debian_10-3_0_1-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_10-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.7.2/normal]' did not fail
+          && needs.test_debian_10-3_0_1-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_2-normal.result != 'success'
-          && (needs.test_debian_10-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/normal];'))
-      - name: Check whether 'Test [debian-10/2.7.2/jemalloc]' did not fail
+          && needs.test_debian_10-2_7_3-normal.result != 'success'
+          && (needs.test_debian_10-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/normal];'))
+      - name: Check whether 'Test [debian-10/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_2-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.7.2/malloctrim]' did not fail
+          && needs.test_debian_10-2_7_3-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_2-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.6.6/normal]' did not fail
+          && needs.test_debian_10-2_7_3-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_6-normal.result != 'success'
-          && (needs.test_debian_10-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/normal];'))
-      - name: Check whether 'Test [debian-10/2.6.6/jemalloc]' did not fail
+          && needs.test_debian_10-2_6_7-normal.result != 'success'
+          && (needs.test_debian_10-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/normal];'))
+      - name: Check whether 'Test [debian-10/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_6-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.6.6/malloctrim]' did not fail
+          && needs.test_debian_10-2_6_7-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_6-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.6/malloctrim];'))
+          && needs.test_debian_10-2_6_7-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.7/malloctrim];'))
       - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4507,69 +4507,69 @@ jobs:
           && needs.test_debian_9-2_6-malloctrim.result != 'success'
           && (needs.test_debian_9-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-9/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-9/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_0-normal.result != 'success'
-          && (needs.test_debian_9-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/normal];'))
-      - name: Check whether 'Test [debian-9/3.0.0/jemalloc]' did not fail
+          && needs.test_debian_9-3_0_1-normal.result != 'success'
+          && (needs.test_debian_9-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_9-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-9/3.0.0/malloctrim]' did not fail
+          && needs.test_debian_9-3_0_1-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_9-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.7.2/normal]' did not fail
+          && needs.test_debian_9-3_0_1-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_2-normal.result != 'success'
-          && (needs.test_debian_9-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/normal];'))
-      - name: Check whether 'Test [debian-9/2.7.2/jemalloc]' did not fail
+          && needs.test_debian_9-2_7_3-normal.result != 'success'
+          && (needs.test_debian_9-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/normal];'))
+      - name: Check whether 'Test [debian-9/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_2-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.7.2/malloctrim]' did not fail
+          && needs.test_debian_9-2_7_3-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_2-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.6.6/normal]' did not fail
+          && needs.test_debian_9-2_7_3-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_6-normal.result != 'success'
-          && (needs.test_debian_9-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/normal];'))
-      - name: Check whether 'Test [debian-9/2.6.6/jemalloc]' did not fail
+          && needs.test_debian_9-2_6_7-normal.result != 'success'
+          && (needs.test_debian_9-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/normal];'))
+      - name: Check whether 'Test [debian-9/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_6-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.6.6/malloctrim]' did not fail
+          && needs.test_debian_9-2_6_7-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_6-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.6/malloctrim];'))
+          && needs.test_debian_9-2_6_7-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.7/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4633,69 +4633,69 @@ jobs:
           && needs.test_ubuntu_18_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-3_0_1-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-3_0_1-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/normal]' did not fail
+          && needs.test_ubuntu_18_04-3_0_1-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_2-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-2_7_3-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-2_7_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/normal]' did not fail
+          && needs.test_ubuntu_18_04-2_7_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_6-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-2_6_7-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_6-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-2_6_7-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_6-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.6/malloctrim];'))
+          && needs.test_ubuntu_18_04-2_6_7-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.7/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4759,69 +4759,69 @@ jobs:
           && needs.test_ubuntu_20_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-3_0_1-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-3_0_1-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/normal]' did not fail
+          && needs.test_ubuntu_20_04-3_0_1-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_2-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-2_7_3-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-2_7_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/normal]' did not fail
+          && needs.test_ubuntu_20_04-2_7_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_6-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-2_6_7-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_6-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-2_6_7-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_6-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.6/malloctrim];'))
+          && needs.test_ubuntu_20_04-2_6_7-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.7/malloctrim];'))
 
 
       ### Create Git tag ###

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -92,7 +92,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.0_centos-7_normal ruby-pkg_3.0.0_centos-7_jemalloc ruby-pkg_3.0.0_centos-7_malloctrim ruby-pkg_3.0.0_centos-8_normal ruby-pkg_3.0.0_centos-8_jemalloc ruby-pkg_3.0.0_centos-8_malloctrim ruby-pkg_3.0.0_debian-10_normal ruby-pkg_3.0.0_debian-10_jemalloc ruby-pkg_3.0.0_debian-10_malloctrim ruby-pkg_3.0.0_debian-9_normal ruby-pkg_3.0.0_debian-9_jemalloc ruby-pkg_3.0.0_debian-9_malloctrim ruby-pkg_3.0.0_ubuntu-18.04_normal ruby-pkg_3.0.0_ubuntu-18.04_jemalloc ruby-pkg_3.0.0_ubuntu-18.04_malloctrim ruby-pkg_3.0.0_ubuntu-20.04_normal ruby-pkg_3.0.0_ubuntu-20.04_jemalloc ruby-pkg_3.0.0_ubuntu-20.04_malloctrim ruby-pkg_2.7.2_centos-7_normal ruby-pkg_2.7.2_centos-7_jemalloc ruby-pkg_2.7.2_centos-7_malloctrim ruby-pkg_2.7.2_centos-8_normal ruby-pkg_2.7.2_centos-8_jemalloc ruby-pkg_2.7.2_centos-8_malloctrim ruby-pkg_2.7.2_debian-10_normal ruby-pkg_2.7.2_debian-10_jemalloc ruby-pkg_2.7.2_debian-10_malloctrim ruby-pkg_2.7.2_debian-9_normal ruby-pkg_2.7.2_debian-9_jemalloc ruby-pkg_2.7.2_debian-9_malloctrim ruby-pkg_2.7.2_ubuntu-18.04_normal ruby-pkg_2.7.2_ubuntu-18.04_jemalloc ruby-pkg_2.7.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.2_ubuntu-20.04_normal ruby-pkg_2.7.2_ubuntu-20.04_jemalloc ruby-pkg_2.7.2_ubuntu-20.04_malloctrim ruby-pkg_2.6.6_centos-7_normal ruby-pkg_2.6.6_centos-7_jemalloc ruby-pkg_2.6.6_centos-7_malloctrim ruby-pkg_2.6.6_centos-8_normal ruby-pkg_2.6.6_centos-8_jemalloc ruby-pkg_2.6.6_centos-8_malloctrim ruby-pkg_2.6.6_debian-10_normal ruby-pkg_2.6.6_debian-10_jemalloc ruby-pkg_2.6.6_debian-10_malloctrim ruby-pkg_2.6.6_debian-9_normal ruby-pkg_2.6.6_debian-9_jemalloc ruby-pkg_2.6.6_debian-9_malloctrim ruby-pkg_2.6.6_ubuntu-18.04_normal ruby-pkg_2.6.6_ubuntu-18.04_jemalloc ruby-pkg_2.6.6_ubuntu-18.04_malloctrim ruby-pkg_2.6.6_ubuntu-20.04_normal ruby-pkg_2.6.6_ubuntu-20.04_jemalloc ruby-pkg_2.6.6_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.1_centos-7_normal ruby-pkg_3.0.1_centos-7_jemalloc ruby-pkg_3.0.1_centos-7_malloctrim ruby-pkg_3.0.1_centos-8_normal ruby-pkg_3.0.1_centos-8_jemalloc ruby-pkg_3.0.1_centos-8_malloctrim ruby-pkg_3.0.1_debian-10_normal ruby-pkg_3.0.1_debian-10_jemalloc ruby-pkg_3.0.1_debian-10_malloctrim ruby-pkg_3.0.1_debian-9_normal ruby-pkg_3.0.1_debian-9_jemalloc ruby-pkg_3.0.1_debian-9_malloctrim ruby-pkg_3.0.1_ubuntu-18.04_normal ruby-pkg_3.0.1_ubuntu-18.04_jemalloc ruby-pkg_3.0.1_ubuntu-18.04_malloctrim ruby-pkg_3.0.1_ubuntu-20.04_normal ruby-pkg_3.0.1_ubuntu-20.04_jemalloc ruby-pkg_3.0.1_ubuntu-20.04_malloctrim ruby-pkg_2.7.3_centos-7_normal ruby-pkg_2.7.3_centos-7_jemalloc ruby-pkg_2.7.3_centos-7_malloctrim ruby-pkg_2.7.3_centos-8_normal ruby-pkg_2.7.3_centos-8_jemalloc ruby-pkg_2.7.3_centos-8_malloctrim ruby-pkg_2.7.3_debian-10_normal ruby-pkg_2.7.3_debian-10_jemalloc ruby-pkg_2.7.3_debian-10_malloctrim ruby-pkg_2.7.3_debian-9_normal ruby-pkg_2.7.3_debian-9_jemalloc ruby-pkg_2.7.3_debian-9_malloctrim ruby-pkg_2.7.3_ubuntu-18.04_normal ruby-pkg_2.7.3_ubuntu-18.04_jemalloc ruby-pkg_2.7.3_ubuntu-18.04_malloctrim ruby-pkg_2.7.3_ubuntu-20.04_normal ruby-pkg_2.7.3_ubuntu-20.04_jemalloc ruby-pkg_2.7.3_ubuntu-20.04_malloctrim ruby-pkg_2.6.7_centos-7_normal ruby-pkg_2.6.7_centos-7_jemalloc ruby-pkg_2.6.7_centos-7_malloctrim ruby-pkg_2.6.7_centos-8_normal ruby-pkg_2.6.7_centos-8_jemalloc ruby-pkg_2.6.7_centos-8_malloctrim ruby-pkg_2.6.7_debian-10_normal ruby-pkg_2.6.7_debian-10_jemalloc ruby-pkg_2.6.7_debian-10_malloctrim ruby-pkg_2.6.7_debian-9_normal ruby-pkg_2.6.7_debian-9_jemalloc ruby-pkg_2.6.7_debian-9_malloctrim ruby-pkg_2.6.7_ubuntu-18.04_normal ruby-pkg_2.6.7_ubuntu-18.04_jemalloc ruby-pkg_2.6.7_ubuntu-18.04_malloctrim ruby-pkg_2.6.7_ubuntu-20.04_normal ruby-pkg_2.6.7_ubuntu-20.04_jemalloc ruby-pkg_2.6.7_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -468,13 +468,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-centos-7_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-3_0_0-normal:
-    name: 'Test [centos-7/3.0.0/normal]'
+  test_centos_7-3_0_1-normal:
+    name: 'Test [centos-7/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -486,7 +486,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -499,16 +499,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-3_0_0-jemalloc:
-    name: 'Test [centos-7/3.0.0/jemalloc]'
+  test_centos_7-3_0_1-jemalloc:
+    name: 'Test [centos-7/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -520,7 +520,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -533,16 +533,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-3_0_0-malloctrim:
-    name: 'Test [centos-7/3.0.0/malloctrim]'
+  test_centos_7-3_0_1-malloctrim:
+    name: 'Test [centos-7/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -554,7 +554,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -567,16 +567,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-2_7_2-normal:
-    name: 'Test [centos-7/2.7.2/normal]'
+  test_centos_7-2_7_3-normal:
+    name: 'Test [centos-7/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -588,7 +588,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -601,16 +601,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-2_7_2-jemalloc:
-    name: 'Test [centos-7/2.7.2/jemalloc]'
+  test_centos_7-2_7_3-jemalloc:
+    name: 'Test [centos-7/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -622,7 +622,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -635,16 +635,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-2_7_2-malloctrim:
-    name: 'Test [centos-7/2.7.2/malloctrim]'
+  test_centos_7-2_7_3-malloctrim:
+    name: 'Test [centos-7/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -656,7 +656,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -669,16 +669,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-2_6_6-normal:
-    name: 'Test [centos-7/2.6.6/normal]'
+  test_centos_7-2_6_7-normal:
+    name: 'Test [centos-7/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -690,7 +690,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -703,16 +703,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-2_6_6-jemalloc:
-    name: 'Test [centos-7/2.6.6/jemalloc]'
+  test_centos_7-2_6_7-jemalloc:
+    name: 'Test [centos-7/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -724,7 +724,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -737,16 +737,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-2_6_6-malloctrim:
-    name: 'Test [centos-7/2.6.6/malloctrim]'
+  test_centos_7-2_6_7-malloctrim:
+    name: 'Test [centos-7/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -758,7 +758,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -771,7 +771,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -1081,13 +1081,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-centos-8_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-3_0_0-normal:
-    name: 'Test [centos-8/3.0.0/normal]'
+  test_centos_8-3_0_1-normal:
+    name: 'Test [centos-8/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1099,7 +1099,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1112,16 +1112,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-3_0_0-jemalloc:
-    name: 'Test [centos-8/3.0.0/jemalloc]'
+  test_centos_8-3_0_1-jemalloc:
+    name: 'Test [centos-8/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1133,7 +1133,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1146,16 +1146,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-3_0_0-malloctrim:
-    name: 'Test [centos-8/3.0.0/malloctrim]'
+  test_centos_8-3_0_1-malloctrim:
+    name: 'Test [centos-8/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1167,7 +1167,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1180,16 +1180,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-2_7_2-normal:
-    name: 'Test [centos-8/2.7.2/normal]'
+  test_centos_8-2_7_3-normal:
+    name: 'Test [centos-8/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1201,7 +1201,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1214,16 +1214,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-2_7_2-jemalloc:
-    name: 'Test [centos-8/2.7.2/jemalloc]'
+  test_centos_8-2_7_3-jemalloc:
+    name: 'Test [centos-8/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1235,7 +1235,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1248,16 +1248,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-2_7_2-malloctrim:
-    name: 'Test [centos-8/2.7.2/malloctrim]'
+  test_centos_8-2_7_3-malloctrim:
+    name: 'Test [centos-8/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1269,7 +1269,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1282,16 +1282,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-2_6_6-normal:
-    name: 'Test [centos-8/2.6.6/normal]'
+  test_centos_8-2_6_7-normal:
+    name: 'Test [centos-8/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1303,7 +1303,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1316,16 +1316,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-2_6_6-jemalloc:
-    name: 'Test [centos-8/2.6.6/jemalloc]'
+  test_centos_8-2_6_7-jemalloc:
+    name: 'Test [centos-8/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1337,7 +1337,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1350,16 +1350,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-2_6_6-malloctrim:
-    name: 'Test [centos-8/2.6.6/malloctrim]'
+  test_centos_8-2_6_7-malloctrim:
+    name: 'Test [centos-8/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1371,7 +1371,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1384,7 +1384,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -1694,13 +1694,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-debian-10_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-3_0_0-normal:
-    name: 'Test [debian-10/3.0.0/normal]'
+  test_debian_10-3_0_1-normal:
+    name: 'Test [debian-10/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1712,7 +1712,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1725,16 +1725,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-3_0_0-jemalloc:
-    name: 'Test [debian-10/3.0.0/jemalloc]'
+  test_debian_10-3_0_1-jemalloc:
+    name: 'Test [debian-10/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1746,7 +1746,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1759,16 +1759,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-3_0_0-malloctrim:
-    name: 'Test [debian-10/3.0.0/malloctrim]'
+  test_debian_10-3_0_1-malloctrim:
+    name: 'Test [debian-10/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1780,7 +1780,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1793,16 +1793,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-2_7_2-normal:
-    name: 'Test [debian-10/2.7.2/normal]'
+  test_debian_10-2_7_3-normal:
+    name: 'Test [debian-10/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1814,7 +1814,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1827,16 +1827,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-2_7_2-jemalloc:
-    name: 'Test [debian-10/2.7.2/jemalloc]'
+  test_debian_10-2_7_3-jemalloc:
+    name: 'Test [debian-10/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1848,7 +1848,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1861,16 +1861,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-2_7_2-malloctrim:
-    name: 'Test [debian-10/2.7.2/malloctrim]'
+  test_debian_10-2_7_3-malloctrim:
+    name: 'Test [debian-10/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1882,7 +1882,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1895,16 +1895,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-2_6_6-normal:
-    name: 'Test [debian-10/2.6.6/normal]'
+  test_debian_10-2_6_7-normal:
+    name: 'Test [debian-10/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1916,7 +1916,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1929,16 +1929,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-2_6_6-jemalloc:
-    name: 'Test [debian-10/2.6.6/jemalloc]'
+  test_debian_10-2_6_7-jemalloc:
+    name: 'Test [debian-10/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1950,7 +1950,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1963,16 +1963,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-2_6_6-malloctrim:
-    name: 'Test [debian-10/2.6.6/malloctrim]'
+  test_debian_10-2_6_7-malloctrim:
+    name: 'Test [debian-10/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1984,7 +1984,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1997,7 +1997,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -2307,13 +2307,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-debian-9_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-3_0_0-normal:
-    name: 'Test [debian-9/3.0.0/normal]'
+  test_debian_9-3_0_1-normal:
+    name: 'Test [debian-9/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2325,7 +2325,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2338,16 +2338,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-3_0_0-jemalloc:
-    name: 'Test [debian-9/3.0.0/jemalloc]'
+  test_debian_9-3_0_1-jemalloc:
+    name: 'Test [debian-9/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2359,7 +2359,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2372,16 +2372,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-3_0_0-malloctrim:
-    name: 'Test [debian-9/3.0.0/malloctrim]'
+  test_debian_9-3_0_1-malloctrim:
+    name: 'Test [debian-9/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2393,7 +2393,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2406,16 +2406,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-2_7_2-normal:
-    name: 'Test [debian-9/2.7.2/normal]'
+  test_debian_9-2_7_3-normal:
+    name: 'Test [debian-9/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2427,7 +2427,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2440,16 +2440,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-2_7_2-jemalloc:
-    name: 'Test [debian-9/2.7.2/jemalloc]'
+  test_debian_9-2_7_3-jemalloc:
+    name: 'Test [debian-9/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2461,7 +2461,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2474,16 +2474,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-2_7_2-malloctrim:
-    name: 'Test [debian-9/2.7.2/malloctrim]'
+  test_debian_9-2_7_3-malloctrim:
+    name: 'Test [debian-9/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2495,7 +2495,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2508,16 +2508,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-2_6_6-normal:
-    name: 'Test [debian-9/2.6.6/normal]'
+  test_debian_9-2_6_7-normal:
+    name: 'Test [debian-9/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2529,7 +2529,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2542,16 +2542,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-2_6_6-jemalloc:
-    name: 'Test [debian-9/2.6.6/jemalloc]'
+  test_debian_9-2_6_7-jemalloc:
+    name: 'Test [debian-9/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2563,7 +2563,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2576,16 +2576,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-2_6_6-malloctrim:
-    name: 'Test [debian-9/2.6.6/malloctrim]'
+  test_debian_9-2_6_7-malloctrim:
+    name: 'Test [debian-9/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2597,7 +2597,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2610,7 +2610,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -2920,13 +2920,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-3_0_0-normal:
-    name: 'Test [ubuntu-18.04/3.0.0/normal]'
+  test_ubuntu_18_04-3_0_1-normal:
+    name: 'Test [ubuntu-18.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2938,7 +2938,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2951,16 +2951,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-3_0_0-jemalloc:
-    name: 'Test [ubuntu-18.04/3.0.0/jemalloc]'
+  test_ubuntu_18_04-3_0_1-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2972,7 +2972,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2985,16 +2985,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-3_0_0-malloctrim:
-    name: 'Test [ubuntu-18.04/3.0.0/malloctrim]'
+  test_ubuntu_18_04-3_0_1-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3006,7 +3006,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3019,16 +3019,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-2_7_2-normal:
-    name: 'Test [ubuntu-18.04/2.7.2/normal]'
+  test_ubuntu_18_04-2_7_3-normal:
+    name: 'Test [ubuntu-18.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3040,7 +3040,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3053,16 +3053,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-2_7_2-jemalloc:
-    name: 'Test [ubuntu-18.04/2.7.2/jemalloc]'
+  test_ubuntu_18_04-2_7_3-jemalloc:
+    name: 'Test [ubuntu-18.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3074,7 +3074,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3087,16 +3087,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-2_7_2-malloctrim:
-    name: 'Test [ubuntu-18.04/2.7.2/malloctrim]'
+  test_ubuntu_18_04-2_7_3-malloctrim:
+    name: 'Test [ubuntu-18.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3108,7 +3108,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3121,16 +3121,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-2_6_6-normal:
-    name: 'Test [ubuntu-18.04/2.6.6/normal]'
+  test_ubuntu_18_04-2_6_7-normal:
+    name: 'Test [ubuntu-18.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3142,7 +3142,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3155,16 +3155,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-2_6_6-jemalloc:
-    name: 'Test [ubuntu-18.04/2.6.6/jemalloc]'
+  test_ubuntu_18_04-2_6_7-jemalloc:
+    name: 'Test [ubuntu-18.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3176,7 +3176,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3189,16 +3189,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-2_6_6-malloctrim:
-    name: 'Test [ubuntu-18.04/2.6.6/malloctrim]'
+  test_ubuntu_18_04-2_6_7-malloctrim:
+    name: 'Test [ubuntu-18.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3210,7 +3210,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3223,7 +3223,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -3533,13 +3533,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-3_0_0-normal:
-    name: 'Test [ubuntu-20.04/3.0.0/normal]'
+  test_ubuntu_20_04-3_0_1-normal:
+    name: 'Test [ubuntu-20.04/3.0.1/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3551,7 +3551,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3564,16 +3564,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.1_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-3_0_0-jemalloc:
-    name: 'Test [ubuntu-20.04/3.0.0/jemalloc]'
+  test_ubuntu_20_04-3_0_1-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.1/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3585,7 +3585,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3598,16 +3598,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.1_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-3_0_0-malloctrim:
-    name: 'Test [ubuntu-20.04/3.0.0/malloctrim]'
+  test_ubuntu_20_04-3_0_1-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.1/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3619,7 +3619,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.0"
+          RUBY_PACKAGE_ID: "3.0.1"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3632,16 +3632,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.0_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.1_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-2_7_2-normal:
-    name: 'Test [ubuntu-20.04/2.7.2/normal]'
+  test_ubuntu_20_04-2_7_3-normal:
+    name: 'Test [ubuntu-20.04/2.7.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3653,7 +3653,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3666,16 +3666,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.2_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-2_7_2-jemalloc:
-    name: 'Test [ubuntu-20.04/2.7.2/jemalloc]'
+  test_ubuntu_20_04-2_7_3-jemalloc:
+    name: 'Test [ubuntu-20.04/2.7.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3687,7 +3687,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3700,16 +3700,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-2_7_2-malloctrim:
-    name: 'Test [ubuntu-20.04/2.7.2/malloctrim]'
+  test_ubuntu_20_04-2_7_3-malloctrim:
+    name: 'Test [ubuntu-20.04/2.7.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3721,7 +3721,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.2"
+          RUBY_PACKAGE_ID: "2.7.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3734,16 +3734,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-2_6_6-normal:
-    name: 'Test [ubuntu-20.04/2.6.6/normal]'
+  test_ubuntu_20_04-2_6_7-normal:
+    name: 'Test [ubuntu-20.04/2.6.7/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3755,7 +3755,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3768,16 +3768,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.6_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.7_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-2_6_6-jemalloc:
-    name: 'Test [ubuntu-20.04/2.6.6/jemalloc]'
+  test_ubuntu_20_04-2_6_7-jemalloc:
+    name: 'Test [ubuntu-20.04/2.6.7/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3789,7 +3789,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3802,16 +3802,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.6_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.7_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-2_6_6-malloctrim:
-    name: 'Test [ubuntu-20.04/2.6.6/malloctrim]'
+  test_ubuntu_20_04-2_6_7-malloctrim:
+    name: 'Test [ubuntu-20.04/2.6.7/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3823,7 +3823,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.6"
+          RUBY_PACKAGE_ID: "2.6.7"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3836,7 +3836,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.6_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.7_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -3857,15 +3857,15 @@ jobs:
       - test_centos_7-2_6-normal
       - test_centos_7-2_6-jemalloc
       - test_centos_7-2_6-malloctrim
-      - test_centos_7-3_0_0-normal
-      - test_centos_7-3_0_0-jemalloc
-      - test_centos_7-3_0_0-malloctrim
-      - test_centos_7-2_7_2-normal
-      - test_centos_7-2_7_2-jemalloc
-      - test_centos_7-2_7_2-malloctrim
-      - test_centos_7-2_6_6-normal
-      - test_centos_7-2_6_6-jemalloc
-      - test_centos_7-2_6_6-malloctrim
+      - test_centos_7-3_0_1-normal
+      - test_centos_7-3_0_1-jemalloc
+      - test_centos_7-3_0_1-malloctrim
+      - test_centos_7-2_7_3-normal
+      - test_centos_7-2_7_3-jemalloc
+      - test_centos_7-2_7_3-malloctrim
+      - test_centos_7-2_6_7-normal
+      - test_centos_7-2_6_7-jemalloc
+      - test_centos_7-2_6_7-malloctrim
       - test_centos_8-3_0-normal
       - test_centos_8-3_0-jemalloc
       - test_centos_8-3_0-malloctrim
@@ -3875,15 +3875,15 @@ jobs:
       - test_centos_8-2_6-normal
       - test_centos_8-2_6-jemalloc
       - test_centos_8-2_6-malloctrim
-      - test_centos_8-3_0_0-normal
-      - test_centos_8-3_0_0-jemalloc
-      - test_centos_8-3_0_0-malloctrim
-      - test_centos_8-2_7_2-normal
-      - test_centos_8-2_7_2-jemalloc
-      - test_centos_8-2_7_2-malloctrim
-      - test_centos_8-2_6_6-normal
-      - test_centos_8-2_6_6-jemalloc
-      - test_centos_8-2_6_6-malloctrim
+      - test_centos_8-3_0_1-normal
+      - test_centos_8-3_0_1-jemalloc
+      - test_centos_8-3_0_1-malloctrim
+      - test_centos_8-2_7_3-normal
+      - test_centos_8-2_7_3-jemalloc
+      - test_centos_8-2_7_3-malloctrim
+      - test_centos_8-2_6_7-normal
+      - test_centos_8-2_6_7-jemalloc
+      - test_centos_8-2_6_7-malloctrim
       - test_debian_10-3_0-normal
       - test_debian_10-3_0-jemalloc
       - test_debian_10-3_0-malloctrim
@@ -3893,15 +3893,15 @@ jobs:
       - test_debian_10-2_6-normal
       - test_debian_10-2_6-jemalloc
       - test_debian_10-2_6-malloctrim
-      - test_debian_10-3_0_0-normal
-      - test_debian_10-3_0_0-jemalloc
-      - test_debian_10-3_0_0-malloctrim
-      - test_debian_10-2_7_2-normal
-      - test_debian_10-2_7_2-jemalloc
-      - test_debian_10-2_7_2-malloctrim
-      - test_debian_10-2_6_6-normal
-      - test_debian_10-2_6_6-jemalloc
-      - test_debian_10-2_6_6-malloctrim
+      - test_debian_10-3_0_1-normal
+      - test_debian_10-3_0_1-jemalloc
+      - test_debian_10-3_0_1-malloctrim
+      - test_debian_10-2_7_3-normal
+      - test_debian_10-2_7_3-jemalloc
+      - test_debian_10-2_7_3-malloctrim
+      - test_debian_10-2_6_7-normal
+      - test_debian_10-2_6_7-jemalloc
+      - test_debian_10-2_6_7-malloctrim
       - test_debian_9-3_0-normal
       - test_debian_9-3_0-jemalloc
       - test_debian_9-3_0-malloctrim
@@ -3911,15 +3911,15 @@ jobs:
       - test_debian_9-2_6-normal
       - test_debian_9-2_6-jemalloc
       - test_debian_9-2_6-malloctrim
-      - test_debian_9-3_0_0-normal
-      - test_debian_9-3_0_0-jemalloc
-      - test_debian_9-3_0_0-malloctrim
-      - test_debian_9-2_7_2-normal
-      - test_debian_9-2_7_2-jemalloc
-      - test_debian_9-2_7_2-malloctrim
-      - test_debian_9-2_6_6-normal
-      - test_debian_9-2_6_6-jemalloc
-      - test_debian_9-2_6_6-malloctrim
+      - test_debian_9-3_0_1-normal
+      - test_debian_9-3_0_1-jemalloc
+      - test_debian_9-3_0_1-malloctrim
+      - test_debian_9-2_7_3-normal
+      - test_debian_9-2_7_3-jemalloc
+      - test_debian_9-2_7_3-malloctrim
+      - test_debian_9-2_6_7-normal
+      - test_debian_9-2_6_7-jemalloc
+      - test_debian_9-2_6_7-malloctrim
       - test_ubuntu_18_04-3_0-normal
       - test_ubuntu_18_04-3_0-jemalloc
       - test_ubuntu_18_04-3_0-malloctrim
@@ -3929,15 +3929,15 @@ jobs:
       - test_ubuntu_18_04-2_6-normal
       - test_ubuntu_18_04-2_6-jemalloc
       - test_ubuntu_18_04-2_6-malloctrim
-      - test_ubuntu_18_04-3_0_0-normal
-      - test_ubuntu_18_04-3_0_0-jemalloc
-      - test_ubuntu_18_04-3_0_0-malloctrim
-      - test_ubuntu_18_04-2_7_2-normal
-      - test_ubuntu_18_04-2_7_2-jemalloc
-      - test_ubuntu_18_04-2_7_2-malloctrim
-      - test_ubuntu_18_04-2_6_6-normal
-      - test_ubuntu_18_04-2_6_6-jemalloc
-      - test_ubuntu_18_04-2_6_6-malloctrim
+      - test_ubuntu_18_04-3_0_1-normal
+      - test_ubuntu_18_04-3_0_1-jemalloc
+      - test_ubuntu_18_04-3_0_1-malloctrim
+      - test_ubuntu_18_04-2_7_3-normal
+      - test_ubuntu_18_04-2_7_3-jemalloc
+      - test_ubuntu_18_04-2_7_3-malloctrim
+      - test_ubuntu_18_04-2_6_7-normal
+      - test_ubuntu_18_04-2_6_7-jemalloc
+      - test_ubuntu_18_04-2_6_7-malloctrim
       - test_ubuntu_20_04-3_0-normal
       - test_ubuntu_20_04-3_0-jemalloc
       - test_ubuntu_20_04-3_0-malloctrim
@@ -3947,15 +3947,15 @@ jobs:
       - test_ubuntu_20_04-2_6-normal
       - test_ubuntu_20_04-2_6-jemalloc
       - test_ubuntu_20_04-2_6-malloctrim
-      - test_ubuntu_20_04-3_0_0-normal
-      - test_ubuntu_20_04-3_0_0-jemalloc
-      - test_ubuntu_20_04-3_0_0-malloctrim
-      - test_ubuntu_20_04-2_7_2-normal
-      - test_ubuntu_20_04-2_7_2-jemalloc
-      - test_ubuntu_20_04-2_7_2-malloctrim
-      - test_ubuntu_20_04-2_6_6-normal
-      - test_ubuntu_20_04-2_6_6-jemalloc
-      - test_ubuntu_20_04-2_6_6-malloctrim
+      - test_ubuntu_20_04-3_0_1-normal
+      - test_ubuntu_20_04-3_0_1-jemalloc
+      - test_ubuntu_20_04-3_0_1-malloctrim
+      - test_ubuntu_20_04-2_7_3-normal
+      - test_ubuntu_20_04-2_7_3-jemalloc
+      - test_ubuntu_20_04-2_7_3-malloctrim
+      - test_ubuntu_20_04-2_6_7-normal
+      - test_ubuntu_20_04-2_6_7-jemalloc
+      - test_ubuntu_20_04-2_6_7-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -4023,60 +4023,60 @@ jobs:
           needs.test_centos_7-2_6-malloctrim.result != 'success'
           && (needs.test_centos_7-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-7/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-7/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_0-normal.result != 'success'
-          && (needs.test_centos_7-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/normal];'))
-      - name: Check whether 'Test [centos-7/3.0.0/jemalloc]' did not fail
+          needs.test_centos_7-3_0_1-normal.result != 'success'
+          && (needs.test_centos_7-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_7-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-7/3.0.0/malloctrim]' did not fail
+          needs.test_centos_7-3_0_1-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_7-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.7.2/normal]' did not fail
+          needs.test_centos_7-3_0_1-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_2-normal.result != 'success'
-          && (needs.test_centos_7-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/normal];'))
-      - name: Check whether 'Test [centos-7/2.7.2/jemalloc]' did not fail
+          needs.test_centos_7-2_7_3-normal.result != 'success'
+          && (needs.test_centos_7-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/normal];'))
+      - name: Check whether 'Test [centos-7/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_2-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.7.2/malloctrim]' did not fail
+          needs.test_centos_7-2_7_3-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_2-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.6.6/normal]' did not fail
+          needs.test_centos_7-2_7_3-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_6-normal.result != 'success'
-          && (needs.test_centos_7-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/normal];'))
-      - name: Check whether 'Test [centos-7/2.6.6/jemalloc]' did not fail
+          needs.test_centos_7-2_6_7-normal.result != 'success'
+          && (needs.test_centos_7-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/normal];'))
+      - name: Check whether 'Test [centos-7/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_6-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.6.6/malloctrim]' did not fail
+          needs.test_centos_7-2_6_7-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_6-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.6/malloctrim];'))
+          needs.test_centos_7-2_6_7-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.7/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4131,60 +4131,60 @@ jobs:
           needs.test_centos_8-2_6-malloctrim.result != 'success'
           && (needs.test_centos_8-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-8/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-8/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_0-normal.result != 'success'
-          && (needs.test_centos_8-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/normal];'))
-      - name: Check whether 'Test [centos-8/3.0.0/jemalloc]' did not fail
+          needs.test_centos_8-3_0_1-normal.result != 'success'
+          && (needs.test_centos_8-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_8-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.0.0/malloctrim]' did not fail
+          needs.test_centos_8-3_0_1-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.7.2/normal]' did not fail
+          needs.test_centos_8-3_0_1-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_2-normal.result != 'success'
-          && (needs.test_centos_8-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/normal];'))
-      - name: Check whether 'Test [centos-8/2.7.2/jemalloc]' did not fail
+          needs.test_centos_8-2_7_3-normal.result != 'success'
+          && (needs.test_centos_8-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/normal];'))
+      - name: Check whether 'Test [centos-8/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_2-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.7.2/malloctrim]' did not fail
+          needs.test_centos_8-2_7_3-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_2-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.6.6/normal]' did not fail
+          needs.test_centos_8-2_7_3-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_6-normal.result != 'success'
-          && (needs.test_centos_8-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/normal];'))
-      - name: Check whether 'Test [centos-8/2.6.6/jemalloc]' did not fail
+          needs.test_centos_8-2_6_7-normal.result != 'success'
+          && (needs.test_centos_8-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/normal];'))
+      - name: Check whether 'Test [centos-8/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_6-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.6.6/malloctrim]' did not fail
+          needs.test_centos_8-2_6_7-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_6-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.6/malloctrim];'))
+          needs.test_centos_8-2_6_7-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.7/malloctrim];'))
       - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4239,60 +4239,60 @@ jobs:
           needs.test_debian_10-2_6-malloctrim.result != 'success'
           && (needs.test_debian_10-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-10/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-10/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_0-normal.result != 'success'
-          && (needs.test_debian_10-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/normal];'))
-      - name: Check whether 'Test [debian-10/3.0.0/jemalloc]' did not fail
+          needs.test_debian_10-3_0_1-normal.result != 'success'
+          && (needs.test_debian_10-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_10-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-10/3.0.0/malloctrim]' did not fail
+          needs.test_debian_10-3_0_1-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_10-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.7.2/normal]' did not fail
+          needs.test_debian_10-3_0_1-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_2-normal.result != 'success'
-          && (needs.test_debian_10-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/normal];'))
-      - name: Check whether 'Test [debian-10/2.7.2/jemalloc]' did not fail
+          needs.test_debian_10-2_7_3-normal.result != 'success'
+          && (needs.test_debian_10-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/normal];'))
+      - name: Check whether 'Test [debian-10/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_2-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.7.2/malloctrim]' did not fail
+          needs.test_debian_10-2_7_3-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_2-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.6.6/normal]' did not fail
+          needs.test_debian_10-2_7_3-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_6-normal.result != 'success'
-          && (needs.test_debian_10-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/normal];'))
-      - name: Check whether 'Test [debian-10/2.6.6/jemalloc]' did not fail
+          needs.test_debian_10-2_6_7-normal.result != 'success'
+          && (needs.test_debian_10-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/normal];'))
+      - name: Check whether 'Test [debian-10/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_6-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.6.6/malloctrim]' did not fail
+          needs.test_debian_10-2_6_7-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_6-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.6/malloctrim];'))
+          needs.test_debian_10-2_6_7-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.7/malloctrim];'))
       - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4347,60 +4347,60 @@ jobs:
           needs.test_debian_9-2_6-malloctrim.result != 'success'
           && (needs.test_debian_9-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-9/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-9/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_0-normal.result != 'success'
-          && (needs.test_debian_9-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/normal];'))
-      - name: Check whether 'Test [debian-9/3.0.0/jemalloc]' did not fail
+          needs.test_debian_9-3_0_1-normal.result != 'success'
+          && (needs.test_debian_9-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_9-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-9/3.0.0/malloctrim]' did not fail
+          needs.test_debian_9-3_0_1-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_9-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.7.2/normal]' did not fail
+          needs.test_debian_9-3_0_1-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_2-normal.result != 'success'
-          && (needs.test_debian_9-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/normal];'))
-      - name: Check whether 'Test [debian-9/2.7.2/jemalloc]' did not fail
+          needs.test_debian_9-2_7_3-normal.result != 'success'
+          && (needs.test_debian_9-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/normal];'))
+      - name: Check whether 'Test [debian-9/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_2-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.7.2/malloctrim]' did not fail
+          needs.test_debian_9-2_7_3-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_2-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.6.6/normal]' did not fail
+          needs.test_debian_9-2_7_3-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_6-normal.result != 'success'
-          && (needs.test_debian_9-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/normal];'))
-      - name: Check whether 'Test [debian-9/2.6.6/jemalloc]' did not fail
+          needs.test_debian_9-2_6_7-normal.result != 'success'
+          && (needs.test_debian_9-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/normal];'))
+      - name: Check whether 'Test [debian-9/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_6-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.6.6/malloctrim]' did not fail
+          needs.test_debian_9-2_6_7-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_6-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.6/malloctrim];'))
+          needs.test_debian_9-2_6_7-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.7/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4455,60 +4455,60 @@ jobs:
           needs.test_ubuntu_18_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-3_0_1-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.0/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-3_0_1-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/normal]' did not fail
+          needs.test_ubuntu_18_04-3_0_1-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_2-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-2_7_3-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.2/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-2_7_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/normal]' did not fail
+          needs.test_ubuntu_18_04-2_7_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_6-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-2_6_7-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_6-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.6/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-2_6_7-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_6-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.6/malloctrim];'))
+          needs.test_ubuntu_18_04-2_6_7-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.7/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4563,60 +4563,60 @@ jobs:
           needs.test_ubuntu_20_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-3_0_1-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.0/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-3_0_1-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.1/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_0-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.0/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/normal]' did not fail
+          needs.test_ubuntu_20_04-3_0_1-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_1-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.1/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_2-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-2_7_3-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.2/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-2_7_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/normal]' did not fail
+          needs.test_ubuntu_20_04-2_7_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_6-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-2_6_7-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_6-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.6/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-2_6_7-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.7/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_6-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_6-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.6/malloctrim];'))
+          needs.test_ubuntu_20_04-2_6_7-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_7-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.7/malloctrim];'))
 
 
       ### Trigger next workflow ###

--- a/config.yml
+++ b/config.yml
@@ -26,24 +26,24 @@ ruby:
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
     - minor_version: 3.0
-      full_version: 3.0.0
-      package_revision: 1
+      full_version: 3.0.1
+      package_revision: 2
     - minor_version: 2.7
-      full_version: 2.7.2
-      package_revision: 3
+      full_version: 2.7.3
+      package_revision: 4
     - minor_version: 2.6
-      full_version: 2.6.6
-      package_revision: 6
+      full_version: 2.6.7
+      package_revision: 7
 
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
-    - full_version: 3.0.0
-      package_revision: 1
-    - full_version: 2.7.2
+    - full_version: 3.0.1
       package_revision: 2
-    - full_version: 2.6.6
-      package_revision: 2
+    - full_version: 2.7.3
+      package_revision: 3
+    - full_version: 2.6.7
+      package_revision: 3
 
 ## (Required)
 ## Which Rbenv version to package.


### PR DESCRIPTION
New Ruby versions were just released:

- https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/
- https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/

Hence I'm creating this PR following `dev-handbook/add-new-ruby-version.md` steps.

It seems there is a problem with CI https://github.com/san983/fullstaq-ruby-server-edition/runs/2278479743?check_suite_focus=true

P.S. I ❤️ this project!