### PR TITLE
Upgrades Ruby to 3.0.3, 2.7.5, and 2.6.9 releases

### DIFF
--- a/.github/workflows/ci-cd-build-packages-1.yml
+++ b/.github/workflows/ci-cd-build-packages-1.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -258,7 +258,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -291,7 +291,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -348,7 +348,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -381,7 +381,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -433,7 +433,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -466,7 +466,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -518,7 +518,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -551,7 +551,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -608,7 +608,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -641,7 +641,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -693,7 +693,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -726,7 +726,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -778,7 +778,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -811,7 +811,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -868,7 +868,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -901,7 +901,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -953,7 +953,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -961,15 +961,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-3_0_2-normal:
-    name: 'Build Ruby [centos-7/3.0.2/normal]'
+  build_ruby_centos_7-3_0_3-normal:
+    name: 'Build Ruby [centos-7/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -986,7 +986,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1021,14 +1021,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-centos-7-normal
+          key: v2-ruby-bin-3.0.3-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1037,24 +1037,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-3_0_2-jemalloc:
-    name: 'Build Ruby [centos-7/3.0.2/jemalloc]'
+  build_ruby_centos_7-3_0_3-jemalloc:
+    name: 'Build Ruby [centos-7/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1071,7 +1071,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1111,14 +1111,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-centos-7-jemalloc
+          key: v2-ruby-bin-3.0.3-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1127,24 +1127,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-3_0_2-malloctrim:
-    name: 'Build Ruby [centos-7/3.0.2/malloctrim]'
+  build_ruby_centos_7-3_0_3-malloctrim:
+    name: 'Build Ruby [centos-7/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1161,7 +1161,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1196,14 +1196,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-centos-7-malloctrim
+          key: v2-ruby-bin-3.0.3-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1212,24 +1212,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-2_7_4-normal:
-    name: 'Build Ruby [centos-7/2.7.4/normal]'
+  build_ruby_centos_7-2_7_5-normal:
+    name: 'Build Ruby [centos-7/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1246,7 +1246,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1281,14 +1281,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-centos-7-normal
+          key: v2-ruby-bin-2.7.5-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1297,24 +1297,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-2_7_4-jemalloc:
-    name: 'Build Ruby [centos-7/2.7.4/jemalloc]'
+  build_ruby_centos_7-2_7_5-jemalloc:
+    name: 'Build Ruby [centos-7/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1331,7 +1331,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1371,14 +1371,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-centos-7-jemalloc
+          key: v2-ruby-bin-2.7.5-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1387,24 +1387,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-2_7_4-malloctrim:
-    name: 'Build Ruby [centos-7/2.7.4/malloctrim]'
+  build_ruby_centos_7-2_7_5-malloctrim:
+    name: 'Build Ruby [centos-7/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1421,7 +1421,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1456,14 +1456,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-centos-7-malloctrim
+          key: v2-ruby-bin-2.7.5-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1472,24 +1472,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_7-2_6_8-normal:
-    name: 'Build Ruby [centos-7/2.6.8/normal]'
+  build_ruby_centos_7-2_6_9-normal:
+    name: 'Build Ruby [centos-7/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1506,7 +1506,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1541,14 +1541,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-centos-7-normal
+          key: v2-ruby-bin-2.6.9-centos-7-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1557,24 +1557,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-7_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-7_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_7-2_6_8-jemalloc:
-    name: 'Build Ruby [centos-7/2.6.8/jemalloc]'
+  build_ruby_centos_7-2_6_9-jemalloc:
+    name: 'Build Ruby [centos-7/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1591,7 +1591,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1631,14 +1631,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-centos-7-jemalloc
+          key: v2-ruby-bin-2.6.9-centos-7-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1647,24 +1647,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-7_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-7_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_7-2_6_8-malloctrim:
-    name: 'Build Ruby [centos-7/2.6.8/malloctrim]'
+  build_ruby_centos_7-2_6_9-malloctrim:
+    name: 'Build Ruby [centos-7/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_7
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-7]' did not fail
@@ -1681,7 +1681,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1716,14 +1716,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-centos-7-malloctrim
+          key: v2-ruby-bin-2.6.9-centos-7-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1732,13 +1732,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-7_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-7_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -1767,7 +1767,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1819,7 +1819,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1852,7 +1852,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1909,7 +1909,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1942,7 +1942,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1994,7 +1994,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2027,7 +2027,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2079,7 +2079,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2112,7 +2112,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2169,7 +2169,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2202,7 +2202,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2254,7 +2254,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2287,7 +2287,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2339,7 +2339,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2372,7 +2372,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2429,7 +2429,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2462,7 +2462,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2514,7 +2514,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2522,15 +2522,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-3_0_2-normal:
-    name: 'Build Ruby [debian-9/3.0.2/normal]'
+  build_ruby_debian_9-3_0_3-normal:
+    name: 'Build Ruby [debian-9/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2547,7 +2547,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2582,14 +2582,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-debian-9-normal
+          key: v2-ruby-bin-3.0.3-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2598,24 +2598,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-3_0_2-jemalloc:
-    name: 'Build Ruby [debian-9/3.0.2/jemalloc]'
+  build_ruby_debian_9-3_0_3-jemalloc:
+    name: 'Build Ruby [debian-9/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2632,7 +2632,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2672,14 +2672,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-debian-9-jemalloc
+          key: v2-ruby-bin-3.0.3-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2688,24 +2688,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-3_0_2-malloctrim:
-    name: 'Build Ruby [debian-9/3.0.2/malloctrim]'
+  build_ruby_debian_9-3_0_3-malloctrim:
+    name: 'Build Ruby [debian-9/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2722,7 +2722,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2757,14 +2757,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-debian-9-malloctrim
+          key: v2-ruby-bin-3.0.3-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2773,24 +2773,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-2_7_4-normal:
-    name: 'Build Ruby [debian-9/2.7.4/normal]'
+  build_ruby_debian_9-2_7_5-normal:
+    name: 'Build Ruby [debian-9/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2807,7 +2807,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2842,14 +2842,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-debian-9-normal
+          key: v2-ruby-bin-2.7.5-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2858,24 +2858,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-2_7_4-jemalloc:
-    name: 'Build Ruby [debian-9/2.7.4/jemalloc]'
+  build_ruby_debian_9-2_7_5-jemalloc:
+    name: 'Build Ruby [debian-9/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2892,7 +2892,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2932,14 +2932,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-debian-9-jemalloc
+          key: v2-ruby-bin-2.7.5-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2948,24 +2948,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-2_7_4-malloctrim:
-    name: 'Build Ruby [debian-9/2.7.4/malloctrim]'
+  build_ruby_debian_9-2_7_5-malloctrim:
+    name: 'Build Ruby [debian-9/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -2982,7 +2982,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3017,14 +3017,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-debian-9-malloctrim
+          key: v2-ruby-bin-2.7.5-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3033,24 +3033,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_9-2_6_8-normal:
-    name: 'Build Ruby [debian-9/2.6.8/normal]'
+  build_ruby_debian_9-2_6_9-normal:
+    name: 'Build Ruby [debian-9/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -3067,7 +3067,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3102,14 +3102,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-debian-9-normal
+          key: v2-ruby-bin-2.6.9-debian-9-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3118,24 +3118,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-9_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_9-2_6_8-jemalloc:
-    name: 'Build Ruby [debian-9/2.6.8/jemalloc]'
+  build_ruby_debian_9-2_6_9-jemalloc:
+    name: 'Build Ruby [debian-9/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -3152,7 +3152,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3192,14 +3192,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-debian-9-jemalloc
+          key: v2-ruby-bin-2.6.9-debian-9-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3208,24 +3208,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_9-2_6_8-malloctrim:
-    name: 'Build Ruby [debian-9/2.6.8/malloctrim]'
+  build_ruby_debian_9-2_6_9-malloctrim:
+    name: 'Build Ruby [debian-9/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_9
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-9]' did not fail
@@ -3242,7 +3242,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3277,14 +3277,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-debian-9-malloctrim
+          key: v2-ruby-bin-2.6.9-debian-9-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3293,13 +3293,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-9_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -3327,17 +3327,17 @@ jobs:
       - build_ruby_centos_7-2_6-jemalloc
       - build_ruby_centos_7-2_6-malloctrim
 
-      - build_ruby_centos_7-3_0_2-normal
-      - build_ruby_centos_7-3_0_2-jemalloc
-      - build_ruby_centos_7-3_0_2-malloctrim
+      - build_ruby_centos_7-3_0_3-normal
+      - build_ruby_centos_7-3_0_3-jemalloc
+      - build_ruby_centos_7-3_0_3-malloctrim
 
-      - build_ruby_centos_7-2_7_4-normal
-      - build_ruby_centos_7-2_7_4-jemalloc
-      - build_ruby_centos_7-2_7_4-malloctrim
+      - build_ruby_centos_7-2_7_5-normal
+      - build_ruby_centos_7-2_7_5-jemalloc
+      - build_ruby_centos_7-2_7_5-malloctrim
 
-      - build_ruby_centos_7-2_6_8-normal
-      - build_ruby_centos_7-2_6_8-jemalloc
-      - build_ruby_centos_7-2_6_8-malloctrim
+      - build_ruby_centos_7-2_6_9-normal
+      - build_ruby_centos_7-2_6_9-jemalloc
+      - build_ruby_centos_7-2_6_9-malloctrim
 
       - build_jemalloc_debian_9
 
@@ -3353,17 +3353,17 @@ jobs:
       - build_ruby_debian_9-2_6-jemalloc
       - build_ruby_debian_9-2_6-malloctrim
 
-      - build_ruby_debian_9-3_0_2-normal
-      - build_ruby_debian_9-3_0_2-jemalloc
-      - build_ruby_debian_9-3_0_2-malloctrim
+      - build_ruby_debian_9-3_0_3-normal
+      - build_ruby_debian_9-3_0_3-jemalloc
+      - build_ruby_debian_9-3_0_3-malloctrim
 
-      - build_ruby_debian_9-2_7_4-normal
-      - build_ruby_debian_9-2_7_4-jemalloc
-      - build_ruby_debian_9-2_7_4-malloctrim
+      - build_ruby_debian_9-2_7_5-normal
+      - build_ruby_debian_9-2_7_5-jemalloc
+      - build_ruby_debian_9-2_7_5-malloctrim
 
-      - build_ruby_debian_9-2_6_8-normal
-      - build_ruby_debian_9-2_6_8-jemalloc
-      - build_ruby_debian_9-2_6_8-malloctrim
+      - build_ruby_debian_9-2_6_9-normal
+      - build_ruby_debian_9-2_6_9-jemalloc
+      - build_ruby_debian_9-2_6_9-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -3401,7 +3401,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_3.0.2_centos-7_normal ruby-pkg_3.0.2_centos-7_jemalloc ruby-pkg_3.0.2_centos-7_malloctrim ruby-pkg_3.0.2_debian-9_normal ruby-pkg_3.0.2_debian-9_jemalloc ruby-pkg_3.0.2_debian-9_malloctrim ruby-pkg_2.7.4_centos-7_normal ruby-pkg_2.7.4_centos-7_jemalloc ruby-pkg_2.7.4_centos-7_malloctrim ruby-pkg_2.7.4_debian-9_normal ruby-pkg_2.7.4_debian-9_jemalloc ruby-pkg_2.7.4_debian-9_malloctrim ruby-pkg_2.6.8_centos-7_normal ruby-pkg_2.6.8_centos-7_jemalloc ruby-pkg_2.6.8_centos-7_malloctrim ruby-pkg_2.6.8_debian-9_normal ruby-pkg_2.6.8_debian-9_jemalloc ruby-pkg_2.6.8_debian-9_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_3.0.3_centos-7_normal ruby-pkg_3.0.3_centos-7_jemalloc ruby-pkg_3.0.3_centos-7_malloctrim ruby-pkg_3.0.3_debian-9_normal ruby-pkg_3.0.3_debian-9_jemalloc ruby-pkg_3.0.3_debian-9_malloctrim ruby-pkg_2.7.5_centos-7_normal ruby-pkg_2.7.5_centos-7_jemalloc ruby-pkg_2.7.5_centos-7_malloctrim ruby-pkg_2.7.5_debian-9_normal ruby-pkg_2.7.5_debian-9_jemalloc ruby-pkg_2.7.5_debian-9_malloctrim ruby-pkg_2.6.9_centos-7_normal ruby-pkg_2.6.9_centos-7_jemalloc ruby-pkg_2.6.9_centos-7_malloctrim ruby-pkg_2.6.9_debian-9_normal ruby-pkg_2.6.9_debian-9_jemalloc ruby-pkg_2.6.9_debian-9_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
       - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-7_normal] to Github
@@ -3494,96 +3494,96 @@ jobs:
         with:
           name: ruby-pkg_2.6_debian-9_malloctrim
           path: artifacts/ruby-pkg_2.6_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-7_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-7_normal
-          path: artifacts/ruby-pkg_3.0.2_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-7_jemalloc] to Github
+          name: ruby-pkg_3.0.3_centos-7_normal
+          path: artifacts/ruby-pkg_3.0.3_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-7_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-7_malloctrim] to Github
+          name: ruby-pkg_3.0.3_centos-7_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-7_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-9_normal] to Github
+          name: ruby-pkg_3.0.3_centos-7_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-9_normal
-          path: artifacts/ruby-pkg_3.0.2_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-9_jemalloc] to Github
+          name: ruby-pkg_3.0.3_debian-9_normal
+          path: artifacts/ruby-pkg_3.0.3_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-9_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-9_malloctrim] to Github
+          name: ruby-pkg_3.0.3_debian-9_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-9_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-7_normal] to Github
+          name: ruby-pkg_3.0.3_debian-9_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-7_normal
-          path: artifacts/ruby-pkg_2.7.4_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-7_jemalloc] to Github
+          name: ruby-pkg_2.7.5_centos-7_normal
+          path: artifacts/ruby-pkg_2.7.5_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-7_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-7_malloctrim] to Github
+          name: ruby-pkg_2.7.5_centos-7_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-7_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-9_normal] to Github
+          name: ruby-pkg_2.7.5_centos-7_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-9_normal
-          path: artifacts/ruby-pkg_2.7.4_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-9_jemalloc] to Github
+          name: ruby-pkg_2.7.5_debian-9_normal
+          path: artifacts/ruby-pkg_2.7.5_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-9_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-9_malloctrim] to Github
+          name: ruby-pkg_2.7.5_debian-9_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-9_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_debian-9_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-7_normal] to Github
+          name: ruby-pkg_2.7.5_debian-9_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_debian-9_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-7_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-7_normal
-          path: artifacts/ruby-pkg_2.6.8_centos-7_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-7_jemalloc] to Github
+          name: ruby-pkg_2.6.9_centos-7_normal
+          path: artifacts/ruby-pkg_2.6.9_centos-7_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-7_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-7_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_centos-7_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-7_malloctrim] to Github
+          name: ruby-pkg_2.6.9_centos-7_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_centos-7_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-7_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-7_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_centos-7_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-9_normal] to Github
+          name: ruby-pkg_2.6.9_centos-7_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_centos-7_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-9_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-9_normal
-          path: artifacts/ruby-pkg_2.6.8_debian-9_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-9_jemalloc] to Github
+          name: ruby-pkg_2.6.9_debian-9_normal
+          path: artifacts/ruby-pkg_2.6.9_debian-9_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-9_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-9_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_debian-9_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-9_malloctrim] to Github
+          name: ruby-pkg_2.6.9_debian-9_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_debian-9_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-9_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-9_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_debian-9_malloctrim
+          name: ruby-pkg_2.6.9_debian-9_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_debian-9_malloctrim
 
 
       ### Check whether dependent jobs failed ###
@@ -3633,33 +3633,33 @@ jobs:
             || (needs.build_ruby_centos_7-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_centos_7-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6/malloctrim];')))
-            || (needs.build_ruby_centos_7-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/normal];')))
-            || (needs.build_ruby_centos_7-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/jemalloc];')))
-            || (needs.build_ruby_centos_7-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.2/malloctrim];')))
-            || (needs.build_ruby_centos_7-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/normal];')))
-            || (needs.build_ruby_centos_7-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/jemalloc];')))
-            || (needs.build_ruby_centos_7-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.4/malloctrim];')))
-            || (needs.build_ruby_centos_7-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/normal];')))
-            || (needs.build_ruby_centos_7-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/jemalloc];')))
-            || (needs.build_ruby_centos_7-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_7-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.8/malloctrim];')))
+            || (needs.build_ruby_centos_7-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/normal];')))
+            || (needs.build_ruby_centos_7-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/jemalloc];')))
+            || (needs.build_ruby_centos_7-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/3.0.3/malloctrim];')))
+            || (needs.build_ruby_centos_7-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/normal];')))
+            || (needs.build_ruby_centos_7-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/jemalloc];')))
+            || (needs.build_ruby_centos_7-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.7.5/malloctrim];')))
+            || (needs.build_ruby_centos_7-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/normal];')))
+            || (needs.build_ruby_centos_7-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/jemalloc];')))
+            || (needs.build_ruby_centos_7-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_7-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-7/2.6.9/malloctrim];')))
       - name: Check whether 'Build Ruby [debian-9]' did not fail
         run: 'false'
         if: |
@@ -3691,33 +3691,33 @@ jobs:
             || (needs.build_ruby_debian_9-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_debian_9-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6/malloctrim];')))
