### PR TITLE
Upgrade Bundler and development gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,4 +34,4 @@ DEPENDENCIES
   rest-client
 
 BUNDLED WITH
-   1.17.3
+   2.2.28

--- a/dev-handbook/dev-environment-setup.md
+++ b/dev-handbook/dev-environment-setup.md
@@ -6,7 +6,7 @@ You can develop Fullstaq Ruby on Linux, macOS, or Windows with WSL2. You just ne
 
  * Bash
  * Docker
- * Ruby (any version >= 2.0)
+ * Ruby (any version >= 2.6)
 
 The small number of dependencies is [intentional](minimal-dependencies-principle.md).
 

--- a/environments/utility/Dockerfile
+++ b/environments/utility/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
 LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
 
@@ -22,7 +22,7 @@ RUN set -x && \
     mkdir /etc/activatecontaineruid && \
     echo 'app_account: utility' > /etc/activatecontaineruid/config.yml && \
     \
-    gem install bundler --no-document -v 1.17.3 && \
+    gem install bundler --no-document -v 2.2.28 && \
     addgroup --gid 9999 utility && \
     adduser --uid 9999 --gid 9999 --disabled-password --gecos Utility utility && \
     usermod -L utility && \

--- a/environments/utility/Gemfile.lock
+++ b/environments/utility/Gemfile.lock
@@ -44,4 +44,4 @@ DEPENDENCIES
   fpm
 
 BUNDLED WITH
-   1.17.3
+   2.2.28

--- a/resources/test-env/Gemfile.lock
+++ b/resources/test-env/Gemfile.lock
@@ -25,4 +25,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.1.4
+   2.2.28


### PR DESCRIPTION
Upgrading Bundler improves compatibility with future Ruby versions. Bundler 1 has problems with Ruby 3.

Upgrading gems fixes security notifications.

[skip ci]