-            || (needs.build_ruby_debian_9-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/normal];')))
-            || (needs.build_ruby_debian_9-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/jemalloc];')))
-            || (needs.build_ruby_debian_9-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.2/malloctrim];')))
-            || (needs.build_ruby_debian_9-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/normal];')))
-            || (needs.build_ruby_debian_9-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/jemalloc];')))
-            || (needs.build_ruby_debian_9-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.4/malloctrim];')))
-            || (needs.build_ruby_debian_9-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/normal];')))
-            || (needs.build_ruby_debian_9-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/jemalloc];')))
-            || (needs.build_ruby_debian_9-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_9-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.8/malloctrim];')))
+            || (needs.build_ruby_debian_9-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/normal];')))
+            || (needs.build_ruby_debian_9-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/jemalloc];')))
+            || (needs.build_ruby_debian_9-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/3.0.3/malloctrim];')))
+            || (needs.build_ruby_debian_9-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/normal];')))
+            || (needs.build_ruby_debian_9-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/jemalloc];')))
+            || (needs.build_ruby_debian_9-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.7.5/malloctrim];')))
+            || (needs.build_ruby_debian_9-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/normal];')))
+            || (needs.build_ruby_debian_9-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/jemalloc];')))
+            || (needs.build_ruby_debian_9-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_9-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-9/2.6.9/malloctrim];')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-build-packages-2.yml
+++ b/.github/workflows/ci-cd-build-packages-2.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -258,7 +258,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -291,7 +291,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -348,7 +348,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -381,7 +381,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -433,7 +433,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -466,7 +466,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -518,7 +518,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -551,7 +551,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -608,7 +608,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -641,7 +641,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -693,7 +693,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -726,7 +726,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -778,7 +778,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -811,7 +811,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -868,7 +868,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -901,7 +901,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -953,7 +953,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -961,15 +961,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-3_0_2-normal:
-    name: 'Build Ruby [centos-8/3.0.2/normal]'
+  build_ruby_centos_8-3_0_3-normal:
+    name: 'Build Ruby [centos-8/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -986,7 +986,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1021,14 +1021,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-centos-8-normal
+          key: v2-ruby-bin-3.0.3-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1037,24 +1037,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-3_0_2-jemalloc:
-    name: 'Build Ruby [centos-8/3.0.2/jemalloc]'
+  build_ruby_centos_8-3_0_3-jemalloc:
+    name: 'Build Ruby [centos-8/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1071,7 +1071,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1111,14 +1111,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-centos-8-jemalloc
+          key: v2-ruby-bin-3.0.3-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1127,24 +1127,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-3_0_2-malloctrim:
-    name: 'Build Ruby [centos-8/3.0.2/malloctrim]'
+  build_ruby_centos_8-3_0_3-malloctrim:
+    name: 'Build Ruby [centos-8/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1161,7 +1161,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1196,14 +1196,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-centos-8-malloctrim
+          key: v2-ruby-bin-3.0.3-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1212,24 +1212,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-2_7_4-normal:
-    name: 'Build Ruby [centos-8/2.7.4/normal]'
+  build_ruby_centos_8-2_7_5-normal:
+    name: 'Build Ruby [centos-8/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1246,7 +1246,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1281,14 +1281,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-centos-8-normal
+          key: v2-ruby-bin-2.7.5-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1297,24 +1297,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-2_7_4-jemalloc:
-    name: 'Build Ruby [centos-8/2.7.4/jemalloc]'
+  build_ruby_centos_8-2_7_5-jemalloc:
+    name: 'Build Ruby [centos-8/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1331,7 +1331,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1371,14 +1371,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-centos-8-jemalloc
+          key: v2-ruby-bin-2.7.5-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1387,24 +1387,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-2_7_4-malloctrim:
-    name: 'Build Ruby [centos-8/2.7.4/malloctrim]'
+  build_ruby_centos_8-2_7_5-malloctrim:
+    name: 'Build Ruby [centos-8/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1421,7 +1421,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1456,14 +1456,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-centos-8-malloctrim
+          key: v2-ruby-bin-2.7.5-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1472,24 +1472,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_centos_8-2_6_8-normal:
-    name: 'Build Ruby [centos-8/2.6.8/normal]'
+  build_ruby_centos_8-2_6_9-normal:
+    name: 'Build Ruby [centos-8/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1506,7 +1506,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1541,14 +1541,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-centos-8-normal
+          key: v2-ruby-bin-2.6.9-centos-8-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1557,24 +1557,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-8_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_centos_8-2_6_8-jemalloc:
-    name: 'Build Ruby [centos-8/2.6.8/jemalloc]'
+  build_ruby_centos_8-2_6_9-jemalloc:
+    name: 'Build Ruby [centos-8/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1591,7 +1591,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1631,14 +1631,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-centos-8-jemalloc
+          key: v2-ruby-bin-2.6.9-centos-8-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1647,24 +1647,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_centos_8-2_6_8-malloctrim:
-    name: 'Build Ruby [centos-8/2.6.8/malloctrim]'
+  build_ruby_centos_8-2_6_9-malloctrim:
+    name: 'Build Ruby [centos-8/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_centos_8
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [centos-8]' did not fail
@@ -1681,7 +1681,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1716,14 +1716,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-centos-8-malloctrim
+          key: v2-ruby-bin-2.6.9-centos-8-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1732,13 +1732,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_centos-8_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -1767,7 +1767,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1819,7 +1819,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1852,7 +1852,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1909,7 +1909,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1942,7 +1942,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1994,7 +1994,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2027,7 +2027,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2079,7 +2079,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2112,7 +2112,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2169,7 +2169,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2202,7 +2202,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2254,7 +2254,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2287,7 +2287,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2339,7 +2339,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2372,7 +2372,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2429,7 +2429,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2462,7 +2462,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2514,7 +2514,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2522,15 +2522,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-3_0_2-normal:
-    name: 'Build Ruby [ubuntu-18.04/3.0.2/normal]'
+  build_ruby_ubuntu_18_04-3_0_3-normal:
+    name: 'Build Ruby [ubuntu-18.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2547,7 +2547,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2582,14 +2582,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-ubuntu-18.04-normal
+          key: v2-ruby-bin-3.0.3-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2598,24 +2598,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-3_0_2-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/3.0.2/jemalloc]'
+  build_ruby_ubuntu_18_04-3_0_3-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2632,7 +2632,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2672,14 +2672,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-3.0.3-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2688,24 +2688,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-3_0_2-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/3.0.2/malloctrim]'
+  build_ruby_ubuntu_18_04-3_0_3-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2722,7 +2722,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2757,14 +2757,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-3.0.3-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2773,24 +2773,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-2_7_4-normal:
-    name: 'Build Ruby [ubuntu-18.04/2.7.4/normal]'
+  build_ruby_ubuntu_18_04-2_7_5-normal:
+    name: 'Build Ruby [ubuntu-18.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2807,7 +2807,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2842,14 +2842,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-ubuntu-18.04-normal
+          key: v2-ruby-bin-2.7.5-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2858,24 +2858,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-2_7_4-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/2.7.4/jemalloc]'
+  build_ruby_ubuntu_18_04-2_7_5-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2892,7 +2892,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2932,14 +2932,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-2.7.5-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2948,24 +2948,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-2_7_4-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/2.7.4/malloctrim]'
+  build_ruby_ubuntu_18_04-2_7_5-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -2982,7 +2982,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3017,14 +3017,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-2.7.5-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3033,24 +3033,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_18_04-2_6_8-normal:
-    name: 'Build Ruby [ubuntu-18.04/2.6.8/normal]'
+  build_ruby_ubuntu_18_04-2_6_9-normal:
+    name: 'Build Ruby [ubuntu-18.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -3067,7 +3067,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3102,14 +3102,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-ubuntu-18.04-normal
+          key: v2-ruby-bin-2.6.9-ubuntu-18.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3118,24 +3118,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-18.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-18.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_18_04-2_6_8-jemalloc:
-    name: 'Build Ruby [ubuntu-18.04/2.6.8/jemalloc]'
+  build_ruby_ubuntu_18_04-2_6_9-jemalloc:
+    name: 'Build Ruby [ubuntu-18.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -3152,7 +3152,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3192,14 +3192,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-ubuntu-18.04-jemalloc
+          key: v2-ruby-bin-2.6.9-ubuntu-18.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3208,24 +3208,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-18.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-18.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_18_04-2_6_8-malloctrim:
-    name: 'Build Ruby [ubuntu-18.04/2.6.8/malloctrim]'
+  build_ruby_ubuntu_18_04-2_6_9-malloctrim:
+    name: 'Build Ruby [ubuntu-18.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_18_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-18.04]' did not fail
@@ -3242,7 +3242,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3277,14 +3277,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-ubuntu-18.04-malloctrim
+          key: v2-ruby-bin-2.6.9-ubuntu-18.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3293,13 +3293,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-18.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-18.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -3327,17 +3327,17 @@ jobs:
       - build_ruby_centos_8-2_6-jemalloc
       - build_ruby_centos_8-2_6-malloctrim
 
-      - build_ruby_centos_8-3_0_2-normal
-      - build_ruby_centos_8-3_0_2-jemalloc
-      - build_ruby_centos_8-3_0_2-malloctrim
+      - build_ruby_centos_8-3_0_3-normal
+      - build_ruby_centos_8-3_0_3-jemalloc
+      - build_ruby_centos_8-3_0_3-malloctrim
 
-      - build_ruby_centos_8-2_7_4-normal
-      - build_ruby_centos_8-2_7_4-jemalloc
-      - build_ruby_centos_8-2_7_4-malloctrim
+      - build_ruby_centos_8-2_7_5-normal
+      - build_ruby_centos_8-2_7_5-jemalloc
+      - build_ruby_centos_8-2_7_5-malloctrim
 
-      - build_ruby_centos_8-2_6_8-normal
-      - build_ruby_centos_8-2_6_8-jemalloc
-      - build_ruby_centos_8-2_6_8-malloctrim
+      - build_ruby_centos_8-2_6_9-normal
+      - build_ruby_centos_8-2_6_9-jemalloc
+      - build_ruby_centos_8-2_6_9-malloctrim
 
       - build_jemalloc_ubuntu_18_04
 
@@ -3353,17 +3353,17 @@ jobs:
       - build_ruby_ubuntu_18_04-2_6-jemalloc
       - build_ruby_ubuntu_18_04-2_6-malloctrim
 
-      - build_ruby_ubuntu_18_04-3_0_2-normal
-      - build_ruby_ubuntu_18_04-3_0_2-jemalloc
-      - build_ruby_ubuntu_18_04-3_0_2-malloctrim
+      - build_ruby_ubuntu_18_04-3_0_3-normal
+      - build_ruby_ubuntu_18_04-3_0_3-jemalloc
+      - build_ruby_ubuntu_18_04-3_0_3-malloctrim
 
-      - build_ruby_ubuntu_18_04-2_7_4-normal
-      - build_ruby_ubuntu_18_04-2_7_4-jemalloc
-      - build_ruby_ubuntu_18_04-2_7_4-malloctrim
+      - build_ruby_ubuntu_18_04-2_7_5-normal
+      - build_ruby_ubuntu_18_04-2_7_5-jemalloc
+      - build_ruby_ubuntu_18_04-2_7_5-malloctrim
 
-      - build_ruby_ubuntu_18_04-2_6_8-normal
-      - build_ruby_ubuntu_18_04-2_6_8-jemalloc
-      - build_ruby_ubuntu_18_04-2_6_8-malloctrim
+      - build_ruby_ubuntu_18_04-2_6_9-normal
+      - build_ruby_ubuntu_18_04-2_6_9-jemalloc
+      - build_ruby_ubuntu_18_04-2_6_9-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -3401,7 +3401,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_3.0.2_centos-8_normal ruby-pkg_3.0.2_centos-8_jemalloc ruby-pkg_3.0.2_centos-8_malloctrim ruby-pkg_3.0.2_ubuntu-18.04_normal ruby-pkg_3.0.2_ubuntu-18.04_jemalloc ruby-pkg_3.0.2_ubuntu-18.04_malloctrim ruby-pkg_2.7.4_centos-8_normal ruby-pkg_2.7.4_centos-8_jemalloc ruby-pkg_2.7.4_centos-8_malloctrim ruby-pkg_2.7.4_ubuntu-18.04_normal ruby-pkg_2.7.4_ubuntu-18.04_jemalloc ruby-pkg_2.7.4_ubuntu-18.04_malloctrim ruby-pkg_2.6.8_centos-8_normal ruby-pkg_2.6.8_centos-8_jemalloc ruby-pkg_2.6.8_centos-8_malloctrim ruby-pkg_2.6.8_ubuntu-18.04_normal ruby-pkg_2.6.8_ubuntu-18.04_jemalloc ruby-pkg_2.6.8_ubuntu-18.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_3.0.3_centos-8_normal ruby-pkg_3.0.3_centos-8_jemalloc ruby-pkg_3.0.3_centos-8_malloctrim ruby-pkg_3.0.3_ubuntu-18.04_normal ruby-pkg_3.0.3_ubuntu-18.04_jemalloc ruby-pkg_3.0.3_ubuntu-18.04_malloctrim ruby-pkg_2.7.5_centos-8_normal ruby-pkg_2.7.5_centos-8_jemalloc ruby-pkg_2.7.5_centos-8_malloctrim ruby-pkg_2.7.5_ubuntu-18.04_normal ruby-pkg_2.7.5_ubuntu-18.04_jemalloc ruby-pkg_2.7.5_ubuntu-18.04_malloctrim ruby-pkg_2.6.9_centos-8_normal ruby-pkg_2.6.9_centos-8_jemalloc ruby-pkg_2.6.9_centos-8_malloctrim ruby-pkg_2.6.9_ubuntu-18.04_normal ruby-pkg_2.6.9_ubuntu-18.04_jemalloc ruby-pkg_2.6.9_ubuntu-18.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
       - name: Archive Ruby package artifact [ruby-pkg_3.0_centos-8_normal] to Github
@@ -3494,96 +3494,96 @@ jobs:
         with:
           name: ruby-pkg_2.6_ubuntu-18.04_malloctrim
           path: artifacts/ruby-pkg_2.6_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-8_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-8_normal
-          path: artifacts/ruby-pkg_3.0.2_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-8_jemalloc] to Github
+          name: ruby-pkg_3.0.3_centos-8_normal
+          path: artifacts/ruby-pkg_3.0.3_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-8_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_centos-8_malloctrim] to Github
+          name: ruby-pkg_3.0.3_centos-8_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_3.0.3_centos-8_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_3.0.3_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_3.0.3_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-8_normal] to Github
+          name: ruby-pkg_3.0.3_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-8_normal
-          path: artifacts/ruby-pkg_2.7.4_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-8_jemalloc] to Github
+          name: ruby-pkg_2.7.5_centos-8_normal
+          path: artifacts/ruby-pkg_2.7.5_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-8_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_centos-8_malloctrim] to Github
+          name: ruby-pkg_2.7.5_centos-8_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_centos-8_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_2.7.5_centos-8_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_2.7.5_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_2.7.5_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-18.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-8_normal] to Github
+          name: ruby-pkg_2.7.5_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-18.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-8_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-8_normal
-          path: artifacts/ruby-pkg_2.6.8_centos-8_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-8_jemalloc] to Github
+          name: ruby-pkg_2.6.9_centos-8_normal
+          path: artifacts/ruby-pkg_2.6.9_centos-8_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-8_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_centos-8_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_centos-8_malloctrim] to Github
+          name: ruby-pkg_2.6.9_centos-8_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_centos-8_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_centos-8_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_centos-8_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_centos-8_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-18.04_normal] to Github
+          name: ruby-pkg_2.6.9_centos-8_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_centos-8_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-18.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-18.04_normal
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-18.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-18.04_jemalloc] to Github
+          name: ruby-pkg_2.6.9_ubuntu-18.04_normal
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-18.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-18.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-18.04_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-18.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-18.04_malloctrim] to Github
+          name: ruby-pkg_2.6.9_ubuntu-18.04_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-18.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-18.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-18.04_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-18.04_malloctrim
+          name: ruby-pkg_2.6.9_ubuntu-18.04_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-18.04_malloctrim
 
 
       ### Check whether dependent jobs failed ###
@@ -3633,33 +3633,33 @@ jobs:
             || (needs.build_ruby_centos_8-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_centos_8-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6/malloctrim];')))
-            || (needs.build_ruby_centos_8-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/normal];')))
-            || (needs.build_ruby_centos_8-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.2/malloctrim];')))
-            || (needs.build_ruby_centos_8-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/normal];')))
-            || (needs.build_ruby_centos_8-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/jemalloc];')))
-            || (needs.build_ruby_centos_8-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.4/malloctrim];')))
-            || (needs.build_ruby_centos_8-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/normal];')))
-            || (needs.build_ruby_centos_8-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/jemalloc];')))
-            || (needs.build_ruby_centos_8-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.8/malloctrim];')))
+            || (needs.build_ruby_centos_8-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/normal];')))
+            || (needs.build_ruby_centos_8-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/jemalloc];')))
+            || (needs.build_ruby_centos_8-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/3.0.3/malloctrim];')))
+            || (needs.build_ruby_centos_8-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/normal];')))
+            || (needs.build_ruby_centos_8-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/jemalloc];')))
+            || (needs.build_ruby_centos_8-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.7.5/malloctrim];')))
+            || (needs.build_ruby_centos_8-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/normal];')))
+            || (needs.build_ruby_centos_8-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/jemalloc];')))
+            || (needs.build_ruby_centos_8-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [centos-8/2.6.9/malloctrim];')))
       - name: Check whether 'Build Ruby [ubuntu-18.04]' did not fail
         run: 'false'
         if: |
@@ -3691,33 +3691,33 @@ jobs:
             || (needs.build_ruby_ubuntu_18_04-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.4/malloctrim];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/normal];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/jemalloc];')))
-            || (needs.build_ruby_ubuntu_18_04-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_18_04-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.8/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/3.0.3/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.7.5/malloctrim];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/normal];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/jemalloc];')))
+            || (needs.build_ruby_ubuntu_18_04-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_18_04-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-18.04/2.6.9/malloctrim];')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-build-packages-3.yml
+++ b/.github/workflows/ci-cd-build-packages-3.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -258,7 +258,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -291,7 +291,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -348,7 +348,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -381,7 +381,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -433,7 +433,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -466,7 +466,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -518,7 +518,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -551,7 +551,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -608,7 +608,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -641,7 +641,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -693,7 +693,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -726,7 +726,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -778,7 +778,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -811,7 +811,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -868,7 +868,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -901,7 +901,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -953,7 +953,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -961,15 +961,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-3_0_2-normal:
-    name: 'Build Ruby [debian-10/3.0.2/normal]'
+  build_ruby_debian_10-3_0_3-normal:
+    name: 'Build Ruby [debian-10/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -986,7 +986,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1021,14 +1021,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-debian-10-normal
+          key: v2-ruby-bin-3.0.3-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1037,24 +1037,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-3_0_2-jemalloc:
-    name: 'Build Ruby [debian-10/3.0.2/jemalloc]'
+  build_ruby_debian_10-3_0_3-jemalloc:
+    name: 'Build Ruby [debian-10/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1071,7 +1071,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1111,14 +1111,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-debian-10-jemalloc
+          key: v2-ruby-bin-3.0.3-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1127,24 +1127,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-3_0_2-malloctrim:
-    name: 'Build Ruby [debian-10/3.0.2/malloctrim]'
+  build_ruby_debian_10-3_0_3-malloctrim:
+    name: 'Build Ruby [debian-10/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1161,7 +1161,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1196,14 +1196,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-debian-10-malloctrim
+          key: v2-ruby-bin-3.0.3-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1212,24 +1212,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-2_7_4-normal:
-    name: 'Build Ruby [debian-10/2.7.4/normal]'
+  build_ruby_debian_10-2_7_5-normal:
+    name: 'Build Ruby [debian-10/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1246,7 +1246,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1281,14 +1281,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-debian-10-normal
+          key: v2-ruby-bin-2.7.5-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1297,24 +1297,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-2_7_4-jemalloc:
-    name: 'Build Ruby [debian-10/2.7.4/jemalloc]'
+  build_ruby_debian_10-2_7_5-jemalloc:
+    name: 'Build Ruby [debian-10/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1331,7 +1331,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1371,14 +1371,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-debian-10-jemalloc
+          key: v2-ruby-bin-2.7.5-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1387,24 +1387,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-2_7_4-malloctrim:
-    name: 'Build Ruby [debian-10/2.7.4/malloctrim]'
+  build_ruby_debian_10-2_7_5-malloctrim:
+    name: 'Build Ruby [debian-10/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1421,7 +1421,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1456,14 +1456,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-debian-10-malloctrim
+          key: v2-ruby-bin-2.7.5-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1472,24 +1472,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_10-2_6_8-normal:
-    name: 'Build Ruby [debian-10/2.6.8/normal]'
+  build_ruby_debian_10-2_6_9-normal:
+    name: 'Build Ruby [debian-10/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1506,7 +1506,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1541,14 +1541,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-debian-10-normal
+          key: v2-ruby-bin-2.6.9-debian-10-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1557,24 +1557,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-10_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-10_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_10-2_6_8-jemalloc:
-    name: 'Build Ruby [debian-10/2.6.8/jemalloc]'
+  build_ruby_debian_10-2_6_9-jemalloc:
+    name: 'Build Ruby [debian-10/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1591,7 +1591,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1631,14 +1631,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-debian-10-jemalloc
+          key: v2-ruby-bin-2.6.9-debian-10-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1647,24 +1647,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-10_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-10_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_10-2_6_8-malloctrim:
-    name: 'Build Ruby [debian-10/2.6.8/malloctrim]'
+  build_ruby_debian_10-2_6_9-malloctrim:
+    name: 'Build Ruby [debian-10/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_10
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-10]' did not fail
@@ -1681,7 +1681,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1716,14 +1716,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-debian-10-malloctrim
+          key: v2-ruby-bin-2.6.9-debian-10-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1732,13 +1732,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-10_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-10_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -1767,7 +1767,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1819,7 +1819,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1852,7 +1852,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1909,7 +1909,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -1942,7 +1942,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1994,7 +1994,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2027,7 +2027,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2079,7 +2079,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2112,7 +2112,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2169,7 +2169,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2202,7 +2202,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2254,7 +2254,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2287,7 +2287,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2339,7 +2339,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2372,7 +2372,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2429,7 +2429,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2462,7 +2462,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2514,7 +2514,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2522,15 +2522,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-3_0_2-normal:
-    name: 'Build Ruby [ubuntu-20.04/3.0.2/normal]'
+  build_ruby_ubuntu_20_04-3_0_3-normal:
+    name: 'Build Ruby [ubuntu-20.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2547,7 +2547,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2582,14 +2582,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-ubuntu-20.04-normal
+          key: v2-ruby-bin-3.0.3-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2598,24 +2598,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-3_0_2-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/3.0.2/jemalloc]'
+  build_ruby_ubuntu_20_04-3_0_3-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2632,7 +2632,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2672,14 +2672,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-3.0.3-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2688,24 +2688,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-3_0_2-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/3.0.2/malloctrim]'
+  build_ruby_ubuntu_20_04-3_0_3-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2722,7 +2722,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2757,14 +2757,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-3.0.3-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2773,24 +2773,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-2_7_4-normal:
-    name: 'Build Ruby [ubuntu-20.04/2.7.4/normal]'
+  build_ruby_ubuntu_20_04-2_7_5-normal:
+    name: 'Build Ruby [ubuntu-20.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2807,7 +2807,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2842,14 +2842,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-ubuntu-20.04-normal
+          key: v2-ruby-bin-2.7.5-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2858,24 +2858,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-2_7_4-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/2.7.4/jemalloc]'
+  build_ruby_ubuntu_20_04-2_7_5-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2892,7 +2892,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -2932,14 +2932,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-2.7.5-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2948,24 +2948,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-2_7_4-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/2.7.4/malloctrim]'
+  build_ruby_ubuntu_20_04-2_7_5-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -2982,7 +2982,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3017,14 +3017,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-2.7.5-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3033,24 +3033,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_ubuntu_20_04-2_6_8-normal:
-    name: 'Build Ruby [ubuntu-20.04/2.6.8/normal]'
+  build_ruby_ubuntu_20_04-2_6_9-normal:
+    name: 'Build Ruby [ubuntu-20.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -3067,7 +3067,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3102,14 +3102,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-ubuntu-20.04-normal
+          key: v2-ruby-bin-2.6.9-ubuntu-20.04-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3118,24 +3118,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-20.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-20.04_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_ubuntu_20_04-2_6_8-jemalloc:
-    name: 'Build Ruby [ubuntu-20.04/2.6.8/jemalloc]'
+  build_ruby_ubuntu_20_04-2_6_9-jemalloc:
+    name: 'Build Ruby [ubuntu-20.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -3152,7 +3152,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3192,14 +3192,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-ubuntu-20.04-jemalloc
+          key: v2-ruby-bin-2.6.9-ubuntu-20.04-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3208,24 +3208,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-20.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-20.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_ubuntu_20_04-2_6_8-malloctrim:
-    name: 'Build Ruby [ubuntu-20.04/2.6.8/malloctrim]'
+  build_ruby_ubuntu_20_04-2_6_9-malloctrim:
+    name: 'Build Ruby [ubuntu-20.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_ubuntu_20_04
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [ubuntu-20.04]' did not fail
@@ -3242,7 +3242,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -3277,14 +3277,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-ubuntu-20.04-malloctrim
+          key: v2-ruby-bin-2.6.9-ubuntu-20.04-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3293,13 +3293,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_ubuntu-20.04_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_ubuntu-20.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -3327,17 +3327,17 @@ jobs:
       - build_ruby_debian_10-2_6-jemalloc
       - build_ruby_debian_10-2_6-malloctrim
 
-      - build_ruby_debian_10-3_0_2-normal
-      - build_ruby_debian_10-3_0_2-jemalloc
-      - build_ruby_debian_10-3_0_2-malloctrim
+      - build_ruby_debian_10-3_0_3-normal
+      - build_ruby_debian_10-3_0_3-jemalloc
+      - build_ruby_debian_10-3_0_3-malloctrim
 
-      - build_ruby_debian_10-2_7_4-normal
-      - build_ruby_debian_10-2_7_4-jemalloc
-      - build_ruby_debian_10-2_7_4-malloctrim
+      - build_ruby_debian_10-2_7_5-normal
+      - build_ruby_debian_10-2_7_5-jemalloc
+      - build_ruby_debian_10-2_7_5-malloctrim
 
-      - build_ruby_debian_10-2_6_8-normal
-      - build_ruby_debian_10-2_6_8-jemalloc
-      - build_ruby_debian_10-2_6_8-malloctrim
+      - build_ruby_debian_10-2_6_9-normal
+      - build_ruby_debian_10-2_6_9-jemalloc
+      - build_ruby_debian_10-2_6_9-malloctrim
 
       - build_jemalloc_ubuntu_20_04
 
@@ -3353,17 +3353,17 @@ jobs:
       - build_ruby_ubuntu_20_04-2_6-jemalloc
       - build_ruby_ubuntu_20_04-2_6-malloctrim
 
-      - build_ruby_ubuntu_20_04-3_0_2-normal
-      - build_ruby_ubuntu_20_04-3_0_2-jemalloc
-      - build_ruby_ubuntu_20_04-3_0_2-malloctrim
+      - build_ruby_ubuntu_20_04-3_0_3-normal
+      - build_ruby_ubuntu_20_04-3_0_3-jemalloc
+      - build_ruby_ubuntu_20_04-3_0_3-malloctrim
 
-      - build_ruby_ubuntu_20_04-2_7_4-normal
-      - build_ruby_ubuntu_20_04-2_7_4-jemalloc
-      - build_ruby_ubuntu_20_04-2_7_4-malloctrim
+      - build_ruby_ubuntu_20_04-2_7_5-normal
+      - build_ruby_ubuntu_20_04-2_7_5-jemalloc
+      - build_ruby_ubuntu_20_04-2_7_5-malloctrim
 
-      - build_ruby_ubuntu_20_04-2_6_8-normal
-      - build_ruby_ubuntu_20_04-2_6_8-jemalloc
-      - build_ruby_ubuntu_20_04-2_6_8-malloctrim
+      - build_ruby_ubuntu_20_04-2_6_9-normal
+      - build_ruby_ubuntu_20_04-2_6_9-jemalloc
+      - build_ruby_ubuntu_20_04-2_6_9-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -3401,7 +3401,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.2_debian-10_normal ruby-pkg_3.0.2_debian-10_jemalloc ruby-pkg_3.0.2_debian-10_malloctrim ruby-pkg_3.0.2_ubuntu-20.04_normal ruby-pkg_3.0.2_ubuntu-20.04_jemalloc ruby-pkg_3.0.2_ubuntu-20.04_malloctrim ruby-pkg_2.7.4_debian-10_normal ruby-pkg_2.7.4_debian-10_jemalloc ruby-pkg_2.7.4_debian-10_malloctrim ruby-pkg_2.7.4_ubuntu-20.04_normal ruby-pkg_2.7.4_ubuntu-20.04_jemalloc ruby-pkg_2.7.4_ubuntu-20.04_malloctrim ruby-pkg_2.6.8_debian-10_normal ruby-pkg_2.6.8_debian-10_jemalloc ruby-pkg_2.6.8_debian-10_malloctrim ruby-pkg_2.6.8_ubuntu-20.04_normal ruby-pkg_2.6.8_ubuntu-20.04_jemalloc ruby-pkg_2.6.8_ubuntu-20.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.3_debian-10_normal ruby-pkg_3.0.3_debian-10_jemalloc ruby-pkg_3.0.3_debian-10_malloctrim ruby-pkg_3.0.3_ubuntu-20.04_normal ruby-pkg_3.0.3_ubuntu-20.04_jemalloc ruby-pkg_3.0.3_ubuntu-20.04_malloctrim ruby-pkg_2.7.5_debian-10_normal ruby-pkg_2.7.5_debian-10_jemalloc ruby-pkg_2.7.5_debian-10_malloctrim ruby-pkg_2.7.5_ubuntu-20.04_normal ruby-pkg_2.7.5_ubuntu-20.04_jemalloc ruby-pkg_2.7.5_ubuntu-20.04_malloctrim ruby-pkg_2.6.9_debian-10_normal ruby-pkg_2.6.9_debian-10_jemalloc ruby-pkg_2.6.9_debian-10_malloctrim ruby-pkg_2.6.9_ubuntu-20.04_normal ruby-pkg_2.6.9_ubuntu-20.04_jemalloc ruby-pkg_2.6.9_ubuntu-20.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
       - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-10_normal] to Github
@@ -3494,96 +3494,96 @@ jobs:
         with:
           name: ruby-pkg_2.6_ubuntu-20.04_malloctrim
           path: artifacts/ruby-pkg_2.6_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-10_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-10_normal
-          path: artifacts/ruby-pkg_3.0.2_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-10_jemalloc] to Github
+          name: ruby-pkg_3.0.3_debian-10_normal
+          path: artifacts/ruby-pkg_3.0.3_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-10_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-10_malloctrim] to Github
+          name: ruby-pkg_3.0.3_debian-10_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-10_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_3.0.3_debian-10_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_3.0.3_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_3.0.3_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-10_normal] to Github
+          name: ruby-pkg_3.0.3_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_ubuntu-20.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-10_normal
-          path: artifacts/ruby-pkg_2.7.4_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-10_jemalloc] to Github
+          name: ruby-pkg_2.7.5_debian-10_normal
+          path: artifacts/ruby-pkg_2.7.5_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-10_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-10_malloctrim] to Github
+          name: ruby-pkg_2.7.5_debian-10_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-10_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_2.7.5_debian-10_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_2.7.5_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_2.7.5_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_ubuntu-20.04_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-10_normal] to Github
+          name: ruby-pkg_2.7.5_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_ubuntu-20.04_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-10_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-10_normal
-          path: artifacts/ruby-pkg_2.6.8_debian-10_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-10_jemalloc] to Github
+          name: ruby-pkg_2.6.9_debian-10_normal
+          path: artifacts/ruby-pkg_2.6.9_debian-10_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-10_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-10_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_debian-10_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-10_malloctrim] to Github
+          name: ruby-pkg_2.6.9_debian-10_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_debian-10_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-10_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-10_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_debian-10_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-20.04_normal] to Github
+          name: ruby-pkg_2.6.9_debian-10_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_debian-10_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-20.04_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-20.04_normal
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-20.04_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-20.04_jemalloc] to Github
+          name: ruby-pkg_2.6.9_ubuntu-20.04_normal
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-20.04_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-20.04_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-20.04_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-20.04_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_ubuntu-20.04_malloctrim] to Github
+          name: ruby-pkg_2.6.9_ubuntu-20.04_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-20.04_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_ubuntu-20.04_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_ubuntu-20.04_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_ubuntu-20.04_malloctrim
+          name: ruby-pkg_2.6.9_ubuntu-20.04_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_ubuntu-20.04_malloctrim
 
 
       ### Check whether dependent jobs failed ###
@@ -3633,33 +3633,33 @@ jobs:
             || (needs.build_ruby_debian_10-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_debian_10-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6/malloctrim];')))
-            || (needs.build_ruby_debian_10-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/normal];')))
-            || (needs.build_ruby_debian_10-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/jemalloc];')))
-            || (needs.build_ruby_debian_10-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.2/malloctrim];')))
-            || (needs.build_ruby_debian_10-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/normal];')))
-            || (needs.build_ruby_debian_10-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/jemalloc];')))
-            || (needs.build_ruby_debian_10-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.4/malloctrim];')))
-            || (needs.build_ruby_debian_10-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/normal];')))
-            || (needs.build_ruby_debian_10-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/jemalloc];')))
-            || (needs.build_ruby_debian_10-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_10-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.8/malloctrim];')))
+            || (needs.build_ruby_debian_10-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/normal];')))
+            || (needs.build_ruby_debian_10-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/jemalloc];')))
+            || (needs.build_ruby_debian_10-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/3.0.3/malloctrim];')))
+            || (needs.build_ruby_debian_10-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/normal];')))
+            || (needs.build_ruby_debian_10-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/jemalloc];')))
+            || (needs.build_ruby_debian_10-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.7.5/malloctrim];')))
+            || (needs.build_ruby_debian_10-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/normal];')))
+            || (needs.build_ruby_debian_10-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/jemalloc];')))
+            || (needs.build_ruby_debian_10-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_10-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-10/2.6.9/malloctrim];')))
       - name: Check whether 'Build Ruby [ubuntu-20.04]' did not fail
         run: 'false'
         if: |
@@ -3691,33 +3691,33 @@ jobs:
             || (needs.build_ruby_ubuntu_20_04-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.4/malloctrim];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/normal];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/jemalloc];')))
-            || (needs.build_ruby_ubuntu_20_04-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_20_04-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.8/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/3.0.3/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.7.5/malloctrim];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/normal];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/jemalloc];')))
+            || (needs.build_ruby_ubuntu_20_04-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_20_04-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [ubuntu-20.04/2.6.9/malloctrim];')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-build-packages-4.yml
+++ b/.github/workflows/ci-cd-build-packages-4.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -211,7 +211,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -244,7 +244,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -301,7 +301,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -334,7 +334,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -386,7 +386,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "3.0"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -419,7 +419,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -471,7 +471,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -504,7 +504,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -561,7 +561,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -594,7 +594,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -646,7 +646,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.7"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -679,7 +679,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -731,7 +731,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -764,7 +764,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -821,7 +821,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -854,7 +854,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -906,7 +906,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "2.6"
-          RUBY_PACKAGE_REVISION: "9"
+          RUBY_PACKAGE_REVISION: "10"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -914,15 +914,15 @@ jobs:
           ARTIFACT_NAME: "ruby-pkg_2.6_debian-11_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_11-3_0_2-normal:
-    name: 'Build Ruby [debian-11/3.0.2/normal]'
+  build_ruby_debian_11-3_0_3-normal:
+    name: 'Build Ruby [debian-11/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -939,7 +939,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -974,14 +974,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-3.0.2-debian-11-normal
+          key: v2-ruby-bin-3.0.3-debian-11-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -990,24 +990,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-11_normal"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-11_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_11-3_0_2-jemalloc:
-    name: 'Build Ruby [debian-11/3.0.2/jemalloc]'
+  build_ruby_debian_11-3_0_3-jemalloc:
+    name: 'Build Ruby [debian-11/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1024,7 +1024,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1064,14 +1064,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-3.0.2-debian-11-jemalloc
+          key: v2-ruby-bin-3.0.3-debian-11-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1080,24 +1080,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-11_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_11-3_0_2-malloctrim:
-    name: 'Build Ruby [debian-11/3.0.2/malloctrim]'
+  build_ruby_debian_11-3_0_3-malloctrim:
+    name: 'Build Ruby [debian-11/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1114,7 +1114,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1149,14 +1149,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-3.0.2-debian-11-malloctrim
+          key: v2-ruby-bin-3.0.3-debian-11-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1165,24 +1165,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.0.2"
-          RUBY_PACKAGE_REVISION: "4"
+          RUBY_PACKAGE_VERSION_ID: "3.0.3"
+          RUBY_PACKAGE_REVISION: "5"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_3.0.2_debian-11_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_3.0.3_debian-11_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_11-2_7_4-normal:
-    name: 'Build Ruby [debian-11/2.7.4/normal]'
+  build_ruby_debian_11-2_7_5-normal:
+    name: 'Build Ruby [debian-11/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1199,7 +1199,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1234,14 +1234,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.7.4-debian-11-normal
+          key: v2-ruby-bin-2.7.5-debian-11-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1250,24 +1250,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-11_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-11_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_11-2_7_4-jemalloc:
-    name: 'Build Ruby [debian-11/2.7.4/jemalloc]'
+  build_ruby_debian_11-2_7_5-jemalloc:
+    name: 'Build Ruby [debian-11/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1284,7 +1284,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1324,14 +1324,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.7.4-debian-11-jemalloc
+          key: v2-ruby-bin-2.7.5-debian-11-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1340,24 +1340,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-11_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_11-2_7_4-malloctrim:
-    name: 'Build Ruby [debian-11/2.7.4/malloctrim]'
+  build_ruby_debian_11-2_7_5-malloctrim:
+    name: 'Build Ruby [debian-11/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1374,7 +1374,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1409,14 +1409,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.7.4-debian-11-malloctrim
+          key: v2-ruby-bin-2.7.5-debian-11-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1425,24 +1425,24 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.7.4"
-          RUBY_PACKAGE_REVISION: "5"
+          RUBY_PACKAGE_VERSION_ID: "2.7.5"
+          RUBY_PACKAGE_REVISION: "6"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.7.4_debian-11_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.7.5_debian-11_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
-  build_ruby_debian_11-2_6_8-normal:
-    name: 'Build Ruby [debian-11/2.6.8/normal]'
+  build_ruby_debian_11-2_6_9-normal:
+    name: 'Build Ruby [debian-11/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/normal];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/normal];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1459,7 +1459,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1494,14 +1494,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-normal
-          key: v2-ruby-bin-2.6.8-debian-11-normal
+          key: v2-ruby-bin-2.6.9-debian-11-normal
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1510,24 +1510,24 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-11_normal"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-11_normal"
           ARTIFACT_PATH: output-normal
 
-  build_ruby_debian_11-2_6_8-jemalloc:
-    name: 'Build Ruby [debian-11/2.6.8/jemalloc]'
+  build_ruby_debian_11-2_6_9-jemalloc:
+    name: 'Build Ruby [debian-11/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/jemalloc];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/jemalloc];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1544,7 +1544,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1584,14 +1584,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-jemalloc
-          key: v2-ruby-bin-2.6.8-debian-11-jemalloc
+          key: v2-ruby-bin-2.6.9-debian-11-jemalloc
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1600,24 +1600,24 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-11_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
 
-  build_ruby_debian_11-2_6_8-malloctrim:
-    name: 'Build Ruby [debian-11/2.6.8/malloctrim]'
+  build_ruby_debian_11-2_6_9-malloctrim:
+    name: 'Build Ruby [debian-11/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - build_jemalloc_debian_11
     # Run even if a dependent job has been skipped
     if: |
-      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/malloctrim];')
+      contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/malloctrim];')
       && !failure() && !cancelled()
     steps:
       - name: Check whether 'Build Jemalloc [debian-11]' did not fail
@@ -1634,7 +1634,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: .
 
       - name: Download Docker image necessary for building
@@ -1669,14 +1669,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: cache-malloctrim
-          key: v2-ruby-bin-2.6.8-debian-11-malloctrim
+          key: v2-ruby-bin-2.6.9-debian-11-malloctrim
 
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1685,13 +1685,13 @@ jobs:
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "2.6.8"
-          RUBY_PACKAGE_REVISION: "6"
+          RUBY_PACKAGE_VERSION_ID: "2.6.9"
+          RUBY_PACKAGE_REVISION: "7"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_2.6.8_debian-11_malloctrim"
+          ARTIFACT_NAME: "ruby-pkg_2.6.9_debian-11_malloctrim"
           ARTIFACT_PATH: output-malloctrim
 
 
@@ -1719,17 +1719,17 @@ jobs:
       - build_ruby_debian_11-2_6-jemalloc
       - build_ruby_debian_11-2_6-malloctrim
 
-      - build_ruby_debian_11-3_0_2-normal
-      - build_ruby_debian_11-3_0_2-jemalloc
-      - build_ruby_debian_11-3_0_2-malloctrim
+      - build_ruby_debian_11-3_0_3-normal
+      - build_ruby_debian_11-3_0_3-jemalloc
+      - build_ruby_debian_11-3_0_3-malloctrim
 
-      - build_ruby_debian_11-2_7_4-normal
-      - build_ruby_debian_11-2_7_4-jemalloc
-      - build_ruby_debian_11-2_7_4-malloctrim
+      - build_ruby_debian_11-2_7_5-normal
+      - build_ruby_debian_11-2_7_5-jemalloc
+      - build_ruby_debian_11-2_7_5-malloctrim
 
-      - build_ruby_debian_11-2_6_8-normal
-      - build_ruby_debian_11-2_6_8-jemalloc
-      - build_ruby_debian_11-2_6_8-malloctrim
+      - build_ruby_debian_11-2_6_9-normal
+      - build_ruby_debian_11-2_6_9-jemalloc
+      - build_ruby_debian_11-2_6_9-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -1761,7 +1761,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_3.0.2_debian-11_normal ruby-pkg_3.0.2_debian-11_jemalloc ruby-pkg_3.0.2_debian-11_malloctrim ruby-pkg_2.7.4_debian-11_normal ruby-pkg_2.7.4_debian-11_jemalloc ruby-pkg_2.7.4_debian-11_malloctrim ruby-pkg_2.6.8_debian-11_normal ruby-pkg_2.6.8_debian-11_jemalloc ruby-pkg_2.6.8_debian-11_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_3.0.3_debian-11_normal ruby-pkg_3.0.3_debian-11_jemalloc ruby-pkg_3.0.3_debian-11_malloctrim ruby-pkg_2.7.5_debian-11_normal ruby-pkg_2.7.5_debian-11_jemalloc ruby-pkg_2.7.5_debian-11_malloctrim ruby-pkg_2.6.9_debian-11_normal ruby-pkg_2.6.9_debian-11_jemalloc ruby-pkg_2.6.9_debian-11_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
       - name: Archive Ruby package artifact [ruby-pkg_3.0_debian-11_normal] to Github
@@ -1809,51 +1809,51 @@ jobs:
         with:
           name: ruby-pkg_2.6_debian-11_malloctrim
           path: artifacts/ruby-pkg_2.6_debian-11_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-11_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-11_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-11_normal
-          path: artifacts/ruby-pkg_3.0.2_debian-11_normal
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-11_jemalloc] to Github
+          name: ruby-pkg_3.0.3_debian-11_normal
+          path: artifacts/ruby-pkg_3.0.3_debian-11_normal
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-11_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-11_jemalloc
-          path: artifacts/ruby-pkg_3.0.2_debian-11_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_3.0.2_debian-11_malloctrim] to Github
+          name: ruby-pkg_3.0.3_debian-11_jemalloc
+          path: artifacts/ruby-pkg_3.0.3_debian-11_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_3.0.3_debian-11_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_3.0.2_debian-11_malloctrim
-          path: artifacts/ruby-pkg_3.0.2_debian-11_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-11_normal] to Github
+          name: ruby-pkg_3.0.3_debian-11_malloctrim
+          path: artifacts/ruby-pkg_3.0.3_debian-11_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-11_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-11_normal
-          path: artifacts/ruby-pkg_2.7.4_debian-11_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-11_jemalloc] to Github
+          name: ruby-pkg_2.7.5_debian-11_normal
+          path: artifacts/ruby-pkg_2.7.5_debian-11_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-11_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-11_jemalloc
-          path: artifacts/ruby-pkg_2.7.4_debian-11_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.7.4_debian-11_malloctrim] to Github
+          name: ruby-pkg_2.7.5_debian-11_jemalloc
+          path: artifacts/ruby-pkg_2.7.5_debian-11_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.7.5_debian-11_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.7.4_debian-11_malloctrim
-          path: artifacts/ruby-pkg_2.7.4_debian-11_malloctrim
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-11_normal] to Github
+          name: ruby-pkg_2.7.5_debian-11_malloctrim
+          path: artifacts/ruby-pkg_2.7.5_debian-11_malloctrim
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-11_normal] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-11_normal
-          path: artifacts/ruby-pkg_2.6.8_debian-11_normal
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-11_jemalloc] to Github
+          name: ruby-pkg_2.6.9_debian-11_normal
+          path: artifacts/ruby-pkg_2.6.9_debian-11_normal
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-11_jemalloc] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-11_jemalloc
-          path: artifacts/ruby-pkg_2.6.8_debian-11_jemalloc
-      - name: Archive Ruby package artifact [ruby-pkg_2.6.8_debian-11_malloctrim] to Github
+          name: ruby-pkg_2.6.9_debian-11_jemalloc
+          path: artifacts/ruby-pkg_2.6.9_debian-11_jemalloc
+      - name: Archive Ruby package artifact [ruby-pkg_2.6.9_debian-11_malloctrim] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-pkg_2.6.8_debian-11_malloctrim
-          path: artifacts/ruby-pkg_2.6.8_debian-11_malloctrim
+          name: ruby-pkg_2.6.9_debian-11_malloctrim
+          path: artifacts/ruby-pkg_2.6.9_debian-11_malloctrim
 
 
       ### Check whether dependent jobs failed ###
@@ -1900,33 +1900,33 @@ jobs:
             || (needs.build_ruby_debian_11-2_6-malloctrim.result != 'success'
               && (needs.build_ruby_debian_11-2_6-malloctrim.result != 'skipped'
                 || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6/malloctrim];')))
-            || (needs.build_ruby_debian_11-3_0_2-normal.result != 'success'
-              && (needs.build_ruby_debian_11-3_0_2-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/normal];')))
-            || (needs.build_ruby_debian_11-3_0_2-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_11-3_0_2-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/jemalloc];')))
-            || (needs.build_ruby_debian_11-3_0_2-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-3_0_2-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.2/malloctrim];')))
-            || (needs.build_ruby_debian_11-2_7_4-normal.result != 'success'
-              && (needs.build_ruby_debian_11-2_7_4-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/normal];')))
-            || (needs.build_ruby_debian_11-2_7_4-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_11-2_7_4-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/jemalloc];')))
-            || (needs.build_ruby_debian_11-2_7_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-2_7_4-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.4/malloctrim];')))
-            || (needs.build_ruby_debian_11-2_6_8-normal.result != 'success'
-              && (needs.build_ruby_debian_11-2_6_8-normal.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/normal];')))
-            || (needs.build_ruby_debian_11-2_6_8-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_11-2_6_8-jemalloc.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/jemalloc];')))
-            || (needs.build_ruby_debian_11-2_6_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-2_6_8-malloctrim.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.8/malloctrim];')))
+            || (needs.build_ruby_debian_11-3_0_3-normal.result != 'success'
+              && (needs.build_ruby_debian_11-3_0_3-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/normal];')))
+            || (needs.build_ruby_debian_11-3_0_3-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-3_0_3-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/jemalloc];')))
+            || (needs.build_ruby_debian_11-3_0_3-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_11-3_0_3-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/3.0.3/malloctrim];')))
+            || (needs.build_ruby_debian_11-2_7_5-normal.result != 'success'
+              && (needs.build_ruby_debian_11-2_7_5-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/normal];')))
+            || (needs.build_ruby_debian_11-2_7_5-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-2_7_5-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/jemalloc];')))
+            || (needs.build_ruby_debian_11-2_7_5-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_11-2_7_5-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.7.5/malloctrim];')))
+            || (needs.build_ruby_debian_11-2_6_9-normal.result != 'success'
+              && (needs.build_ruby_debian_11-2_6_9-normal.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/normal];')))
+            || (needs.build_ruby_debian_11-2_6_9-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-2_6_9-jemalloc.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/jemalloc];')))
+            || (needs.build_ruby_debian_11-2_6_9-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_11-2_6_9-malloctrim.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Build Ruby [debian-11/2.6.9/malloctrim];')))
 
 
       ### Trigger next workflow ###

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -417,12 +417,12 @@ jobs:
   ### Sources ###
 
 
-  download_ruby_source_3_0_2:
-    name: Download Ruby source [3.0.2]
+  download_ruby_source_3_0_3:
+    name: Download Ruby source [3.0.3]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.2;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.3;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -435,25 +435,25 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-3.0.2
+          key: v3-ruby-src-3.0.3
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 3.0.2
+          RUBY_VERSION: 3.0.3
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: output
-  download_ruby_source_2_7_4:
-    name: Download Ruby source [2.7.4]
+  download_ruby_source_2_7_5:
+    name: Download Ruby source [2.7.5]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.4;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.5;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -466,25 +466,25 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-2.7.4
+          key: v3-ruby-src-2.7.5
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 2.7.4
+          RUBY_VERSION: 2.7.5
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: output
-  download_ruby_source_2_6_8:
-    name: Download Ruby source [2.6.8]
+  download_ruby_source_2_6_9:
+    name: Download Ruby source [2.6.9]
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.8;')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.9;')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -497,18 +497,18 @@ jobs:
         uses: actions/cache@v1
         with:
           path: output
-          key: v3-ruby-src-2.6.8
+          key: v3-ruby-src-2.6.9
 
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         if: steps.fetch_cache.outputs.cache-hit != 'true'
         env:
-          RUBY_VERSION: 2.6.8
+          RUBY_VERSION: 2.6.9
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: output
 
 
@@ -742,9 +742,9 @@ jobs:
       - build_docker_image_ubuntu_18_04
       - build_docker_image_ubuntu_20_04
       - build_docker_image_utility
-      - download_ruby_source_3_0_2
-      - download_ruby_source_2_7_4
-      - download_ruby_source_2_6_8
+      - download_ruby_source_3_0_3
+      - download_ruby_source_2_7_5
+      - download_ruby_source_2_6_9
       - build_common_deb
       - build_common_rpm
       - build_rbenv_deb
@@ -897,38 +897,38 @@ jobs:
           path: artifacts
 
 
-      - name: Download Ruby source artifact [3.0.2] from Google Cloud
+      - name: Download Ruby source artifact [3.0.3] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.0.2
+          ARTIFACT_NAME: ruby-src-3.0.3
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [3.0.2] to Github
+      - name: Archive Ruby source artifact [3.0.3] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-3.0.2
+          name: ruby-src-3.0.3
           path: artifacts
-      - name: Download Ruby source artifact [2.7.4] from Google Cloud
+      - name: Download Ruby source artifact [2.7.5] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.7.4
+          ARTIFACT_NAME: ruby-src-2.7.5
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [2.7.4] to Github
+      - name: Archive Ruby source artifact [2.7.5] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-2.7.4
+          name: ruby-src-2.7.5
           path: artifacts
-      - name: Download Ruby source artifact [2.6.8] from Google Cloud
+      - name: Download Ruby source artifact [2.6.9] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-2.6.8
+          ARTIFACT_NAME: ruby-src-2.6.9
           ARTIFACT_PATH: artifacts
           CLEAR: true
-      - name: Archive Ruby source artifact [2.6.8] to Github
+      - name: Archive Ruby source artifact [2.6.9] to Github
         uses: actions/upload-artifact@v2
         with:
-          name: ruby-src-2.6.8
+          name: ruby-src-2.6.9
           path: artifacts
 
       - name: Download common DEB artifact from Google Cloud
@@ -1036,15 +1036,15 @@ jobs:
         run: 'false'
         if: |
           false
-            || (needs.download_ruby_source_3_0_2.result != 'success'
-              && (needs.download_ruby_source_3_0_2.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.2;')))
-            || (needs.download_ruby_source_2_7_4.result != 'success'
-              && (needs.download_ruby_source_2_7_4.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.4;')))
-            || (needs.download_ruby_source_2_6_8.result != 'success'
-              && (needs.download_ruby_source_2_6_8.result != 'skipped'
-                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.8;')))
+            || (needs.download_ruby_source_3_0_3.result != 'success'
+              && (needs.download_ruby_source_3_0_3.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 3.0.3;')))
+            || (needs.download_ruby_source_2_7_5.result != 'success'
+              && (needs.download_ruby_source_2_7_5.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.7.5;')))
+            || (needs.download_ruby_source_2_6_9.result != 'success'
+              && (needs.download_ruby_source_2_6_9.result != 'skipped'
+                || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Download Ruby source 2.6.9;')))
       - name: Check whether 'Build common DEB' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -97,7 +97,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.2_centos-7_normal ruby-pkg_3.0.2_centos-7_jemalloc ruby-pkg_3.0.2_centos-7_malloctrim ruby-pkg_3.0.2_centos-8_normal ruby-pkg_3.0.2_centos-8_jemalloc ruby-pkg_3.0.2_centos-8_malloctrim ruby-pkg_3.0.2_debian-10_normal ruby-pkg_3.0.2_debian-10_jemalloc ruby-pkg_3.0.2_debian-10_malloctrim ruby-pkg_3.0.2_debian-11_normal ruby-pkg_3.0.2_debian-11_jemalloc ruby-pkg_3.0.2_debian-11_malloctrim ruby-pkg_3.0.2_debian-9_normal ruby-pkg_3.0.2_debian-9_jemalloc ruby-pkg_3.0.2_debian-9_malloctrim ruby-pkg_3.0.2_ubuntu-18.04_normal ruby-pkg_3.0.2_ubuntu-18.04_jemalloc ruby-pkg_3.0.2_ubuntu-18.04_malloctrim ruby-pkg_3.0.2_ubuntu-20.04_normal ruby-pkg_3.0.2_ubuntu-20.04_jemalloc ruby-pkg_3.0.2_ubuntu-20.04_malloctrim ruby-pkg_2.7.4_centos-7_normal ruby-pkg_2.7.4_centos-7_jemalloc ruby-pkg_2.7.4_centos-7_malloctrim ruby-pkg_2.7.4_centos-8_normal ruby-pkg_2.7.4_centos-8_jemalloc ruby-pkg_2.7.4_centos-8_malloctrim ruby-pkg_2.7.4_debian-10_normal ruby-pkg_2.7.4_debian-10_jemalloc ruby-pkg_2.7.4_debian-10_malloctrim ruby-pkg_2.7.4_debian-11_normal ruby-pkg_2.7.4_debian-11_jemalloc ruby-pkg_2.7.4_debian-11_malloctrim ruby-pkg_2.7.4_debian-9_normal ruby-pkg_2.7.4_debian-9_jemalloc ruby-pkg_2.7.4_debian-9_malloctrim ruby-pkg_2.7.4_ubuntu-18.04_normal ruby-pkg_2.7.4_ubuntu-18.04_jemalloc ruby-pkg_2.7.4_ubuntu-18.04_malloctrim ruby-pkg_2.7.4_ubuntu-20.04_normal ruby-pkg_2.7.4_ubuntu-20.04_jemalloc ruby-pkg_2.7.4_ubuntu-20.04_malloctrim ruby-pkg_2.6.8_centos-7_normal ruby-pkg_2.6.8_centos-7_jemalloc ruby-pkg_2.6.8_centos-7_malloctrim ruby-pkg_2.6.8_centos-8_normal ruby-pkg_2.6.8_centos-8_jemalloc ruby-pkg_2.6.8_centos-8_malloctrim ruby-pkg_2.6.8_debian-10_normal ruby-pkg_2.6.8_debian-10_jemalloc ruby-pkg_2.6.8_debian-10_malloctrim ruby-pkg_2.6.8_debian-11_normal ruby-pkg_2.6.8_debian-11_jemalloc ruby-pkg_2.6.8_debian-11_malloctrim ruby-pkg_2.6.8_debian-9_normal ruby-pkg_2.6.8_debian-9_jemalloc ruby-pkg_2.6.8_debian-9_malloctrim ruby-pkg_2.6.8_ubuntu-18.04_normal ruby-pkg_2.6.8_ubuntu-18.04_jemalloc ruby-pkg_2.6.8_ubuntu-18.04_malloctrim ruby-pkg_2.6.8_ubuntu-20.04_normal ruby-pkg_2.6.8_ubuntu-20.04_jemalloc ruby-pkg_2.6.8_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.3_centos-7_normal ruby-pkg_3.0.3_centos-7_jemalloc ruby-pkg_3.0.3_centos-7_malloctrim ruby-pkg_3.0.3_centos-8_normal ruby-pkg_3.0.3_centos-8_jemalloc ruby-pkg_3.0.3_centos-8_malloctrim ruby-pkg_3.0.3_debian-10_normal ruby-pkg_3.0.3_debian-10_jemalloc ruby-pkg_3.0.3_debian-10_malloctrim ruby-pkg_3.0.3_debian-11_normal ruby-pkg_3.0.3_debian-11_jemalloc ruby-pkg_3.0.3_debian-11_malloctrim ruby-pkg_3.0.3_debian-9_normal ruby-pkg_3.0.3_debian-9_jemalloc ruby-pkg_3.0.3_debian-9_malloctrim ruby-pkg_3.0.3_ubuntu-18.04_normal ruby-pkg_3.0.3_ubuntu-18.04_jemalloc ruby-pkg_3.0.3_ubuntu-18.04_malloctrim ruby-pkg_3.0.3_ubuntu-20.04_normal ruby-pkg_3.0.3_ubuntu-20.04_jemalloc ruby-pkg_3.0.3_ubuntu-20.04_malloctrim ruby-pkg_2.7.5_centos-7_normal ruby-pkg_2.7.5_centos-7_jemalloc ruby-pkg_2.7.5_centos-7_malloctrim ruby-pkg_2.7.5_centos-8_normal ruby-pkg_2.7.5_centos-8_jemalloc ruby-pkg_2.7.5_centos-8_malloctrim ruby-pkg_2.7.5_debian-10_normal ruby-pkg_2.7.5_debian-10_jemalloc ruby-pkg_2.7.5_debian-10_malloctrim ruby-pkg_2.7.5_debian-11_normal ruby-pkg_2.7.5_debian-11_jemalloc ruby-pkg_2.7.5_debian-11_malloctrim ruby-pkg_2.7.5_debian-9_normal ruby-pkg_2.7.5_debian-9_jemalloc ruby-pkg_2.7.5_debian-9_malloctrim ruby-pkg_2.7.5_ubuntu-18.04_normal ruby-pkg_2.7.5_ubuntu-18.04_jemalloc ruby-pkg_2.7.5_ubuntu-18.04_malloctrim ruby-pkg_2.7.5_ubuntu-20.04_normal ruby-pkg_2.7.5_ubuntu-20.04_jemalloc ruby-pkg_2.7.5_ubuntu-20.04_malloctrim ruby-pkg_2.6.9_centos-7_normal ruby-pkg_2.6.9_centos-7_jemalloc ruby-pkg_2.6.9_centos-7_malloctrim ruby-pkg_2.6.9_centos-8_normal ruby-pkg_2.6.9_centos-8_jemalloc ruby-pkg_2.6.9_centos-8_malloctrim ruby-pkg_2.6.9_debian-10_normal ruby-pkg_2.6.9_debian-10_jemalloc ruby-pkg_2.6.9_debian-10_malloctrim ruby-pkg_2.6.9_debian-11_normal ruby-pkg_2.6.9_debian-11_jemalloc ruby-pkg_2.6.9_debian-11_malloctrim ruby-pkg_2.6.9_debian-9_normal ruby-pkg_2.6.9_debian-9_jemalloc ruby-pkg_2.6.9_debian-9_malloctrim ruby-pkg_2.6.9_ubuntu-18.04_normal ruby-pkg_2.6.9_ubuntu-18.04_jemalloc ruby-pkg_2.6.9_ubuntu-18.04_malloctrim ruby-pkg_2.6.9_ubuntu-20.04_normal ruby-pkg_2.6.9_ubuntu-20.04_jemalloc ruby-pkg_2.6.9_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -455,15 +455,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-7_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-3_0_2-normal:
-    name: 'Test [centos-7/3.0.2/normal]'
+  test_centos_7-3_0_3-normal:
+    name: 'Test [centos-7/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -475,7 +475,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -488,17 +488,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-3_0_2-jemalloc:
-    name: 'Test [centos-7/3.0.2/jemalloc]'
+  test_centos_7-3_0_3-jemalloc:
+    name: 'Test [centos-7/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -510,7 +510,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -523,17 +523,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-3_0_2-malloctrim:
-    name: 'Test [centos-7/3.0.2/malloctrim]'
+  test_centos_7-3_0_3-malloctrim:
+    name: 'Test [centos-7/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -545,7 +545,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -558,17 +558,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-2_7_4-normal:
-    name: 'Test [centos-7/2.7.4/normal]'
+  test_centos_7-2_7_5-normal:
+    name: 'Test [centos-7/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -580,7 +580,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -593,17 +593,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-2_7_4-jemalloc:
-    name: 'Test [centos-7/2.7.4/jemalloc]'
+  test_centos_7-2_7_5-jemalloc:
+    name: 'Test [centos-7/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -615,7 +615,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -628,17 +628,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-2_7_4-malloctrim:
-    name: 'Test [centos-7/2.7.4/malloctrim]'
+  test_centos_7-2_7_5-malloctrim:
+    name: 'Test [centos-7/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -650,7 +650,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -663,17 +663,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_7-2_6_8-normal:
-    name: 'Test [centos-7/2.6.8/normal]'
+  test_centos_7-2_6_9-normal:
+    name: 'Test [centos-7/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -685,7 +685,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -698,17 +698,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_7-2_6_8-jemalloc:
-    name: 'Test [centos-7/2.6.8/jemalloc]'
+  test_centos_7-2_6_9-jemalloc:
+    name: 'Test [centos-7/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -720,7 +720,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -733,17 +733,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_7-2_6_8-malloctrim:
-    name: 'Test [centos-7/2.6.8/malloctrim]'
+  test_centos_7-2_6_9-malloctrim:
+    name: 'Test [centos-7/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -755,7 +755,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -768,7 +768,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-7_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-7_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_centos_8-3_0-normal:
@@ -1086,15 +1086,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-3_0_2-normal:
-    name: 'Test [centos-8/3.0.2/normal]'
+  test_centos_8-3_0_3-normal:
+    name: 'Test [centos-8/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1106,7 +1106,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1119,17 +1119,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-3_0_2-jemalloc:
-    name: 'Test [centos-8/3.0.2/jemalloc]'
+  test_centos_8-3_0_3-jemalloc:
+    name: 'Test [centos-8/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1141,7 +1141,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1154,17 +1154,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-3_0_2-malloctrim:
-    name: 'Test [centos-8/3.0.2/malloctrim]'
+  test_centos_8-3_0_3-malloctrim:
+    name: 'Test [centos-8/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1176,7 +1176,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1189,17 +1189,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-2_7_4-normal:
-    name: 'Test [centos-8/2.7.4/normal]'
+  test_centos_8-2_7_5-normal:
+    name: 'Test [centos-8/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1211,7 +1211,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1224,17 +1224,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-2_7_4-jemalloc:
-    name: 'Test [centos-8/2.7.4/jemalloc]'
+  test_centos_8-2_7_5-jemalloc:
+    name: 'Test [centos-8/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1246,7 +1246,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1259,17 +1259,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-2_7_4-malloctrim:
-    name: 'Test [centos-8/2.7.4/malloctrim]'
+  test_centos_8-2_7_5-malloctrim:
+    name: 'Test [centos-8/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1281,7 +1281,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1294,17 +1294,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_centos_8-2_6_8-normal:
-    name: 'Test [centos-8/2.6.8/normal]'
+  test_centos_8-2_6_9-normal:
+    name: 'Test [centos-8/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1316,7 +1316,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1329,17 +1329,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_centos_8-2_6_8-jemalloc:
-    name: 'Test [centos-8/2.6.8/jemalloc]'
+  test_centos_8-2_6_9-jemalloc:
+    name: 'Test [centos-8/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1351,7 +1351,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1364,17 +1364,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_centos_8-2_6_8-malloctrim:
-    name: 'Test [centos-8/2.6.8/malloctrim]'
+  test_centos_8-2_6_9-malloctrim:
+    name: 'Test [centos-8/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1386,7 +1386,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1399,7 +1399,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-centos-8_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_10-3_0-normal:
@@ -1717,15 +1717,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-10_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-3_0_2-normal:
-    name: 'Test [debian-10/3.0.2/normal]'
+  test_debian_10-3_0_3-normal:
+    name: 'Test [debian-10/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1737,7 +1737,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1750,17 +1750,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-3_0_2-jemalloc:
-    name: 'Test [debian-10/3.0.2/jemalloc]'
+  test_debian_10-3_0_3-jemalloc:
+    name: 'Test [debian-10/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1772,7 +1772,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1785,17 +1785,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-3_0_2-malloctrim:
-    name: 'Test [debian-10/3.0.2/malloctrim]'
+  test_debian_10-3_0_3-malloctrim:
+    name: 'Test [debian-10/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1807,7 +1807,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1820,17 +1820,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-2_7_4-normal:
-    name: 'Test [debian-10/2.7.4/normal]'
+  test_debian_10-2_7_5-normal:
+    name: 'Test [debian-10/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1842,7 +1842,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1855,17 +1855,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-2_7_4-jemalloc:
-    name: 'Test [debian-10/2.7.4/jemalloc]'
+  test_debian_10-2_7_5-jemalloc:
+    name: 'Test [debian-10/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1877,7 +1877,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1890,17 +1890,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-2_7_4-malloctrim:
-    name: 'Test [debian-10/2.7.4/malloctrim]'
+  test_debian_10-2_7_5-malloctrim:
+    name: 'Test [debian-10/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1912,7 +1912,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1925,17 +1925,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_10-2_6_8-normal:
-    name: 'Test [debian-10/2.6.8/normal]'
+  test_debian_10-2_6_9-normal:
+    name: 'Test [debian-10/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1947,7 +1947,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1960,17 +1960,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_10-2_6_8-jemalloc:
-    name: 'Test [debian-10/2.6.8/jemalloc]'
+  test_debian_10-2_6_9-jemalloc:
+    name: 'Test [debian-10/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1982,7 +1982,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1995,17 +1995,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_10-2_6_8-malloctrim:
-    name: 'Test [debian-10/2.6.8/malloctrim]'
+  test_debian_10-2_6_9-malloctrim:
+    name: 'Test [debian-10/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2017,7 +2017,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2030,7 +2030,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-10_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-10_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_11-3_0-normal:
@@ -2348,15 +2348,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-11_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_11-3_0_2-normal:
-    name: 'Test [debian-11/3.0.2/normal]'
+  test_debian_11-3_0_3-normal:
+    name: 'Test [debian-11/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2368,7 +2368,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2381,17 +2381,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-debian-11_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_11-3_0_2-jemalloc:
-    name: 'Test [debian-11/3.0.2/jemalloc]'
+  test_debian_11-3_0_3-jemalloc:
+    name: 'Test [debian-11/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2403,7 +2403,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2416,17 +2416,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-11_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_11-3_0_2-malloctrim:
-    name: 'Test [debian-11/3.0.2/malloctrim]'
+  test_debian_11-3_0_3-malloctrim:
+    name: 'Test [debian-11/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2438,7 +2438,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2451,17 +2451,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-11_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_11-2_7_4-normal:
-    name: 'Test [debian-11/2.7.4/normal]'
+  test_debian_11-2_7_5-normal:
+    name: 'Test [debian-11/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2473,7 +2473,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2486,17 +2486,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-debian-11_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_11-2_7_4-jemalloc:
-    name: 'Test [debian-11/2.7.4/jemalloc]'
+  test_debian_11-2_7_5-jemalloc:
+    name: 'Test [debian-11/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2508,7 +2508,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2521,17 +2521,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-11_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_11-2_7_4-malloctrim:
-    name: 'Test [debian-11/2.7.4/malloctrim]'
+  test_debian_11-2_7_5-malloctrim:
+    name: 'Test [debian-11/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2543,7 +2543,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2556,17 +2556,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-11_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_11-2_6_8-normal:
-    name: 'Test [debian-11/2.6.8/normal]'
+  test_debian_11-2_6_9-normal:
+    name: 'Test [debian-11/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2578,7 +2578,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2591,17 +2591,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-debian-11_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_11-2_6_8-jemalloc:
-    name: 'Test [debian-11/2.6.8/jemalloc]'
+  test_debian_11-2_6_9-jemalloc:
+    name: 'Test [debian-11/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2613,7 +2613,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2626,17 +2626,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-11_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_11-2_6_8-malloctrim:
-    name: 'Test [debian-11/2.6.8/malloctrim]'
+  test_debian_11-2_6_9-malloctrim:
+    name: 'Test [debian-11/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2648,7 +2648,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2661,7 +2661,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-11_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_debian_9-3_0-normal:
@@ -2979,15 +2979,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-9_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-3_0_2-normal:
-    name: 'Test [debian-9/3.0.2/normal]'
+  test_debian_9-3_0_3-normal:
+    name: 'Test [debian-9/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2999,7 +2999,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3012,17 +3012,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-3_0_2-jemalloc:
-    name: 'Test [debian-9/3.0.2/jemalloc]'
+  test_debian_9-3_0_3-jemalloc:
+    name: 'Test [debian-9/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3034,7 +3034,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3047,17 +3047,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-3_0_2-malloctrim:
-    name: 'Test [debian-9/3.0.2/malloctrim]'
+  test_debian_9-3_0_3-malloctrim:
+    name: 'Test [debian-9/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3069,7 +3069,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3082,17 +3082,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-2_7_4-normal:
-    name: 'Test [debian-9/2.7.4/normal]'
+  test_debian_9-2_7_5-normal:
+    name: 'Test [debian-9/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3104,7 +3104,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3117,17 +3117,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-2_7_4-jemalloc:
-    name: 'Test [debian-9/2.7.4/jemalloc]'
+  test_debian_9-2_7_5-jemalloc:
+    name: 'Test [debian-9/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3139,7 +3139,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3152,17 +3152,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-2_7_4-malloctrim:
-    name: 'Test [debian-9/2.7.4/malloctrim]'
+  test_debian_9-2_7_5-malloctrim:
+    name: 'Test [debian-9/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3174,7 +3174,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3187,17 +3187,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_debian_9-2_6_8-normal:
-    name: 'Test [debian-9/2.6.8/normal]'
+  test_debian_9-2_6_9-normal:
+    name: 'Test [debian-9/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3209,7 +3209,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3222,17 +3222,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_debian_9-2_6_8-jemalloc:
-    name: 'Test [debian-9/2.6.8/jemalloc]'
+  test_debian_9-2_6_9-jemalloc:
+    name: 'Test [debian-9/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3244,7 +3244,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3257,17 +3257,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_debian_9-2_6_8-malloctrim:
-    name: 'Test [debian-9/2.6.8/malloctrim]'
+  test_debian_9-2_6_9-malloctrim:
+    name: 'Test [debian-9/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3279,7 +3279,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3292,7 +3292,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-9_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-debian-9_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_18_04-3_0-normal:
@@ -3610,15 +3610,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-3_0_2-normal:
-    name: 'Test [ubuntu-18.04/3.0.2/normal]'
+  test_ubuntu_18_04-3_0_3-normal:
+    name: 'Test [ubuntu-18.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3630,7 +3630,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3643,17 +3643,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-3_0_2-jemalloc:
-    name: 'Test [ubuntu-18.04/3.0.2/jemalloc]'
+  test_ubuntu_18_04-3_0_3-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3665,7 +3665,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3678,17 +3678,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-3_0_2-malloctrim:
-    name: 'Test [ubuntu-18.04/3.0.2/malloctrim]'
+  test_ubuntu_18_04-3_0_3-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3700,7 +3700,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3713,17 +3713,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-2_7_4-normal:
-    name: 'Test [ubuntu-18.04/2.7.4/normal]'
+  test_ubuntu_18_04-2_7_5-normal:
+    name: 'Test [ubuntu-18.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3735,7 +3735,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3748,17 +3748,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-2_7_4-jemalloc:
-    name: 'Test [ubuntu-18.04/2.7.4/jemalloc]'
+  test_ubuntu_18_04-2_7_5-jemalloc:
+    name: 'Test [ubuntu-18.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3770,7 +3770,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3783,17 +3783,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-2_7_4-malloctrim:
-    name: 'Test [ubuntu-18.04/2.7.4/malloctrim]'
+  test_ubuntu_18_04-2_7_5-malloctrim:
+    name: 'Test [ubuntu-18.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3805,7 +3805,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3818,17 +3818,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_18_04-2_6_8-normal:
-    name: 'Test [ubuntu-18.04/2.6.8/normal]'
+  test_ubuntu_18_04-2_6_9-normal:
+    name: 'Test [ubuntu-18.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3840,7 +3840,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3853,17 +3853,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_18_04-2_6_8-jemalloc:
-    name: 'Test [ubuntu-18.04/2.6.8/jemalloc]'
+  test_ubuntu_18_04-2_6_9-jemalloc:
+    name: 'Test [ubuntu-18.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3875,7 +3875,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3888,17 +3888,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_18_04-2_6_8-malloctrim:
-    name: 'Test [ubuntu-18.04/2.6.8/malloctrim]'
+  test_ubuntu_18_04-2_6_9-malloctrim:
+    name: 'Test [ubuntu-18.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3910,7 +3910,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3923,7 +3923,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-18.04_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
   test_ubuntu_20_04-3_0-normal:
@@ -4241,15 +4241,15 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-3_0_2-normal:
-    name: 'Test [ubuntu-20.04/3.0.2/normal]'
+  test_ubuntu_20_04-3_0_3-normal:
+    name: 'Test [ubuntu-20.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4261,7 +4261,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4274,17 +4274,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.2_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.3_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-3_0_2-jemalloc:
-    name: 'Test [ubuntu-20.04/3.0.2/jemalloc]'
+  test_ubuntu_20_04-3_0_3-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4296,7 +4296,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4309,17 +4309,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-3_0_2-malloctrim:
-    name: 'Test [ubuntu-20.04/3.0.2/malloctrim]'
+  test_ubuntu_20_04-3_0_3-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4331,7 +4331,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4344,17 +4344,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-2_7_4-normal:
-    name: 'Test [ubuntu-20.04/2.7.4/normal]'
+  test_ubuntu_20_04-2_7_5-normal:
+    name: 'Test [ubuntu-20.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4366,7 +4366,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4379,17 +4379,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.4_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.5_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-2_7_4-jemalloc:
-    name: 'Test [ubuntu-20.04/2.7.4/jemalloc]'
+  test_ubuntu_20_04-2_7_5-jemalloc:
+    name: 'Test [ubuntu-20.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4401,7 +4401,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4414,17 +4414,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-2_7_4-malloctrim:
-    name: 'Test [ubuntu-20.04/2.7.4/malloctrim]'
+  test_ubuntu_20_04-2_7_5-malloctrim:
+    name: 'Test [ubuntu-20.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4436,7 +4436,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4449,17 +4449,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
-  test_ubuntu_20_04-2_6_8-normal:
-    name: 'Test [ubuntu-20.04/2.6.8/normal]'
+  test_ubuntu_20_04-2_6_9-normal:
+    name: 'Test [ubuntu-20.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/normal];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4471,7 +4471,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4484,17 +4484,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.8_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.9_normal
           ARTIFACT_PATH: mark-normal
-  test_ubuntu_20_04-2_6_8-jemalloc:
-    name: 'Test [ubuntu-20.04/2.6.8/jemalloc]'
+  test_ubuntu_20_04-2_6_9-jemalloc:
+    name: 'Test [ubuntu-20.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/jemalloc];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4506,7 +4506,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4519,17 +4519,17 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-  test_ubuntu_20_04-2_6_8-malloctrim:
-    name: 'Test [ubuntu-20.04/2.6.8/malloctrim]'
+  test_ubuntu_20_04-2_6_9-malloctrim:
+    name: 'Test [ubuntu-20.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
     if: |
       github.ref == 'refs/heads/main'
-      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/malloctrim];')
+      && contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4541,7 +4541,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4554,7 +4554,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-production-ubuntu-20.04_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -4579,15 +4579,15 @@ jobs:
       - test_centos_7-2_6-normal
       - test_centos_7-2_6-jemalloc
       - test_centos_7-2_6-malloctrim
-      - test_centos_7-3_0_2-normal
-      - test_centos_7-3_0_2-jemalloc
-      - test_centos_7-3_0_2-malloctrim
-      - test_centos_7-2_7_4-normal
-      - test_centos_7-2_7_4-jemalloc
-      - test_centos_7-2_7_4-malloctrim
-      - test_centos_7-2_6_8-normal
-      - test_centos_7-2_6_8-jemalloc
-      - test_centos_7-2_6_8-malloctrim
+      - test_centos_7-3_0_3-normal
+      - test_centos_7-3_0_3-jemalloc
+      - test_centos_7-3_0_3-malloctrim
+      - test_centos_7-2_7_5-normal
+      - test_centos_7-2_7_5-jemalloc
+      - test_centos_7-2_7_5-malloctrim
+      - test_centos_7-2_6_9-normal
+      - test_centos_7-2_6_9-jemalloc
+      - test_centos_7-2_6_9-malloctrim
       - test_centos_8-3_0-normal
       - test_centos_8-3_0-jemalloc
       - test_centos_8-3_0-malloctrim
@@ -4597,15 +4597,15 @@ jobs:
       - test_centos_8-2_6-normal
       - test_centos_8-2_6-jemalloc
       - test_centos_8-2_6-malloctrim
-      - test_centos_8-3_0_2-normal
-      - test_centos_8-3_0_2-jemalloc
-      - test_centos_8-3_0_2-malloctrim
-      - test_centos_8-2_7_4-normal
-      - test_centos_8-2_7_4-jemalloc
-      - test_centos_8-2_7_4-malloctrim
-      - test_centos_8-2_6_8-normal
-      - test_centos_8-2_6_8-jemalloc
-      - test_centos_8-2_6_8-malloctrim
+      - test_centos_8-3_0_3-normal
+      - test_centos_8-3_0_3-jemalloc
+      - test_centos_8-3_0_3-malloctrim
+      - test_centos_8-2_7_5-normal
+      - test_centos_8-2_7_5-jemalloc
+      - test_centos_8-2_7_5-malloctrim
+      - test_centos_8-2_6_9-normal
+      - test_centos_8-2_6_9-jemalloc
+      - test_centos_8-2_6_9-malloctrim
       - test_debian_10-3_0-normal
       - test_debian_10-3_0-jemalloc
       - test_debian_10-3_0-malloctrim
@@ -4615,15 +4615,15 @@ jobs:
       - test_debian_10-2_6-normal
       - test_debian_10-2_6-jemalloc
       - test_debian_10-2_6-malloctrim
-      - test_debian_10-3_0_2-normal
-      - test_debian_10-3_0_2-jemalloc
-      - test_debian_10-3_0_2-malloctrim
-      - test_debian_10-2_7_4-normal
-      - test_debian_10-2_7_4-jemalloc
-      - test_debian_10-2_7_4-malloctrim
-      - test_debian_10-2_6_8-normal
-      - test_debian_10-2_6_8-jemalloc
-      - test_debian_10-2_6_8-malloctrim
+      - test_debian_10-3_0_3-normal
+      - test_debian_10-3_0_3-jemalloc
+      - test_debian_10-3_0_3-malloctrim
+      - test_debian_10-2_7_5-normal
+      - test_debian_10-2_7_5-jemalloc
+      - test_debian_10-2_7_5-malloctrim
+      - test_debian_10-2_6_9-normal
+      - test_debian_10-2_6_9-jemalloc
+      - test_debian_10-2_6_9-malloctrim
       - test_debian_11-3_0-normal
       - test_debian_11-3_0-jemalloc
       - test_debian_11-3_0-malloctrim
@@ -4633,15 +4633,15 @@ jobs:
       - test_debian_11-2_6-normal
       - test_debian_11-2_6-jemalloc
       - test_debian_11-2_6-malloctrim
-      - test_debian_11-3_0_2-normal
-      - test_debian_11-3_0_2-jemalloc
-      - test_debian_11-3_0_2-malloctrim
-      - test_debian_11-2_7_4-normal
-      - test_debian_11-2_7_4-jemalloc
-      - test_debian_11-2_7_4-malloctrim
-      - test_debian_11-2_6_8-normal
-      - test_debian_11-2_6_8-jemalloc
-      - test_debian_11-2_6_8-malloctrim
+      - test_debian_11-3_0_3-normal
+      - test_debian_11-3_0_3-jemalloc
+      - test_debian_11-3_0_3-malloctrim
+      - test_debian_11-2_7_5-normal
+      - test_debian_11-2_7_5-jemalloc
+      - test_debian_11-2_7_5-malloctrim
+      - test_debian_11-2_6_9-normal
+      - test_debian_11-2_6_9-jemalloc
+      - test_debian_11-2_6_9-malloctrim
       - test_debian_9-3_0-normal
       - test_debian_9-3_0-jemalloc
       - test_debian_9-3_0-malloctrim
@@ -4651,15 +4651,15 @@ jobs:
       - test_debian_9-2_6-normal
       - test_debian_9-2_6-jemalloc
       - test_debian_9-2_6-malloctrim
-      - test_debian_9-3_0_2-normal
-      - test_debian_9-3_0_2-jemalloc
-      - test_debian_9-3_0_2-malloctrim
-      - test_debian_9-2_7_4-normal
-      - test_debian_9-2_7_4-jemalloc
-      - test_debian_9-2_7_4-malloctrim
-      - test_debian_9-2_6_8-normal
-      - test_debian_9-2_6_8-jemalloc
-      - test_debian_9-2_6_8-malloctrim
+      - test_debian_9-3_0_3-normal
+      - test_debian_9-3_0_3-jemalloc
+      - test_debian_9-3_0_3-malloctrim
+      - test_debian_9-2_7_5-normal
+      - test_debian_9-2_7_5-jemalloc
+      - test_debian_9-2_7_5-malloctrim
+      - test_debian_9-2_6_9-normal
+      - test_debian_9-2_6_9-jemalloc
+      - test_debian_9-2_6_9-malloctrim
       - test_ubuntu_18_04-3_0-normal
       - test_ubuntu_18_04-3_0-jemalloc
       - test_ubuntu_18_04-3_0-malloctrim
@@ -4669,15 +4669,15 @@ jobs:
       - test_ubuntu_18_04-2_6-normal
       - test_ubuntu_18_04-2_6-jemalloc
       - test_ubuntu_18_04-2_6-malloctrim
-      - test_ubuntu_18_04-3_0_2-normal
-      - test_ubuntu_18_04-3_0_2-jemalloc
-      - test_ubuntu_18_04-3_0_2-malloctrim
-      - test_ubuntu_18_04-2_7_4-normal
-      - test_ubuntu_18_04-2_7_4-jemalloc
-      - test_ubuntu_18_04-2_7_4-malloctrim
-      - test_ubuntu_18_04-2_6_8-normal
-      - test_ubuntu_18_04-2_6_8-jemalloc
-      - test_ubuntu_18_04-2_6_8-malloctrim
+      - test_ubuntu_18_04-3_0_3-normal
+      - test_ubuntu_18_04-3_0_3-jemalloc
+      - test_ubuntu_18_04-3_0_3-malloctrim
+      - test_ubuntu_18_04-2_7_5-normal
+      - test_ubuntu_18_04-2_7_5-jemalloc
+      - test_ubuntu_18_04-2_7_5-malloctrim
+      - test_ubuntu_18_04-2_6_9-normal
+      - test_ubuntu_18_04-2_6_9-jemalloc
+      - test_ubuntu_18_04-2_6_9-malloctrim
       - test_ubuntu_20_04-3_0-normal
       - test_ubuntu_20_04-3_0-jemalloc
       - test_ubuntu_20_04-3_0-malloctrim
@@ -4687,15 +4687,15 @@ jobs:
       - test_ubuntu_20_04-2_6-normal
       - test_ubuntu_20_04-2_6-jemalloc
       - test_ubuntu_20_04-2_6-malloctrim
-      - test_ubuntu_20_04-3_0_2-normal
-      - test_ubuntu_20_04-3_0_2-jemalloc
-      - test_ubuntu_20_04-3_0_2-malloctrim
-      - test_ubuntu_20_04-2_7_4-normal
-      - test_ubuntu_20_04-2_7_4-jemalloc
-      - test_ubuntu_20_04-2_7_4-malloctrim
-      - test_ubuntu_20_04-2_6_8-normal
-      - test_ubuntu_20_04-2_6_8-jemalloc
-      - test_ubuntu_20_04-2_6_8-malloctrim
+      - test_ubuntu_20_04-3_0_3-normal
+      - test_ubuntu_20_04-3_0_3-jemalloc
+      - test_ubuntu_20_04-3_0_3-malloctrim
+      - test_ubuntu_20_04-2_7_5-normal
+      - test_ubuntu_20_04-2_7_5-jemalloc
+      - test_ubuntu_20_04-2_7_5-malloctrim
+      - test_ubuntu_20_04-2_6_9-normal
+      - test_ubuntu_20_04-2_6_9-jemalloc
+      - test_ubuntu_20_04-2_6_9-malloctrim
     if: 'always()'
     steps:
       - uses: actions/checkout@v2
@@ -4773,69 +4773,69 @@ jobs:
           && needs.test_centos_7-2_6-malloctrim.result != 'success'
           && (needs.test_centos_7-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-7/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [centos-7/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_2-normal.result != 'success'
-          && (needs.test_centos_7-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/normal];'))
-      - name: Check whether 'Test [centos-7/3.0.2/jemalloc]' did not fail
+          && needs.test_centos_7-3_0_3-normal.result != 'success'
+          && (needs.test_centos_7-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_2-jemalloc.result != 'success'
-          && (needs.test_centos_7-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [centos-7/3.0.2/malloctrim]' did not fail
+          && needs.test_centos_7-3_0_3-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-3_0_2-malloctrim.result != 'success'
-          && (needs.test_centos_7-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.7.4/normal]' did not fail
+          && needs.test_centos_7-3_0_3-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_4-normal.result != 'success'
-          && (needs.test_centos_7-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/normal];'))
-      - name: Check whether 'Test [centos-7/2.7.4/jemalloc]' did not fail
+          && needs.test_centos_7-2_7_5-normal.result != 'success'
+          && (needs.test_centos_7-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/normal];'))
+      - name: Check whether 'Test [centos-7/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_4-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.7.4/malloctrim]' did not fail
+          && needs.test_centos_7-2_7_5-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_7_4-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.6.8/normal]' did not fail
+          && needs.test_centos_7-2_7_5-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_8-normal.result != 'success'
-          && (needs.test_centos_7-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/normal];'))
-      - name: Check whether 'Test [centos-7/2.6.8/jemalloc]' did not fail
+          && needs.test_centos_7-2_6_9-normal.result != 'success'
+          && (needs.test_centos_7-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/normal];'))
+      - name: Check whether 'Test [centos-7/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_8-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.6.8/malloctrim]' did not fail
+          && needs.test_centos_7-2_6_9-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_7-2_6_8-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.8/malloctrim];'))
+          && needs.test_centos_7-2_6_9-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-7/2.6.9/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4899,69 +4899,69 @@ jobs:
           && needs.test_centos_8-2_6-malloctrim.result != 'success'
           && (needs.test_centos_8-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-8/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [centos-8/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_2-normal.result != 'success'
-          && (needs.test_centos_8-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/normal];'))
-      - name: Check whether 'Test [centos-8/3.0.2/jemalloc]' did not fail
+          && needs.test_centos_8-3_0_3-normal.result != 'success'
+          && (needs.test_centos_8-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_2-jemalloc.result != 'success'
-          && (needs.test_centos_8-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.0.2/malloctrim]' did not fail
+          && needs.test_centos_8-3_0_3-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_0_2-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.7.4/normal]' did not fail
+          && needs.test_centos_8-3_0_3-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_4-normal.result != 'success'
-          && (needs.test_centos_8-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/normal];'))
-      - name: Check whether 'Test [centos-8/2.7.4/jemalloc]' did not fail
+          && needs.test_centos_8-2_7_5-normal.result != 'success'
+          && (needs.test_centos_8-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/normal];'))
+      - name: Check whether 'Test [centos-8/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_4-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.7.4/malloctrim]' did not fail
+          && needs.test_centos_8-2_7_5-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_7_4-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.6.8/normal]' did not fail
+          && needs.test_centos_8-2_7_5-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_8-normal.result != 'success'
-          && (needs.test_centos_8-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/normal];'))
-      - name: Check whether 'Test [centos-8/2.6.8/jemalloc]' did not fail
+          && needs.test_centos_8-2_6_9-normal.result != 'success'
+          && (needs.test_centos_8-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/normal];'))
+      - name: Check whether 'Test [centos-8/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_8-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.6.8/malloctrim]' did not fail
+          && needs.test_centos_8-2_6_9-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-2_6_8-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.8/malloctrim];'))
+          && needs.test_centos_8-2_6_9-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [centos-8/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5025,69 +5025,69 @@ jobs:
           && needs.test_debian_10-2_6-malloctrim.result != 'success'
           && (needs.test_debian_10-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-10/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-10/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_2-normal.result != 'success'
-          && (needs.test_debian_10-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-10/3.0.2/jemalloc]' did not fail
+          && needs.test_debian_10-3_0_3-normal.result != 'success'
+          && (needs.test_debian_10-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_10-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-10/3.0.2/malloctrim]' did not fail
+          && needs.test_debian_10-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_10-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.7.4/normal]' did not fail
+          && needs.test_debian_10-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_4-normal.result != 'success'
-          && (needs.test_debian_10-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-10/2.7.4/jemalloc]' did not fail
+          && needs.test_debian_10-2_7_5-normal.result != 'success'
+          && (needs.test_debian_10-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-10/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.7.4/malloctrim]' did not fail
+          && needs.test_debian_10-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.6.8/normal]' did not fail
+          && needs.test_debian_10-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_8-normal.result != 'success'
-          && (needs.test_debian_10-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-10/2.6.8/jemalloc]' did not fail
+          && needs.test_debian_10-2_6_9-normal.result != 'success'
+          && (needs.test_debian_10-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-10/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.6.8/malloctrim]' did not fail
+          && needs.test_debian_10-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_10-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.8/malloctrim];'))
+          && needs.test_debian_10-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-10/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5151,69 +5151,69 @@ jobs:
           && needs.test_debian_11-2_6-malloctrim.result != 'success'
           && (needs.test_debian_11-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-11/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-11/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_0_2-normal.result != 'success'
-          && (needs.test_debian_11-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-11/3.0.2/jemalloc]' did not fail
+          && needs.test_debian_11-3_0_3-normal.result != 'success'
+          && (needs.test_debian_11-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-11/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_11-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.0.2/malloctrim]' did not fail
+          && needs.test_debian_11-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_11-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-11/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-11/2.7.4/normal]' did not fail
+          && needs.test_debian_11-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_11-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-11/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_7_4-normal.result != 'success'
-          && (needs.test_debian_11-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-11/2.7.4/jemalloc]' did not fail
+          && needs.test_debian_11-2_7_5-normal.result != 'success'
+          && (needs.test_debian_11-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-11/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_11-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-11/2.7.4/malloctrim]' did not fail
+          && needs.test_debian_11-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_11-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-11/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_11-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-11/2.6.8/normal]' did not fail
+          && needs.test_debian_11-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_11-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-11/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_6_8-normal.result != 'success'
-          && (needs.test_debian_11-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-11/2.6.8/jemalloc]' did not fail
+          && needs.test_debian_11-2_6_9-normal.result != 'success'
+          && (needs.test_debian_11-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-11/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_11-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-11/2.6.8/malloctrim]' did not fail
+          && needs.test_debian_11-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_11-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-11/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_11-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.8/malloctrim];'))
+          && needs.test_debian_11-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_11-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-11/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5277,69 +5277,69 @@ jobs:
           && needs.test_debian_9-2_6-malloctrim.result != 'success'
           && (needs.test_debian_9-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-9/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-9/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_2-normal.result != 'success'
-          && (needs.test_debian_9-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-9/3.0.2/jemalloc]' did not fail
+          && needs.test_debian_9-3_0_3-normal.result != 'success'
+          && (needs.test_debian_9-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_9-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-9/3.0.2/malloctrim]' did not fail
+          && needs.test_debian_9-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_9-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.7.4/normal]' did not fail
+          && needs.test_debian_9-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_4-normal.result != 'success'
-          && (needs.test_debian_9-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-9/2.7.4/jemalloc]' did not fail
+          && needs.test_debian_9-2_7_5-normal.result != 'success'
+          && (needs.test_debian_9-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-9/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.7.4/malloctrim]' did not fail
+          && needs.test_debian_9-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.6.8/normal]' did not fail
+          && needs.test_debian_9-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_8-normal.result != 'success'
-          && (needs.test_debian_9-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-9/2.6.8/jemalloc]' did not fail
+          && needs.test_debian_9-2_6_9-normal.result != 'success'
+          && (needs.test_debian_9-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-9/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.6.8/malloctrim]' did not fail
+          && needs.test_debian_9-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_9-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.8/malloctrim];'))
+          && needs.test_debian_9-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [debian-9/2.6.9/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5403,69 +5403,69 @@ jobs:
           && needs.test_ubuntu_18_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_2-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-3_0_3-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-3_0_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-3_0_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/normal]' did not fail
+          && needs.test_ubuntu_18_04-3_0_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_4-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-2_7_5-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_4-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-2_7_5-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_7_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/normal]' did not fail
+          && needs.test_ubuntu_18_04-2_7_5-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_8-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/jemalloc]' did not fail
+          && needs.test_ubuntu_18_04-2_6_9-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_8-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/malloctrim]' did not fail
+          && needs.test_ubuntu_18_04-2_6_9-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_18_04-2_6_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.8/malloctrim];'))
+          && needs.test_ubuntu_18_04-2_6_9-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-18.04/2.6.9/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5529,69 +5529,69 @@ jobs:
           && needs.test_ubuntu_20_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_2-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-3_0_3-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-3_0_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-3_0_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/normal]' did not fail
+          && needs.test_ubuntu_20_04-3_0_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_4-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-2_7_5-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_4-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-2_7_5-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_7_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/normal]' did not fail
+          && needs.test_ubuntu_20_04-2_7_5-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_8-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/jemalloc]' did not fail
+          && needs.test_ubuntu_20_04-2_6_9-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_8-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/malloctrim]' did not fail
+          && needs.test_ubuntu_20_04-2_6_9-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_20_04-2_6_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.8/malloctrim];'))
+          && needs.test_ubuntu_20_04-2_6_9-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against production repo [ubuntu-20.04/2.6.9/malloctrim];'))
 
 
       ### Create Git tag ###

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -96,7 +96,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.2_centos-7_normal ruby-pkg_3.0.2_centos-7_jemalloc ruby-pkg_3.0.2_centos-7_malloctrim ruby-pkg_3.0.2_centos-8_normal ruby-pkg_3.0.2_centos-8_jemalloc ruby-pkg_3.0.2_centos-8_malloctrim ruby-pkg_3.0.2_debian-10_normal ruby-pkg_3.0.2_debian-10_jemalloc ruby-pkg_3.0.2_debian-10_malloctrim ruby-pkg_3.0.2_debian-11_normal ruby-pkg_3.0.2_debian-11_jemalloc ruby-pkg_3.0.2_debian-11_malloctrim ruby-pkg_3.0.2_debian-9_normal ruby-pkg_3.0.2_debian-9_jemalloc ruby-pkg_3.0.2_debian-9_malloctrim ruby-pkg_3.0.2_ubuntu-18.04_normal ruby-pkg_3.0.2_ubuntu-18.04_jemalloc ruby-pkg_3.0.2_ubuntu-18.04_malloctrim ruby-pkg_3.0.2_ubuntu-20.04_normal ruby-pkg_3.0.2_ubuntu-20.04_jemalloc ruby-pkg_3.0.2_ubuntu-20.04_malloctrim ruby-pkg_2.7.4_centos-7_normal ruby-pkg_2.7.4_centos-7_jemalloc ruby-pkg_2.7.4_centos-7_malloctrim ruby-pkg_2.7.4_centos-8_normal ruby-pkg_2.7.4_centos-8_jemalloc ruby-pkg_2.7.4_centos-8_malloctrim ruby-pkg_2.7.4_debian-10_normal ruby-pkg_2.7.4_debian-10_jemalloc ruby-pkg_2.7.4_debian-10_malloctrim ruby-pkg_2.7.4_debian-11_normal ruby-pkg_2.7.4_debian-11_jemalloc ruby-pkg_2.7.4_debian-11_malloctrim ruby-pkg_2.7.4_debian-9_normal ruby-pkg_2.7.4_debian-9_jemalloc ruby-pkg_2.7.4_debian-9_malloctrim ruby-pkg_2.7.4_ubuntu-18.04_normal ruby-pkg_2.7.4_ubuntu-18.04_jemalloc ruby-pkg_2.7.4_ubuntu-18.04_malloctrim ruby-pkg_2.7.4_ubuntu-20.04_normal ruby-pkg_2.7.4_ubuntu-20.04_jemalloc ruby-pkg_2.7.4_ubuntu-20.04_malloctrim ruby-pkg_2.6.8_centos-7_normal ruby-pkg_2.6.8_centos-7_jemalloc ruby-pkg_2.6.8_centos-7_malloctrim ruby-pkg_2.6.8_centos-8_normal ruby-pkg_2.6.8_centos-8_jemalloc ruby-pkg_2.6.8_centos-8_malloctrim ruby-pkg_2.6.8_debian-10_normal ruby-pkg_2.6.8_debian-10_jemalloc ruby-pkg_2.6.8_debian-10_malloctrim ruby-pkg_2.6.8_debian-11_normal ruby-pkg_2.6.8_debian-11_jemalloc ruby-pkg_2.6.8_debian-11_malloctrim ruby-pkg_2.6.8_debian-9_normal ruby-pkg_2.6.8_debian-9_jemalloc ruby-pkg_2.6.8_debian-9_malloctrim ruby-pkg_2.6.8_ubuntu-18.04_normal ruby-pkg_2.6.8_ubuntu-18.04_jemalloc ruby-pkg_2.6.8_ubuntu-18.04_malloctrim ruby-pkg_2.6.8_ubuntu-20.04_normal ruby-pkg_2.6.8_ubuntu-20.04_jemalloc ruby-pkg_2.6.8_ubuntu-20.04_malloctrim
+            ruby-pkg_3.0_centos-7_normal ruby-pkg_3.0_centos-7_jemalloc ruby-pkg_3.0_centos-7_malloctrim ruby-pkg_3.0_centos-8_normal ruby-pkg_3.0_centos-8_jemalloc ruby-pkg_3.0_centos-8_malloctrim ruby-pkg_3.0_debian-10_normal ruby-pkg_3.0_debian-10_jemalloc ruby-pkg_3.0_debian-10_malloctrim ruby-pkg_3.0_debian-11_normal ruby-pkg_3.0_debian-11_jemalloc ruby-pkg_3.0_debian-11_malloctrim ruby-pkg_3.0_debian-9_normal ruby-pkg_3.0_debian-9_jemalloc ruby-pkg_3.0_debian-9_malloctrim ruby-pkg_3.0_ubuntu-18.04_normal ruby-pkg_3.0_ubuntu-18.04_jemalloc ruby-pkg_3.0_ubuntu-18.04_malloctrim ruby-pkg_3.0_ubuntu-20.04_normal ruby-pkg_3.0_ubuntu-20.04_jemalloc ruby-pkg_3.0_ubuntu-20.04_malloctrim ruby-pkg_2.7_centos-7_normal ruby-pkg_2.7_centos-7_jemalloc ruby-pkg_2.7_centos-7_malloctrim ruby-pkg_2.7_centos-8_normal ruby-pkg_2.7_centos-8_jemalloc ruby-pkg_2.7_centos-8_malloctrim ruby-pkg_2.7_debian-10_normal ruby-pkg_2.7_debian-10_jemalloc ruby-pkg_2.7_debian-10_malloctrim ruby-pkg_2.7_debian-11_normal ruby-pkg_2.7_debian-11_jemalloc ruby-pkg_2.7_debian-11_malloctrim ruby-pkg_2.7_debian-9_normal ruby-pkg_2.7_debian-9_jemalloc ruby-pkg_2.7_debian-9_malloctrim ruby-pkg_2.7_ubuntu-18.04_normal ruby-pkg_2.7_ubuntu-18.04_jemalloc ruby-pkg_2.7_ubuntu-18.04_malloctrim ruby-pkg_2.7_ubuntu-20.04_normal ruby-pkg_2.7_ubuntu-20.04_jemalloc ruby-pkg_2.7_ubuntu-20.04_malloctrim ruby-pkg_2.6_centos-7_normal ruby-pkg_2.6_centos-7_jemalloc ruby-pkg_2.6_centos-7_malloctrim ruby-pkg_2.6_centos-8_normal ruby-pkg_2.6_centos-8_jemalloc ruby-pkg_2.6_centos-8_malloctrim ruby-pkg_2.6_debian-10_normal ruby-pkg_2.6_debian-10_jemalloc ruby-pkg_2.6_debian-10_malloctrim ruby-pkg_2.6_debian-11_normal ruby-pkg_2.6_debian-11_jemalloc ruby-pkg_2.6_debian-11_malloctrim ruby-pkg_2.6_debian-9_normal ruby-pkg_2.6_debian-9_jemalloc ruby-pkg_2.6_debian-9_malloctrim ruby-pkg_2.6_ubuntu-18.04_normal ruby-pkg_2.6_ubuntu-18.04_jemalloc ruby-pkg_2.6_ubuntu-18.04_malloctrim ruby-pkg_2.6_ubuntu-20.04_normal ruby-pkg_2.6_ubuntu-20.04_jemalloc ruby-pkg_2.6_ubuntu-20.04_malloctrim ruby-pkg_3.0.3_centos-7_normal ruby-pkg_3.0.3_centos-7_jemalloc ruby-pkg_3.0.3_centos-7_malloctrim ruby-pkg_3.0.3_centos-8_normal ruby-pkg_3.0.3_centos-8_jemalloc ruby-pkg_3.0.3_centos-8_malloctrim ruby-pkg_3.0.3_debian-10_normal ruby-pkg_3.0.3_debian-10_jemalloc ruby-pkg_3.0.3_debian-10_malloctrim ruby-pkg_3.0.3_debian-11_normal ruby-pkg_3.0.3_debian-11_jemalloc ruby-pkg_3.0.3_debian-11_malloctrim ruby-pkg_3.0.3_debian-9_normal ruby-pkg_3.0.3_debian-9_jemalloc ruby-pkg_3.0.3_debian-9_malloctrim ruby-pkg_3.0.3_ubuntu-18.04_normal ruby-pkg_3.0.3_ubuntu-18.04_jemalloc ruby-pkg_3.0.3_ubuntu-18.04_malloctrim ruby-pkg_3.0.3_ubuntu-20.04_normal ruby-pkg_3.0.3_ubuntu-20.04_jemalloc ruby-pkg_3.0.3_ubuntu-20.04_malloctrim ruby-pkg_2.7.5_centos-7_normal ruby-pkg_2.7.5_centos-7_jemalloc ruby-pkg_2.7.5_centos-7_malloctrim ruby-pkg_2.7.5_centos-8_normal ruby-pkg_2.7.5_centos-8_jemalloc ruby-pkg_2.7.5_centos-8_malloctrim ruby-pkg_2.7.5_debian-10_normal ruby-pkg_2.7.5_debian-10_jemalloc ruby-pkg_2.7.5_debian-10_malloctrim ruby-pkg_2.7.5_debian-11_normal ruby-pkg_2.7.5_debian-11_jemalloc ruby-pkg_2.7.5_debian-11_malloctrim ruby-pkg_2.7.5_debian-9_normal ruby-pkg_2.7.5_debian-9_jemalloc ruby-pkg_2.7.5_debian-9_malloctrim ruby-pkg_2.7.5_ubuntu-18.04_normal ruby-pkg_2.7.5_ubuntu-18.04_jemalloc ruby-pkg_2.7.5_ubuntu-18.04_malloctrim ruby-pkg_2.7.5_ubuntu-20.04_normal ruby-pkg_2.7.5_ubuntu-20.04_jemalloc ruby-pkg_2.7.5_ubuntu-20.04_malloctrim ruby-pkg_2.6.9_centos-7_normal ruby-pkg_2.6.9_centos-7_jemalloc ruby-pkg_2.6.9_centos-7_malloctrim ruby-pkg_2.6.9_centos-8_normal ruby-pkg_2.6.9_centos-8_jemalloc ruby-pkg_2.6.9_centos-8_malloctrim ruby-pkg_2.6.9_debian-10_normal ruby-pkg_2.6.9_debian-10_jemalloc ruby-pkg_2.6.9_debian-10_malloctrim ruby-pkg_2.6.9_debian-11_normal ruby-pkg_2.6.9_debian-11_jemalloc ruby-pkg_2.6.9_debian-11_malloctrim ruby-pkg_2.6.9_debian-9_normal ruby-pkg_2.6.9_debian-9_jemalloc ruby-pkg_2.6.9_debian-9_malloctrim ruby-pkg_2.6.9_ubuntu-18.04_normal ruby-pkg_2.6.9_ubuntu-18.04_jemalloc ruby-pkg_2.6.9_ubuntu-18.04_malloctrim ruby-pkg_2.6.9_ubuntu-20.04_normal ruby-pkg_2.6.9_ubuntu-20.04_jemalloc ruby-pkg_2.6.9_ubuntu-20.04_malloctrim
           ARTIFACT_PATH: pkgs
 
       - name: Download Docker image necessary for publishing
@@ -443,13 +443,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-centos-7_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-3_0_2-normal:
-    name: 'Test [centos-7/3.0.2/normal]'
+  test_centos_7-3_0_3-normal:
+    name: 'Test [centos-7/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -461,7 +461,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -474,16 +474,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-3_0_2-jemalloc:
-    name: 'Test [centos-7/3.0.2/jemalloc]'
+  test_centos_7-3_0_3-jemalloc:
+    name: 'Test [centos-7/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -495,7 +495,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -508,16 +508,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-3_0_2-malloctrim:
-    name: 'Test [centos-7/3.0.2/malloctrim]'
+  test_centos_7-3_0_3-malloctrim:
+    name: 'Test [centos-7/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -529,7 +529,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -542,16 +542,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-2_7_4-normal:
-    name: 'Test [centos-7/2.7.4/normal]'
+  test_centos_7-2_7_5-normal:
+    name: 'Test [centos-7/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -563,7 +563,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -576,16 +576,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-2_7_4-jemalloc:
-    name: 'Test [centos-7/2.7.4/jemalloc]'
+  test_centos_7-2_7_5-jemalloc:
+    name: 'Test [centos-7/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -597,7 +597,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -610,16 +610,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-2_7_4-malloctrim:
-    name: 'Test [centos-7/2.7.4/malloctrim]'
+  test_centos_7-2_7_5-malloctrim:
+    name: 'Test [centos-7/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -631,7 +631,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -644,16 +644,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_7-2_6_8-normal:
-    name: 'Test [centos-7/2.6.8/normal]'
+  test_centos_7-2_6_9-normal:
+    name: 'Test [centos-7/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -665,7 +665,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -678,16 +678,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_7-2_6_8-jemalloc:
-    name: 'Test [centos-7/2.6.8/jemalloc]'
+  test_centos_7-2_6_9-jemalloc:
+    name: 'Test [centos-7/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -699,7 +699,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -712,16 +712,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_7-2_6_8-malloctrim:
-    name: 'Test [centos-7/2.6.8/malloctrim]'
+  test_centos_7-2_6_9-malloctrim:
+    name: 'Test [centos-7/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -733,7 +733,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-7"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -746,7 +746,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-7_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-7_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -1056,13 +1056,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-centos-8_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-3_0_2-normal:
-    name: 'Test [centos-8/3.0.2/normal]'
+  test_centos_8-3_0_3-normal:
+    name: 'Test [centos-8/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1074,7 +1074,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1087,16 +1087,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-3_0_2-jemalloc:
-    name: 'Test [centos-8/3.0.2/jemalloc]'
+  test_centos_8-3_0_3-jemalloc:
+    name: 'Test [centos-8/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1108,7 +1108,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1121,16 +1121,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-3_0_2-malloctrim:
-    name: 'Test [centos-8/3.0.2/malloctrim]'
+  test_centos_8-3_0_3-malloctrim:
+    name: 'Test [centos-8/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1142,7 +1142,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1155,16 +1155,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-2_7_4-normal:
-    name: 'Test [centos-8/2.7.4/normal]'
+  test_centos_8-2_7_5-normal:
+    name: 'Test [centos-8/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1176,7 +1176,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1189,16 +1189,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-2_7_4-jemalloc:
-    name: 'Test [centos-8/2.7.4/jemalloc]'
+  test_centos_8-2_7_5-jemalloc:
+    name: 'Test [centos-8/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1210,7 +1210,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1223,16 +1223,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-2_7_4-malloctrim:
-    name: 'Test [centos-8/2.7.4/malloctrim]'
+  test_centos_8-2_7_5-malloctrim:
+    name: 'Test [centos-8/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1244,7 +1244,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1257,16 +1257,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_centos_8-2_6_8-normal:
-    name: 'Test [centos-8/2.6.8/normal]'
+  test_centos_8-2_6_9-normal:
+    name: 'Test [centos-8/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1278,7 +1278,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1291,16 +1291,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_centos_8-2_6_8-jemalloc:
-    name: 'Test [centos-8/2.6.8/jemalloc]'
+  test_centos_8-2_6_9-jemalloc:
+    name: 'Test [centos-8/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1312,7 +1312,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1325,16 +1325,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_centos_8-2_6_8-malloctrim:
-    name: 'Test [centos-8/2.6.8/malloctrim]'
+  test_centos_8-2_6_9-malloctrim:
+    name: 'Test [centos-8/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1346,7 +1346,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1359,7 +1359,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-centos-8_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -1669,13 +1669,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-debian-10_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-3_0_2-normal:
-    name: 'Test [debian-10/3.0.2/normal]'
+  test_debian_10-3_0_3-normal:
+    name: 'Test [debian-10/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1687,7 +1687,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1700,16 +1700,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-3_0_2-jemalloc:
-    name: 'Test [debian-10/3.0.2/jemalloc]'
+  test_debian_10-3_0_3-jemalloc:
+    name: 'Test [debian-10/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1721,7 +1721,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1734,16 +1734,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-3_0_2-malloctrim:
-    name: 'Test [debian-10/3.0.2/malloctrim]'
+  test_debian_10-3_0_3-malloctrim:
+    name: 'Test [debian-10/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1755,7 +1755,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1768,16 +1768,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-2_7_4-normal:
-    name: 'Test [debian-10/2.7.4/normal]'
+  test_debian_10-2_7_5-normal:
+    name: 'Test [debian-10/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1789,7 +1789,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1802,16 +1802,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-2_7_4-jemalloc:
-    name: 'Test [debian-10/2.7.4/jemalloc]'
+  test_debian_10-2_7_5-jemalloc:
+    name: 'Test [debian-10/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1823,7 +1823,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1836,16 +1836,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-2_7_4-malloctrim:
-    name: 'Test [debian-10/2.7.4/malloctrim]'
+  test_debian_10-2_7_5-malloctrim:
+    name: 'Test [debian-10/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1857,7 +1857,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1870,16 +1870,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_10-2_6_8-normal:
-    name: 'Test [debian-10/2.6.8/normal]'
+  test_debian_10-2_6_9-normal:
+    name: 'Test [debian-10/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1891,7 +1891,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1904,16 +1904,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_10-2_6_8-jemalloc:
-    name: 'Test [debian-10/2.6.8/jemalloc]'
+  test_debian_10-2_6_9-jemalloc:
+    name: 'Test [debian-10/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1925,7 +1925,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1938,16 +1938,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_10-2_6_8-malloctrim:
-    name: 'Test [debian-10/2.6.8/malloctrim]'
+  test_debian_10-2_6_9-malloctrim:
+    name: 'Test [debian-10/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -1959,7 +1959,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-10"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -1972,7 +1972,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-10_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-10_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -2282,13 +2282,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-debian-11_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_11-3_0_2-normal:
-    name: 'Test [debian-11/3.0.2/normal]'
+  test_debian_11-3_0_3-normal:
+    name: 'Test [debian-11/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2300,7 +2300,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2313,16 +2313,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-debian-11_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_11-3_0_2-jemalloc:
-    name: 'Test [debian-11/3.0.2/jemalloc]'
+  test_debian_11-3_0_3-jemalloc:
+    name: 'Test [debian-11/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2334,7 +2334,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2347,16 +2347,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-11_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_11-3_0_2-malloctrim:
-    name: 'Test [debian-11/3.0.2/malloctrim]'
+  test_debian_11-3_0_3-malloctrim:
+    name: 'Test [debian-11/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2368,7 +2368,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2381,16 +2381,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-11_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_11-2_7_4-normal:
-    name: 'Test [debian-11/2.7.4/normal]'
+  test_debian_11-2_7_5-normal:
+    name: 'Test [debian-11/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2402,7 +2402,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2415,16 +2415,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-debian-11_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_11-2_7_4-jemalloc:
-    name: 'Test [debian-11/2.7.4/jemalloc]'
+  test_debian_11-2_7_5-jemalloc:
+    name: 'Test [debian-11/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2436,7 +2436,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2449,16 +2449,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-11_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_11-2_7_4-malloctrim:
-    name: 'Test [debian-11/2.7.4/malloctrim]'
+  test_debian_11-2_7_5-malloctrim:
+    name: 'Test [debian-11/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2470,7 +2470,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2483,16 +2483,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-11_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_11-2_6_8-normal:
-    name: 'Test [debian-11/2.6.8/normal]'
+  test_debian_11-2_6_9-normal:
+    name: 'Test [debian-11/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2504,7 +2504,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2517,16 +2517,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-debian-11_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_11-2_6_8-jemalloc:
-    name: 'Test [debian-11/2.6.8/jemalloc]'
+  test_debian_11-2_6_9-jemalloc:
+    name: 'Test [debian-11/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2538,7 +2538,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2551,16 +2551,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-11_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_11-2_6_8-malloctrim:
-    name: 'Test [debian-11/2.6.8/malloctrim]'
+  test_debian_11-2_6_9-malloctrim:
+    name: 'Test [debian-11/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2572,7 +2572,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2585,7 +2585,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-11_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -2895,13 +2895,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-debian-9_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-3_0_2-normal:
-    name: 'Test [debian-9/3.0.2/normal]'
+  test_debian_9-3_0_3-normal:
+    name: 'Test [debian-9/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2913,7 +2913,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2926,16 +2926,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-3_0_2-jemalloc:
-    name: 'Test [debian-9/3.0.2/jemalloc]'
+  test_debian_9-3_0_3-jemalloc:
+    name: 'Test [debian-9/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2947,7 +2947,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2960,16 +2960,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-3_0_2-malloctrim:
-    name: 'Test [debian-9/3.0.2/malloctrim]'
+  test_debian_9-3_0_3-malloctrim:
+    name: 'Test [debian-9/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -2981,7 +2981,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -2994,16 +2994,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-2_7_4-normal:
-    name: 'Test [debian-9/2.7.4/normal]'
+  test_debian_9-2_7_5-normal:
+    name: 'Test [debian-9/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3015,7 +3015,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3028,16 +3028,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-2_7_4-jemalloc:
-    name: 'Test [debian-9/2.7.4/jemalloc]'
+  test_debian_9-2_7_5-jemalloc:
+    name: 'Test [debian-9/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3049,7 +3049,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3062,16 +3062,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-2_7_4-malloctrim:
-    name: 'Test [debian-9/2.7.4/malloctrim]'
+  test_debian_9-2_7_5-malloctrim:
+    name: 'Test [debian-9/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3083,7 +3083,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3096,16 +3096,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_debian_9-2_6_8-normal:
-    name: 'Test [debian-9/2.6.8/normal]'
+  test_debian_9-2_6_9-normal:
+    name: 'Test [debian-9/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3117,7 +3117,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3130,16 +3130,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_debian_9-2_6_8-jemalloc:
-    name: 'Test [debian-9/2.6.8/jemalloc]'
+  test_debian_9-2_6_9-jemalloc:
+    name: 'Test [debian-9/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3151,7 +3151,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3164,16 +3164,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_debian_9-2_6_8-malloctrim:
-    name: 'Test [debian-9/2.6.8/malloctrim]'
+  test_debian_9-2_6_9-malloctrim:
+    name: 'Test [debian-9/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3185,7 +3185,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-9"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3198,7 +3198,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-9_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-debian-9_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -3508,13 +3508,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-3_0_2-normal:
-    name: 'Test [ubuntu-18.04/3.0.2/normal]'
+  test_ubuntu_18_04-3_0_3-normal:
+    name: 'Test [ubuntu-18.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3526,7 +3526,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3539,16 +3539,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-3_0_2-jemalloc:
-    name: 'Test [ubuntu-18.04/3.0.2/jemalloc]'
+  test_ubuntu_18_04-3_0_3-jemalloc:
+    name: 'Test [ubuntu-18.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3560,7 +3560,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3573,16 +3573,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-3_0_2-malloctrim:
-    name: 'Test [ubuntu-18.04/3.0.2/malloctrim]'
+  test_ubuntu_18_04-3_0_3-malloctrim:
+    name: 'Test [ubuntu-18.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3594,7 +3594,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3607,16 +3607,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-2_7_4-normal:
-    name: 'Test [ubuntu-18.04/2.7.4/normal]'
+  test_ubuntu_18_04-2_7_5-normal:
+    name: 'Test [ubuntu-18.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3628,7 +3628,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3641,16 +3641,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-2_7_4-jemalloc:
-    name: 'Test [ubuntu-18.04/2.7.4/jemalloc]'
+  test_ubuntu_18_04-2_7_5-jemalloc:
+    name: 'Test [ubuntu-18.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3662,7 +3662,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3675,16 +3675,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-2_7_4-malloctrim:
-    name: 'Test [ubuntu-18.04/2.7.4/malloctrim]'
+  test_ubuntu_18_04-2_7_5-malloctrim:
+    name: 'Test [ubuntu-18.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3696,7 +3696,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3709,16 +3709,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_18_04-2_6_8-normal:
-    name: 'Test [ubuntu-18.04/2.6.8/normal]'
+  test_ubuntu_18_04-2_6_9-normal:
+    name: 'Test [ubuntu-18.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3730,7 +3730,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3743,16 +3743,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_18_04-2_6_8-jemalloc:
-    name: 'Test [ubuntu-18.04/2.6.8/jemalloc]'
+  test_ubuntu_18_04-2_6_9-jemalloc:
+    name: 'Test [ubuntu-18.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3764,7 +3764,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3777,16 +3777,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_18_04-2_6_8-malloctrim:
-    name: 'Test [ubuntu-18.04/2.6.8/malloctrim]'
+  test_ubuntu_18_04-2_6_9-malloctrim:
+    name: 'Test [ubuntu-18.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -3798,7 +3798,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-18.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -3811,7 +3811,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-18.04_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -4121,13 +4121,13 @@ jobs:
           ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-3_0_2-normal:
-    name: 'Test [ubuntu-20.04/3.0.2/normal]'
+  test_ubuntu_20_04-3_0_3-normal:
+    name: 'Test [ubuntu-20.04/3.0.3/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4139,7 +4139,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4152,16 +4152,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.2_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.3_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-3_0_2-jemalloc:
-    name: 'Test [ubuntu-20.04/3.0.2/jemalloc]'
+  test_ubuntu_20_04-3_0_3-jemalloc:
+    name: 'Test [ubuntu-20.04/3.0.3/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4173,7 +4173,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4186,16 +4186,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.2_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-3_0_2-malloctrim:
-    name: 'Test [ubuntu-20.04/3.0.2/malloctrim]'
+  test_ubuntu_20_04-3_0_3-malloctrim:
+    name: 'Test [ubuntu-20.04/3.0.3/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4207,7 +4207,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "3.0.2"
+          RUBY_PACKAGE_ID: "3.0.3"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4220,16 +4220,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.2_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_3.0.3_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-2_7_4-normal:
-    name: 'Test [ubuntu-20.04/2.7.4/normal]'
+  test_ubuntu_20_04-2_7_5-normal:
+    name: 'Test [ubuntu-20.04/2.7.5/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4241,7 +4241,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4254,16 +4254,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.4_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.5_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-2_7_4-jemalloc:
-    name: 'Test [ubuntu-20.04/2.7.4/jemalloc]'
+  test_ubuntu_20_04-2_7_5-jemalloc:
+    name: 'Test [ubuntu-20.04/2.7.5/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4275,7 +4275,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4288,16 +4288,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.4_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.5_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-2_7_4-malloctrim:
-    name: 'Test [ubuntu-20.04/2.7.4/malloctrim]'
+  test_ubuntu_20_04-2_7_5-malloctrim:
+    name: 'Test [ubuntu-20.04/2.7.5/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4309,7 +4309,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.7.4"
+          RUBY_PACKAGE_ID: "2.7.5"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4322,16 +4322,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.4_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.7.5_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
-  test_ubuntu_20_04-2_6_8-normal:
-    name: 'Test [ubuntu-20.04/2.6.8/normal]'
+  test_ubuntu_20_04-2_6_9-normal:
+    name: 'Test [ubuntu-20.04/2.6.9/normal]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/normal];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/normal];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4343,7 +4343,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4356,16 +4356,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.8_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.9_normal
           ARTIFACT_PATH: mark-normal
 
-  test_ubuntu_20_04-2_6_8-jemalloc:
-    name: 'Test [ubuntu-20.04/2.6.8/jemalloc]'
+  test_ubuntu_20_04-2_6_9-jemalloc:
+    name: 'Test [ubuntu-20.04/2.6.9/jemalloc]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/jemalloc];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/jemalloc];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4377,7 +4377,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4390,16 +4390,16 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.8_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.9_jemalloc
           ARTIFACT_PATH: mark-jemalloc
 
-  test_ubuntu_20_04-2_6_8-malloctrim:
-    name: 'Test [ubuntu-20.04/2.6.8/malloctrim]'
+  test_ubuntu_20_04-2_6_9-malloctrim:
+    name: 'Test [ubuntu-20.04/2.6.9/malloctrim]'
     runs-on: ubuntu-20.04
     needs:
       - determine_necessary_jobs
       - publish
-    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/malloctrim];')
+    if: contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/malloctrim];')
     steps:
       - uses: actions/checkout@v2
       - name: Login to Google Cloud
@@ -4411,7 +4411,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-20.04"
-          RUBY_PACKAGE_ID: "2.6.8"
+          RUBY_PACKAGE_ID: "2.6.9"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "malloctrim"
           VARIANT_PACKAGE_SUFFIX: "-malloctrim"
@@ -4424,7 +4424,7 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.8_malloctrim
+          ARTIFACT_NAME: tested-against-test-ubuntu-20.04_2.6.9_malloctrim
           ARTIFACT_PATH: mark-malloctrim
 
 
@@ -4447,15 +4447,15 @@ jobs:
       - test_centos_7-2_6-normal
       - test_centos_7-2_6-jemalloc
       - test_centos_7-2_6-malloctrim
-      - test_centos_7-3_0_2-normal
-      - test_centos_7-3_0_2-jemalloc
-      - test_centos_7-3_0_2-malloctrim
-      - test_centos_7-2_7_4-normal
-      - test_centos_7-2_7_4-jemalloc
-      - test_centos_7-2_7_4-malloctrim
-      - test_centos_7-2_6_8-normal
-      - test_centos_7-2_6_8-jemalloc
-      - test_centos_7-2_6_8-malloctrim
+      - test_centos_7-3_0_3-normal
+      - test_centos_7-3_0_3-jemalloc
+      - test_centos_7-3_0_3-malloctrim
+      - test_centos_7-2_7_5-normal
+      - test_centos_7-2_7_5-jemalloc
+      - test_centos_7-2_7_5-malloctrim
+      - test_centos_7-2_6_9-normal
+      - test_centos_7-2_6_9-jemalloc
+      - test_centos_7-2_6_9-malloctrim
       - test_centos_8-3_0-normal
       - test_centos_8-3_0-jemalloc
       - test_centos_8-3_0-malloctrim
@@ -4465,15 +4465,15 @@ jobs:
       - test_centos_8-2_6-normal
       - test_centos_8-2_6-jemalloc
       - test_centos_8-2_6-malloctrim
-      - test_centos_8-3_0_2-normal
-      - test_centos_8-3_0_2-jemalloc
-      - test_centos_8-3_0_2-malloctrim
-      - test_centos_8-2_7_4-normal
-      - test_centos_8-2_7_4-jemalloc
-      - test_centos_8-2_7_4-malloctrim
-      - test_centos_8-2_6_8-normal
-      - test_centos_8-2_6_8-jemalloc
-      - test_centos_8-2_6_8-malloctrim
+      - test_centos_8-3_0_3-normal
+      - test_centos_8-3_0_3-jemalloc
+      - test_centos_8-3_0_3-malloctrim
+      - test_centos_8-2_7_5-normal
+      - test_centos_8-2_7_5-jemalloc
+      - test_centos_8-2_7_5-malloctrim
+      - test_centos_8-2_6_9-normal
+      - test_centos_8-2_6_9-jemalloc
+      - test_centos_8-2_6_9-malloctrim
       - test_debian_10-3_0-normal
       - test_debian_10-3_0-jemalloc
       - test_debian_10-3_0-malloctrim
@@ -4483,15 +4483,15 @@ jobs:
       - test_debian_10-2_6-normal
       - test_debian_10-2_6-jemalloc
       - test_debian_10-2_6-malloctrim
-      - test_debian_10-3_0_2-normal
-      - test_debian_10-3_0_2-jemalloc
-      - test_debian_10-3_0_2-malloctrim
-      - test_debian_10-2_7_4-normal
-      - test_debian_10-2_7_4-jemalloc
-      - test_debian_10-2_7_4-malloctrim
-      - test_debian_10-2_6_8-normal
-      - test_debian_10-2_6_8-jemalloc
-      - test_debian_10-2_6_8-malloctrim
+      - test_debian_10-3_0_3-normal
+      - test_debian_10-3_0_3-jemalloc
+      - test_debian_10-3_0_3-malloctrim
+      - test_debian_10-2_7_5-normal
+      - test_debian_10-2_7_5-jemalloc
+      - test_debian_10-2_7_5-malloctrim
+      - test_debian_10-2_6_9-normal
+      - test_debian_10-2_6_9-jemalloc
+      - test_debian_10-2_6_9-malloctrim
       - test_debian_11-3_0-normal
       - test_debian_11-3_0-jemalloc
       - test_debian_11-3_0-malloctrim
@@ -4501,15 +4501,15 @@ jobs:
       - test_debian_11-2_6-normal
       - test_debian_11-2_6-jemalloc
       - test_debian_11-2_6-malloctrim
-      - test_debian_11-3_0_2-normal
-      - test_debian_11-3_0_2-jemalloc
-      - test_debian_11-3_0_2-malloctrim
-      - test_debian_11-2_7_4-normal
-      - test_debian_11-2_7_4-jemalloc
-      - test_debian_11-2_7_4-malloctrim
-      - test_debian_11-2_6_8-normal
-      - test_debian_11-2_6_8-jemalloc
-      - test_debian_11-2_6_8-malloctrim
+      - test_debian_11-3_0_3-normal
+      - test_debian_11-3_0_3-jemalloc
+      - test_debian_11-3_0_3-malloctrim
+      - test_debian_11-2_7_5-normal
+      - test_debian_11-2_7_5-jemalloc
+      - test_debian_11-2_7_5-malloctrim
+      - test_debian_11-2_6_9-normal
+      - test_debian_11-2_6_9-jemalloc
+      - test_debian_11-2_6_9-malloctrim
       - test_debian_9-3_0-normal
       - test_debian_9-3_0-jemalloc
       - test_debian_9-3_0-malloctrim
@@ -4519,15 +4519,15 @@ jobs:
       - test_debian_9-2_6-normal
       - test_debian_9-2_6-jemalloc
       - test_debian_9-2_6-malloctrim
-      - test_debian_9-3_0_2-normal
-      - test_debian_9-3_0_2-jemalloc
-      - test_debian_9-3_0_2-malloctrim
-      - test_debian_9-2_7_4-normal
-      - test_debian_9-2_7_4-jemalloc
-      - test_debian_9-2_7_4-malloctrim
-      - test_debian_9-2_6_8-normal
-      - test_debian_9-2_6_8-jemalloc
-      - test_debian_9-2_6_8-malloctrim
+      - test_debian_9-3_0_3-normal
+      - test_debian_9-3_0_3-jemalloc
+      - test_debian_9-3_0_3-malloctrim
+      - test_debian_9-2_7_5-normal
+      - test_debian_9-2_7_5-jemalloc
+      - test_debian_9-2_7_5-malloctrim
+      - test_debian_9-2_6_9-normal
+      - test_debian_9-2_6_9-jemalloc
+      - test_debian_9-2_6_9-malloctrim
       - test_ubuntu_18_04-3_0-normal
       - test_ubuntu_18_04-3_0-jemalloc
       - test_ubuntu_18_04-3_0-malloctrim
@@ -4537,15 +4537,15 @@ jobs:
       - test_ubuntu_18_04-2_6-normal
       - test_ubuntu_18_04-2_6-jemalloc
       - test_ubuntu_18_04-2_6-malloctrim
-      - test_ubuntu_18_04-3_0_2-normal
-      - test_ubuntu_18_04-3_0_2-jemalloc
-      - test_ubuntu_18_04-3_0_2-malloctrim
-      - test_ubuntu_18_04-2_7_4-normal
-      - test_ubuntu_18_04-2_7_4-jemalloc
-      - test_ubuntu_18_04-2_7_4-malloctrim
-      - test_ubuntu_18_04-2_6_8-normal
-      - test_ubuntu_18_04-2_6_8-jemalloc
-      - test_ubuntu_18_04-2_6_8-malloctrim
+      - test_ubuntu_18_04-3_0_3-normal
+      - test_ubuntu_18_04-3_0_3-jemalloc
+      - test_ubuntu_18_04-3_0_3-malloctrim
+      - test_ubuntu_18_04-2_7_5-normal
+      - test_ubuntu_18_04-2_7_5-jemalloc
+      - test_ubuntu_18_04-2_7_5-malloctrim
+      - test_ubuntu_18_04-2_6_9-normal
+      - test_ubuntu_18_04-2_6_9-jemalloc
+      - test_ubuntu_18_04-2_6_9-malloctrim
       - test_ubuntu_20_04-3_0-normal
       - test_ubuntu_20_04-3_0-jemalloc
       - test_ubuntu_20_04-3_0-malloctrim
@@ -4555,15 +4555,15 @@ jobs:
       - test_ubuntu_20_04-2_6-normal
       - test_ubuntu_20_04-2_6-jemalloc
       - test_ubuntu_20_04-2_6-malloctrim
-      - test_ubuntu_20_04-3_0_2-normal
-      - test_ubuntu_20_04-3_0_2-jemalloc
-      - test_ubuntu_20_04-3_0_2-malloctrim
-      - test_ubuntu_20_04-2_7_4-normal
-      - test_ubuntu_20_04-2_7_4-jemalloc
-      - test_ubuntu_20_04-2_7_4-malloctrim
-      - test_ubuntu_20_04-2_6_8-normal
-      - test_ubuntu_20_04-2_6_8-jemalloc
-      - test_ubuntu_20_04-2_6_8-malloctrim
+      - test_ubuntu_20_04-3_0_3-normal
+      - test_ubuntu_20_04-3_0_3-jemalloc
+      - test_ubuntu_20_04-3_0_3-malloctrim
+      - test_ubuntu_20_04-2_7_5-normal
+      - test_ubuntu_20_04-2_7_5-jemalloc
+      - test_ubuntu_20_04-2_7_5-malloctrim
+      - test_ubuntu_20_04-2_6_9-normal
+      - test_ubuntu_20_04-2_6_9-jemalloc
+      - test_ubuntu_20_04-2_6_9-malloctrim
     runs-on: ubuntu-20.04
     if: 'always()'
     steps:
@@ -4635,60 +4635,60 @@ jobs:
           needs.test_centos_7-2_6-malloctrim.result != 'success'
           && (needs.test_centos_7-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-7/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [centos-7/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_2-normal.result != 'success'
-          && (needs.test_centos_7-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/normal];'))
-      - name: Check whether 'Test [centos-7/3.0.2/jemalloc]' did not fail
+          needs.test_centos_7-3_0_3-normal.result != 'success'
+          && (needs.test_centos_7-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/normal];'))
+      - name: Check whether 'Test [centos-7/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_2-jemalloc.result != 'success'
-          && (needs.test_centos_7-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [centos-7/3.0.2/malloctrim]' did not fail
+          needs.test_centos_7-3_0_3-jemalloc.result != 'success'
+          && (needs.test_centos_7-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [centos-7/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-3_0_2-malloctrim.result != 'success'
-          && (needs.test_centos_7-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.7.4/normal]' did not fail
+          needs.test_centos_7-3_0_3-malloctrim.result != 'success'
+          && (needs.test_centos_7-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_4-normal.result != 'success'
-          && (needs.test_centos_7-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/normal];'))
-      - name: Check whether 'Test [centos-7/2.7.4/jemalloc]' did not fail
+          needs.test_centos_7-2_7_5-normal.result != 'success'
+          && (needs.test_centos_7-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/normal];'))
+      - name: Check whether 'Test [centos-7/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_4-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.7.4/malloctrim]' did not fail
+          needs.test_centos_7-2_7_5-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_7_4-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [centos-7/2.6.8/normal]' did not fail
+          needs.test_centos_7-2_7_5-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [centos-7/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_8-normal.result != 'success'
-          && (needs.test_centos_7-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/normal];'))
-      - name: Check whether 'Test [centos-7/2.6.8/jemalloc]' did not fail
+          needs.test_centos_7-2_6_9-normal.result != 'success'
+          && (needs.test_centos_7-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/normal];'))
+      - name: Check whether 'Test [centos-7/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_8-jemalloc.result != 'success'
-          && (needs.test_centos_7-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [centos-7/2.6.8/malloctrim]' did not fail
+          needs.test_centos_7-2_6_9-jemalloc.result != 'success'
+          && (needs.test_centos_7-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [centos-7/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_7-2_6_8-malloctrim.result != 'success'
-          && (needs.test_centos_7-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.8/malloctrim];'))
+          needs.test_centos_7-2_6_9-malloctrim.result != 'success'
+          && (needs.test_centos_7-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-7/2.6.9/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4743,60 +4743,60 @@ jobs:
           needs.test_centos_8-2_6-malloctrim.result != 'success'
           && (needs.test_centos_8-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6/malloctrim];'))
-      - name: Check whether 'Test [centos-8/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [centos-8/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_2-normal.result != 'success'
-          && (needs.test_centos_8-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/normal];'))
-      - name: Check whether 'Test [centos-8/3.0.2/jemalloc]' did not fail
+          needs.test_centos_8-3_0_3-normal.result != 'success'
+          && (needs.test_centos_8-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/normal];'))
+      - name: Check whether 'Test [centos-8/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_2-jemalloc.result != 'success'
-          && (needs.test_centos_8-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.0.2/malloctrim]' did not fail
+          needs.test_centos_8-3_0_3-jemalloc.result != 'success'
+          && (needs.test_centos_8-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [centos-8/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-3_0_2-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.7.4/normal]' did not fail
+          needs.test_centos_8-3_0_3-malloctrim.result != 'success'
+          && (needs.test_centos_8-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_4-normal.result != 'success'
-          && (needs.test_centos_8-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/normal];'))
-      - name: Check whether 'Test [centos-8/2.7.4/jemalloc]' did not fail
+          needs.test_centos_8-2_7_5-normal.result != 'success'
+          && (needs.test_centos_8-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/normal];'))
+      - name: Check whether 'Test [centos-8/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_4-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.7.4/malloctrim]' did not fail
+          needs.test_centos_8-2_7_5-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_7_4-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [centos-8/2.6.8/normal]' did not fail
+          needs.test_centos_8-2_7_5-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [centos-8/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_8-normal.result != 'success'
-          && (needs.test_centos_8-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/normal];'))
-      - name: Check whether 'Test [centos-8/2.6.8/jemalloc]' did not fail
+          needs.test_centos_8-2_6_9-normal.result != 'success'
+          && (needs.test_centos_8-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/normal];'))
+      - name: Check whether 'Test [centos-8/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_8-jemalloc.result != 'success'
-          && (needs.test_centos_8-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [centos-8/2.6.8/malloctrim]' did not fail
+          needs.test_centos_8-2_6_9-jemalloc.result != 'success'
+          && (needs.test_centos_8-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [centos-8/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-2_6_8-malloctrim.result != 'success'
-          && (needs.test_centos_8-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.8/malloctrim];'))
+          needs.test_centos_8-2_6_9-malloctrim.result != 'success'
+          && (needs.test_centos_8-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [centos-8/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-10/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4851,60 +4851,60 @@ jobs:
           needs.test_debian_10-2_6-malloctrim.result != 'success'
           && (needs.test_debian_10-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-10/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-10/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_2-normal.result != 'success'
-          && (needs.test_debian_10-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-10/3.0.2/jemalloc]' did not fail
+          needs.test_debian_10-3_0_3-normal.result != 'success'
+          && (needs.test_debian_10-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-10/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_10-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-10/3.0.2/malloctrim]' did not fail
+          needs.test_debian_10-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_10-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-10/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_10-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.7.4/normal]' did not fail
+          needs.test_debian_10-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_10-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_4-normal.result != 'success'
-          && (needs.test_debian_10-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-10/2.7.4/jemalloc]' did not fail
+          needs.test_debian_10-2_7_5-normal.result != 'success'
+          && (needs.test_debian_10-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-10/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.7.4/malloctrim]' did not fail
+          needs.test_debian_10-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-10/2.6.8/normal]' did not fail
+          needs.test_debian_10-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-10/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_8-normal.result != 'success'
-          && (needs.test_debian_10-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-10/2.6.8/jemalloc]' did not fail
+          needs.test_debian_10-2_6_9-normal.result != 'success'
+          && (needs.test_debian_10-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-10/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_10-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-10/2.6.8/malloctrim]' did not fail
+          needs.test_debian_10-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_10-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-10/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_10-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_10-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.8/malloctrim];'))
+          needs.test_debian_10-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_10-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-10/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -4959,60 +4959,60 @@ jobs:
           needs.test_debian_11-2_6-malloctrim.result != 'success'
           && (needs.test_debian_11-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-11/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-11/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-3_0_2-normal.result != 'success'
-          && (needs.test_debian_11-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-11/3.0.2/jemalloc]' did not fail
+          needs.test_debian_11-3_0_3-normal.result != 'success'
+          && (needs.test_debian_11-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-11/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_11-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.0.2/malloctrim]' did not fail
+          needs.test_debian_11-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_11-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-11/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-11/2.7.4/normal]' did not fail
+          needs.test_debian_11-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_11-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-11/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_7_4-normal.result != 'success'
-          && (needs.test_debian_11-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-11/2.7.4/jemalloc]' did not fail
+          needs.test_debian_11-2_7_5-normal.result != 'success'
+          && (needs.test_debian_11-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-11/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_11-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-11/2.7.4/malloctrim]' did not fail
+          needs.test_debian_11-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_11-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-11/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_11-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-11/2.6.8/normal]' did not fail
+          needs.test_debian_11-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_11-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-11/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_6_8-normal.result != 'success'
-          && (needs.test_debian_11-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-11/2.6.8/jemalloc]' did not fail
+          needs.test_debian_11-2_6_9-normal.result != 'success'
+          && (needs.test_debian_11-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-11/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_11-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-11/2.6.8/malloctrim]' did not fail
+          needs.test_debian_11-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_11-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-11/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_11-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.8/malloctrim];'))
+          needs.test_debian_11-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_11-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-11/2.6.9/malloctrim];'))
       - name: Check whether 'Test [debian-9/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5067,60 +5067,60 @@ jobs:
           needs.test_debian_9-2_6-malloctrim.result != 'success'
           && (needs.test_debian_9-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6/malloctrim];'))
-      - name: Check whether 'Test [debian-9/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [debian-9/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_2-normal.result != 'success'
-          && (needs.test_debian_9-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/normal];'))
-      - name: Check whether 'Test [debian-9/3.0.2/jemalloc]' did not fail
+          needs.test_debian_9-3_0_3-normal.result != 'success'
+          && (needs.test_debian_9-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/normal];'))
+      - name: Check whether 'Test [debian-9/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_2-jemalloc.result != 'success'
-          && (needs.test_debian_9-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [debian-9/3.0.2/malloctrim]' did not fail
+          needs.test_debian_9-3_0_3-jemalloc.result != 'success'
+          && (needs.test_debian_9-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [debian-9/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-3_0_2-malloctrim.result != 'success'
-          && (needs.test_debian_9-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.7.4/normal]' did not fail
+          needs.test_debian_9-3_0_3-malloctrim.result != 'success'
+          && (needs.test_debian_9-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_4-normal.result != 'success'
-          && (needs.test_debian_9-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/normal];'))
-      - name: Check whether 'Test [debian-9/2.7.4/jemalloc]' did not fail
+          needs.test_debian_9-2_7_5-normal.result != 'success'
+          && (needs.test_debian_9-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/normal];'))
+      - name: Check whether 'Test [debian-9/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_4-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.7.4/malloctrim]' did not fail
+          needs.test_debian_9-2_7_5-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_7_4-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [debian-9/2.6.8/normal]' did not fail
+          needs.test_debian_9-2_7_5-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [debian-9/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_8-normal.result != 'success'
-          && (needs.test_debian_9-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/normal];'))
-      - name: Check whether 'Test [debian-9/2.6.8/jemalloc]' did not fail
+          needs.test_debian_9-2_6_9-normal.result != 'success'
+          && (needs.test_debian_9-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/normal];'))
+      - name: Check whether 'Test [debian-9/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_8-jemalloc.result != 'success'
-          && (needs.test_debian_9-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [debian-9/2.6.8/malloctrim]' did not fail
+          needs.test_debian_9-2_6_9-jemalloc.result != 'success'
+          && (needs.test_debian_9-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [debian-9/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_9-2_6_8-malloctrim.result != 'success'
-          && (needs.test_debian_9-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.8/malloctrim];'))
+          needs.test_debian_9-2_6_9-malloctrim.result != 'success'
+          && (needs.test_debian_9-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [debian-9/2.6.9/malloctrim];'))
       - name: Check whether 'Test [ubuntu-18.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5175,60 +5175,60 @@ jobs:
           needs.test_ubuntu_18_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_18_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_2-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-3_0_3-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/3.0.2/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-3_0_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-3_0_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/normal]' did not fail
+          needs.test_ubuntu_18_04-3_0_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_4-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-2_7_5-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_4-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.7.4/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-2_7_5-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_7_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/normal]' did not fail
+          needs.test_ubuntu_18_04-2_7_5-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_8-normal.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/normal];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/jemalloc]' did not fail
+          needs.test_ubuntu_18_04-2_6_9-normal.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/normal];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_8-jemalloc.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-18.04/2.6.8/malloctrim]' did not fail
+          needs.test_ubuntu_18_04-2_6_9-jemalloc.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-18.04/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_18_04-2_6_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_18_04-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.8/malloctrim];'))
+          needs.test_ubuntu_18_04-2_6_9-malloctrim.result != 'success'
+          && (needs.test_ubuntu_18_04-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-18.04/2.6.9/malloctrim];'))
       - name: Check whether 'Test [ubuntu-20.04/3.0/normal]' did not fail
         run: 'false'
         if: |
@@ -5283,60 +5283,60 @@ jobs:
           needs.test_ubuntu_20_04-2_6-malloctrim.result != 'success'
           && (needs.test_ubuntu_20_04-2_6-malloctrim.result != 'skipped'
             || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_2-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-3_0_3-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_2-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/3.0.2/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-3_0_3-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/3.0.3/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-3_0_2-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-3_0_2-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/normal]' did not fail
+          needs.test_ubuntu_20_04-3_0_3-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-3_0_3-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/3.0.3/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_4-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-2_7_5-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_4-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.7.4/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-2_7_5-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.7.5/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_7_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_7_4-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.4/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/normal]' did not fail
+          needs.test_ubuntu_20_04-2_7_5-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_7_5-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.7.5/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_8-normal.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-normal.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/normal];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/jemalloc]' did not fail
+          needs.test_ubuntu_20_04-2_6_9-normal.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-normal.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/normal];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_8-jemalloc.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-jemalloc.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-20.04/2.6.8/malloctrim]' did not fail
+          needs.test_ubuntu_20_04-2_6_9-jemalloc.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-jemalloc.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-20.04/2.6.9/malloctrim]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_20_04-2_6_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_20_04-2_6_8-malloctrim.result != 'skipped'
-            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.8/malloctrim];'))
+          needs.test_ubuntu_20_04-2_6_9-malloctrim.result != 'success'
+          && (needs.test_ubuntu_20_04-2_6_9-malloctrim.result != 'skipped'
+            || contains(needs.determine_necessary_jobs.outputs.necessary_jobs, ';Test against test repo [ubuntu-20.04/2.6.9/malloctrim];'))
 
 
       ### Trigger next workflow ###

--- a/config.yml
+++ b/config.yml
@@ -12,24 +12,24 @@ ruby:
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
     - minor_version: 3.0
-      full_version: 3.0.2
-      package_revision: 4
+      full_version: 3.0.3
+      package_revision: 5
     - minor_version: 2.7
-      full_version: 2.7.4
-      package_revision: 6
+      full_version: 2.7.5
+      package_revision: 7
     - minor_version: 2.6
-      full_version: 2.6.8
-      package_revision: 9
+      full_version: 2.6.9
+      package_revision: 10
 
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
-    - full_version: 3.0.2
-      package_revision: 4
-    - full_version: 2.7.4
+    - full_version: 3.0.3
       package_revision: 5
-    - full_version: 2.6.8
+    - full_version: 2.7.5
       package_revision: 6
+    - full_version: 2.6.9
+      package_revision: 7
 
 ## (Required)
 ## Which Rbenv version to package.


### PR DESCRIPTION
New Ruby versions were just released:

- https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-7-5-released/
- https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/