### PR TITLE
Add Ruby 4.0.0

### DIFF
--- a/.github/workflows/ci-cd-build-packages-1.yml
+++ b/.github/workflows/ci-cd-build-packages-1.yml
@@ -154,6 +154,297 @@ jobs:
 
 
 
+  build_ruby_centos_8-4_0-normal:
+    name: 'Ruby [centos-8/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_centos-8_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_centos_8-4_0-jemalloc:
+    name: 'Ruby [centos-8/4.0/jemalloc]'
+
+    needs: build_jemalloc_centos_8
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [centos-8];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-8
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_centos-8_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_centos_8-4_0-malloctrim:
+    name: 'Ruby [centos-8/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_centos-8_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_centos_8-3_4-normal:
     name: 'Ruby [centos-8/3.4/normal]'
 
@@ -1024,6 +1315,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_centos-8_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_centos_8-4_0_0-normal:
+    name: 'Ruby [centos-8/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_centos_8-4_0_0-jemalloc:
+    name: 'Ruby [centos-8/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_centos_8
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [centos-8]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_centos_8.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [centos-8];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-centos-8
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_centos_8-4_0_0-malloctrim:
+    name: 'Ruby [centos-8/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          ARTIFACT_NAME: 'docker-image-centos-8'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1901,6 +2483,297 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  build_ruby_el_9-4_0-normal:
+    name: 'Ruby [el-9/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_el-9_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_el_9-4_0-jemalloc:
+    name: 'Ruby [el-9/4.0/jemalloc]'
+
+    needs: build_jemalloc_el_9
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [el-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_el_9.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [el-9];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-el-9
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_el-9_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_el_9-4_0-malloctrim:
+    name: 'Ruby [el-9/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_el-9_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_el_9-3_4-normal:
     name: 'Ruby [el-9/3.4/normal]'
 
@@ -2771,6 +3644,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_el-9_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_el_9-4_0_0-normal:
+    name: 'Ruby [el-9/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_el_9-4_0_0-jemalloc:
+    name: 'Ruby [el-9/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_el_9
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [el-9]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_el_9.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [el-9];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-el-9
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_el_9-4_0_0-malloctrim:
+    name: 'Ruby [el-9/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          ARTIFACT_NAME: 'docker-image-el-9'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "el-9"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/el-9"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "RPM"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3657,6 +4821,10 @@ jobs:
 
       - build_jemalloc_centos_8
 
+      - build_ruby_centos_8-4_0-normal
+      - build_ruby_centos_8-4_0-jemalloc
+      - build_ruby_centos_8-4_0-malloctrim
+
       - build_ruby_centos_8-3_4-normal
       - build_ruby_centos_8-3_4-jemalloc
       - build_ruby_centos_8-3_4-malloctrim
@@ -3668,6 +4836,10 @@ jobs:
       - build_ruby_centos_8-3_2-normal
       - build_ruby_centos_8-3_2-jemalloc
       - build_ruby_centos_8-3_2-malloctrim
+
+      - build_ruby_centos_8-4_0_0-normal
+      - build_ruby_centos_8-4_0_0-jemalloc
+      - build_ruby_centos_8-4_0_0-malloctrim
 
       - build_ruby_centos_8-3_4_8-normal
       - build_ruby_centos_8-3_4_8-jemalloc
@@ -3683,6 +4855,10 @@ jobs:
 
       - build_jemalloc_el_9
 
+      - build_ruby_el_9-4_0-normal
+      - build_ruby_el_9-4_0-jemalloc
+      - build_ruby_el_9-4_0-malloctrim
+
       - build_ruby_el_9-3_4-normal
       - build_ruby_el_9-3_4-jemalloc
       - build_ruby_el_9-3_4-malloctrim
@@ -3694,6 +4870,10 @@ jobs:
       - build_ruby_el_9-3_2-normal
       - build_ruby_el_9-3_2-jemalloc
       - build_ruby_el_9-3_2-malloctrim
+
+      - build_ruby_el_9-4_0_0-normal
+      - build_ruby_el_9-4_0_0-jemalloc
+      - build_ruby_el_9-4_0_0-malloctrim
 
       - build_ruby_el_9-3_4_8-normal
       - build_ruby_el_9-3_4_8-jemalloc
@@ -3754,10 +4934,28 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_centos-8_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_centos-8_normal
+          path: artifacts/ruby-pkg_4.0_centos-8_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_centos-8_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_centos-8_jemalloc
+          path: artifacts/ruby-pkg_4.0_centos-8_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_centos-8_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_centos-8_malloctrim
+          path: artifacts/ruby-pkg_4.0_centos-8_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3811,6 +5009,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_centos-8_malloctrim
           path: artifacts/ruby-pkg_3.2_centos-8_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_centos-8_normal
+          path: artifacts/ruby-pkg_4.0.0_centos-8_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_centos-8_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_centos-8_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_centos-8_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_centos-8_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3866,6 +5082,24 @@ jobs:
           name: ruby-pkg_3.2.9_centos-8_malloctrim
           path: artifacts/ruby-pkg_3.2.9_centos-8_malloctrim
           compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_el-9_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_el-9_normal
+          path: artifacts/ruby-pkg_4.0_el-9_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_el-9_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_el-9_jemalloc
+          path: artifacts/ruby-pkg_4.0_el-9_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_el-9_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_el-9_malloctrim
+          path: artifacts/ruby-pkg_4.0_el-9_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_el-9_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3919,6 +5153,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_el-9_malloctrim
           path: artifacts/ruby-pkg_3.2_el-9_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_el-9_normal
+          path: artifacts/ruby-pkg_4.0.0_el-9_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_el-9_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_el-9_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_el-9_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_el-9_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_el-9_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3992,6 +5244,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_centos_8-4_0-normal.result != 'success'
+              && (needs.build_ruby_centos_8-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/normal];')))
+            || (needs.build_ruby_centos_8-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/jemalloc];')))
+            || (needs.build_ruby_centos_8-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/malloctrim];')))
             || (needs.build_ruby_centos_8-3_4-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4/normal];')))
@@ -4019,6 +5280,15 @@ jobs:
             || (needs.build_ruby_centos_8-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_centos_8-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.2/malloctrim];')))
+            || (needs.build_ruby_centos_8-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_centos_8-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/normal];')))
+            || (needs.build_ruby_centos_8-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/jemalloc];')))
+            || (needs.build_ruby_centos_8-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_centos_8-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/malloctrim];')))
             || (needs.build_ruby_centos_8-3_4_8-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4.8/normal];')))
@@ -4050,6 +5320,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_el_9-4_0-normal.result != 'success'
+              && (needs.build_ruby_el_9-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/normal];')))
+            || (needs.build_ruby_el_9-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_el_9-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/jemalloc];')))
+            || (needs.build_ruby_el_9-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_el_9-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/malloctrim];')))
             || (needs.build_ruby_el_9-3_4-normal.result != 'success'
               && (needs.build_ruby_el_9-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4/normal];')))
@@ -4077,6 +5356,15 @@ jobs:
             || (needs.build_ruby_el_9-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_el_9-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.2/malloctrim];')))
+            || (needs.build_ruby_el_9-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_el_9-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/normal];')))
+            || (needs.build_ruby_el_9-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_el_9-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/jemalloc];')))
+            || (needs.build_ruby_el_9-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_el_9-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/malloctrim];')))
             || (needs.build_ruby_el_9-3_4_8-normal.result != 'success'
               && (needs.build_ruby_el_9-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4.8/normal];')))

--- a/.github/workflows/ci-cd-build-packages-2.yml
+++ b/.github/workflows/ci-cd-build-packages-2.yml
@@ -154,6 +154,297 @@ jobs:
 
 
 
+  build_ruby_debian_11-4_0-normal:
+    name: 'Ruby [debian-11/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-11_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_11-4_0-jemalloc:
+    name: 'Ruby [debian-11/4.0/jemalloc]'
+
+    needs: build_jemalloc_debian_11
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-11]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_11.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-11];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-11
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-11_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_11-4_0-malloctrim:
+    name: 'Ruby [debian-11/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-11_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_debian_11-3_4-normal:
     name: 'Ruby [debian-11/3.4/normal]'
 
@@ -1024,6 +1315,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_debian-11_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_11-4_0_0-normal:
+    name: 'Ruby [debian-11/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_11-4_0_0-jemalloc:
+    name: 'Ruby [debian-11/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_debian_11
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-11]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_11.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-11];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-11
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_11-4_0_0-malloctrim:
+    name: 'Ruby [debian-11/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-11'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-11"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1901,6 +2483,297 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  build_ruby_ubuntu_22_04-4_0-normal:
+    name: 'Ruby [ubuntu-22.04/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-22.04_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_22_04-4_0-jemalloc:
+    name: 'Ruby [ubuntu-22.04/4.0/jemalloc]'
+
+    needs: build_jemalloc_ubuntu_22_04
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [ubuntu-22.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_22_04.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [ubuntu-22.04];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-22.04
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-22.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_22_04-4_0-malloctrim:
+    name: 'Ruby [ubuntu-22.04/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-22.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_ubuntu_22_04-3_4-normal:
     name: 'Ruby [ubuntu-22.04/3.4/normal]'
 
@@ -2771,6 +3644,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_ubuntu-22.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_22_04-4_0_0-normal:
+    name: 'Ruby [ubuntu-22.04/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_22_04-4_0_0-jemalloc:
+    name: 'Ruby [ubuntu-22.04/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_ubuntu_22_04
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [ubuntu-22.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_22_04.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [ubuntu-22.04];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-22.04
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_22_04-4_0_0-malloctrim:
+    name: 'Ruby [ubuntu-22.04/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3657,6 +4821,10 @@ jobs:
 
       - build_jemalloc_debian_11
 
+      - build_ruby_debian_11-4_0-normal
+      - build_ruby_debian_11-4_0-jemalloc
+      - build_ruby_debian_11-4_0-malloctrim
+
       - build_ruby_debian_11-3_4-normal
       - build_ruby_debian_11-3_4-jemalloc
       - build_ruby_debian_11-3_4-malloctrim
@@ -3668,6 +4836,10 @@ jobs:
       - build_ruby_debian_11-3_2-normal
       - build_ruby_debian_11-3_2-jemalloc
       - build_ruby_debian_11-3_2-malloctrim
+
+      - build_ruby_debian_11-4_0_0-normal
+      - build_ruby_debian_11-4_0_0-jemalloc
+      - build_ruby_debian_11-4_0_0-malloctrim
 
       - build_ruby_debian_11-3_4_8-normal
       - build_ruby_debian_11-3_4_8-jemalloc
@@ -3683,6 +4855,10 @@ jobs:
 
       - build_jemalloc_ubuntu_22_04
 
+      - build_ruby_ubuntu_22_04-4_0-normal
+      - build_ruby_ubuntu_22_04-4_0-jemalloc
+      - build_ruby_ubuntu_22_04-4_0-malloctrim
+
       - build_ruby_ubuntu_22_04-3_4-normal
       - build_ruby_ubuntu_22_04-3_4-jemalloc
       - build_ruby_ubuntu_22_04-3_4-malloctrim
@@ -3694,6 +4870,10 @@ jobs:
       - build_ruby_ubuntu_22_04-3_2-normal
       - build_ruby_ubuntu_22_04-3_2-jemalloc
       - build_ruby_ubuntu_22_04-3_2-malloctrim
+
+      - build_ruby_ubuntu_22_04-4_0_0-normal
+      - build_ruby_ubuntu_22_04-4_0_0-jemalloc
+      - build_ruby_ubuntu_22_04-4_0_0-malloctrim
 
       - build_ruby_ubuntu_22_04-3_4_8-normal
       - build_ruby_ubuntu_22_04-3_4_8-jemalloc
@@ -3754,10 +4934,28 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-11_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-11_normal
+          path: artifacts/ruby-pkg_4.0_debian-11_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-11_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-11_jemalloc
+          path: artifacts/ruby-pkg_4.0_debian-11_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-11_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-11_malloctrim
+          path: artifacts/ruby-pkg_4.0_debian-11_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3811,6 +5009,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_debian-11_malloctrim
           path: artifacts/ruby-pkg_3.2_debian-11_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-11_normal
+          path: artifacts/ruby-pkg_4.0.0_debian-11_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-11_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_debian-11_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-11_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_debian-11_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3866,6 +5082,24 @@ jobs:
           name: ruby-pkg_3.2.9_debian-11_malloctrim
           path: artifacts/ruby-pkg_3.2.9_debian-11_malloctrim
           compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-22.04_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-22.04_normal
+          path: artifacts/ruby-pkg_4.0_ubuntu-22.04_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-22.04_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-22.04_jemalloc
+          path: artifacts/ruby-pkg_4.0_ubuntu-22.04_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-22.04_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-22.04_malloctrim
+          path: artifacts/ruby-pkg_4.0_ubuntu-22.04_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3919,6 +5153,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_ubuntu-22.04_malloctrim
           path: artifacts/ruby-pkg_3.2_ubuntu-22.04_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-22.04_normal
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-22.04_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-22.04_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3992,6 +5244,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_debian_11-4_0-normal.result != 'success'
+              && (needs.build_ruby_debian_11-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/normal];')))
+            || (needs.build_ruby_debian_11-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/jemalloc];')))
+            || (needs.build_ruby_debian_11-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_11-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/malloctrim];')))
             || (needs.build_ruby_debian_11-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4/normal];')))
@@ -4019,6 +5280,15 @@ jobs:
             || (needs.build_ruby_debian_11-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_debian_11-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.2/malloctrim];')))
+            || (needs.build_ruby_debian_11-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_debian_11-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/normal];')))
+            || (needs.build_ruby_debian_11-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/jemalloc];')))
+            || (needs.build_ruby_debian_11-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_11-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/malloctrim];')))
             || (needs.build_ruby_debian_11-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4.8/normal];')))
@@ -4050,6 +5320,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_ubuntu_22_04-4_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/normal];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_4-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4/normal];')))
@@ -4077,6 +5356,15 @@ jobs:
             || (needs.build_ruby_ubuntu_22_04-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.2/malloctrim];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/normal];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_4_8-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4.8/normal];')))

--- a/.github/workflows/ci-cd-build-packages-3.yml
+++ b/.github/workflows/ci-cd-build-packages-3.yml
@@ -154,6 +154,297 @@ jobs:
 
 
 
+  build_ruby_debian_12-4_0-normal:
+    name: 'Ruby [debian-12/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-12_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_12-4_0-jemalloc:
+    name: 'Ruby [debian-12/4.0/jemalloc]'
+
+    needs: build_jemalloc_debian_12
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-12]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_12.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-12];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-12
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-12_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_12-4_0-malloctrim:
+    name: 'Ruby [debian-12/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-12_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_debian_12-3_4-normal:
     name: 'Ruby [debian-12/3.4/normal]'
 
@@ -1024,6 +1315,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_debian-12_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_12-4_0_0-normal:
+    name: 'Ruby [debian-12/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_12-4_0_0-jemalloc:
+    name: 'Ruby [debian-12/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_debian_12
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-12]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_12.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-12];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-12
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_12-4_0_0-malloctrim:
+    name: 'Ruby [debian-12/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-12'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-12"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-12"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1901,6 +2483,297 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  build_ruby_ubuntu_24_04-4_0-normal:
+    name: 'Ruby [ubuntu-24.04/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-24.04_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_24_04-4_0-jemalloc:
+    name: 'Ruby [ubuntu-24.04/4.0/jemalloc]'
+
+    needs: build_jemalloc_ubuntu_24_04
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [ubuntu-24.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_24_04.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [ubuntu-24.04];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-24.04
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-24.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_24_04-4_0-malloctrim:
+    name: 'Ruby [ubuntu-24.04/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-24.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_ubuntu_24_04-3_4-normal:
     name: 'Ruby [ubuntu-24.04/3.4/normal]'
 
@@ -2771,6 +3644,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.2_ubuntu-24.04_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_24_04-4_0_0-normal:
+    name: 'Ruby [ubuntu-24.04/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_24_04-4_0_0-jemalloc:
+    name: 'Ruby [ubuntu-24.04/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_ubuntu_24_04
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [ubuntu-24.04]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_ubuntu_24_04.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [ubuntu-24.04];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-ubuntu-24.04
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_ubuntu_24_04-4_0_0-malloctrim:
+    name: 'Ruby [ubuntu-24.04/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3657,6 +4821,10 @@ jobs:
 
       - build_jemalloc_debian_12
 
+      - build_ruby_debian_12-4_0-normal
+      - build_ruby_debian_12-4_0-jemalloc
+      - build_ruby_debian_12-4_0-malloctrim
+
       - build_ruby_debian_12-3_4-normal
       - build_ruby_debian_12-3_4-jemalloc
       - build_ruby_debian_12-3_4-malloctrim
@@ -3668,6 +4836,10 @@ jobs:
       - build_ruby_debian_12-3_2-normal
       - build_ruby_debian_12-3_2-jemalloc
       - build_ruby_debian_12-3_2-malloctrim
+
+      - build_ruby_debian_12-4_0_0-normal
+      - build_ruby_debian_12-4_0_0-jemalloc
+      - build_ruby_debian_12-4_0_0-malloctrim
 
       - build_ruby_debian_12-3_4_8-normal
       - build_ruby_debian_12-3_4_8-jemalloc
@@ -3683,6 +4855,10 @@ jobs:
 
       - build_jemalloc_ubuntu_24_04
 
+      - build_ruby_ubuntu_24_04-4_0-normal
+      - build_ruby_ubuntu_24_04-4_0-jemalloc
+      - build_ruby_ubuntu_24_04-4_0-malloctrim
+
       - build_ruby_ubuntu_24_04-3_4-normal
       - build_ruby_ubuntu_24_04-3_4-jemalloc
       - build_ruby_ubuntu_24_04-3_4-malloctrim
@@ -3694,6 +4870,10 @@ jobs:
       - build_ruby_ubuntu_24_04-3_2-normal
       - build_ruby_ubuntu_24_04-3_2-jemalloc
       - build_ruby_ubuntu_24_04-3_2-malloctrim
+
+      - build_ruby_ubuntu_24_04-4_0_0-normal
+      - build_ruby_ubuntu_24_04-4_0_0-jemalloc
+      - build_ruby_ubuntu_24_04-4_0_0-malloctrim
 
       - build_ruby_ubuntu_24_04-3_4_8-normal
       - build_ruby_ubuntu_24_04-3_4_8-jemalloc
@@ -3754,10 +4934,28 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-12_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-12_normal
+          path: artifacts/ruby-pkg_4.0_debian-12_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-12_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-12_jemalloc
+          path: artifacts/ruby-pkg_4.0_debian-12_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-12_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-12_malloctrim
+          path: artifacts/ruby-pkg_4.0_debian-12_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3811,6 +5009,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_debian-12_malloctrim
           path: artifacts/ruby-pkg_3.2_debian-12_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-12_normal
+          path: artifacts/ruby-pkg_4.0.0_debian-12_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-12_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_debian-12_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-12_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_debian-12_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3866,6 +5082,24 @@ jobs:
           name: ruby-pkg_3.2.9_debian-12_malloctrim
           path: artifacts/ruby-pkg_3.2.9_debian-12_malloctrim
           compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-24.04_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-24.04_normal
+          path: artifacts/ruby-pkg_4.0_ubuntu-24.04_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-24.04_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-24.04_jemalloc
+          path: artifacts/ruby-pkg_4.0_ubuntu-24.04_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-24.04_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_ubuntu-24.04_malloctrim
+          path: artifacts/ruby-pkg_4.0_ubuntu-24.04_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -3919,6 +5153,24 @@ jobs:
         with:
           name: ruby-pkg_3.2_ubuntu-24.04_malloctrim
           path: artifacts/ruby-pkg_3.2_ubuntu-24.04_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-24.04_normal
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-24.04_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_ubuntu-24.04_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -3992,6 +5244,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_debian_12-4_0-normal.result != 'success'
+              && (needs.build_ruby_debian_12-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/normal];')))
+            || (needs.build_ruby_debian_12-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_12-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/jemalloc];')))
+            || (needs.build_ruby_debian_12-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_12-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/malloctrim];')))
             || (needs.build_ruby_debian_12-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4/normal];')))
@@ -4019,6 +5280,15 @@ jobs:
             || (needs.build_ruby_debian_12-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_debian_12-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.2/malloctrim];')))
+            || (needs.build_ruby_debian_12-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_debian_12-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/normal];')))
+            || (needs.build_ruby_debian_12-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_12-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/jemalloc];')))
+            || (needs.build_ruby_debian_12-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_12-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/malloctrim];')))
             || (needs.build_ruby_debian_12-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4.8/normal];')))
@@ -4050,6 +5320,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_ubuntu_24_04-4_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/normal];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_4-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4/normal];')))
@@ -4077,6 +5356,15 @@ jobs:
             || (needs.build_ruby_ubuntu_24_04-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.2/malloctrim];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/normal];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/jemalloc];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_4_8-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4.8/normal];')))

--- a/.github/workflows/ci-cd-build-packages-4.yml
+++ b/.github/workflows/ci-cd-build-packages-4.yml
@@ -95,6 +95,297 @@ jobs:
 
 
 
+  build_ruby_debian_13-4_0-normal:
+    name: 'Ruby [debian-13/4.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-13_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_13-4_0-jemalloc:
+    name: 'Ruby [debian-13/4.0/jemalloc]'
+
+    needs: build_jemalloc_debian_13
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-13]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_13.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-13];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-13
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-13_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_13-4_0-malloctrim:
+    name: 'Ruby [debian-13/4.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0_debian-13_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   build_ruby_debian_13-3_4-normal:
     name: 'Ruby [debian-13/3.4/normal]'
 
@@ -674,6 +965,297 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_debian-13_malloctrim"
+          ARTIFACT_PATH: output-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_13-4_0_0-normal:
+    name: 'Ruby [debian-13/4.0.0/normal]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/normal];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "normal"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_normal"
+          ARTIFACT_PATH: output-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_13-4_0_0-jemalloc:
+    name: 'Ruby [debian-13/4.0.0/jemalloc]'
+
+    needs: build_jemalloc_debian_13
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/jemalloc];')
+      && !failure() && !cancelled()
+    steps:
+      
+      - name: Check whether 'Build Jemalloc [debian-13]' did not fail
+        run: 'false'
+        if: |
+          needs.build_jemalloc_debian_13.result == 'skipped'
+          && contains(inputs.necessary_jobs, ';Build Jemalloc [debian-13];')        
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+      - name: Fetch Jemalloc binary
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: jemalloc-bin-debian-13
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}        
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "jemalloc"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_jemalloc"
+          ARTIFACT_PATH: output-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  build_ruby_debian_13-4_0_0-malloctrim:
+    name: 'Ruby [debian-13/4.0.0/malloctrim]'
+
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    # Run even if a dependent job has been skipped
+    if: |
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/malloctrim];')
+      && !failure() && !cancelled()
+    steps:
+      
+
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
+      - name: Fetch Ruby source
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Download Docker image necessary for building
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          ARTIFACT_NAME: 'docker-image-debian-13'
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for building
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
+        env:
+          TARBALL: image.tar.zst
+
+      - name: Download Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          ARTIFACT_NAME: docker-image-utility
+          ARTIFACT_PATH: .
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Load Docker image necessary for packaging
+        run: ./internal-scripts/ci-cd/load-docker-image.sh
+        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
+        env:
+          TARBALL: image.tar.zst
+
+      
+
+      - name: Build binaries
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
+        env:
+          ENVIRONMENT_NAME: "debian-13"
+          VARIANT_NAME: "malloctrim"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          CACHE_KEY_PREFIX: "sccache/debian-13"
+
+      - name: Build package
+        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          PACKAGE_FORMAT: "DEB"
+          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_REVISION: "0"
+
+      - name: Archive package artifact to Google Cloud
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_malloctrim"
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1269,6 +1851,10 @@ jobs:
 
       - build_jemalloc_debian_13
 
+      - build_ruby_debian_13-4_0-normal
+      - build_ruby_debian_13-4_0-jemalloc
+      - build_ruby_debian_13-4_0-malloctrim
+
       - build_ruby_debian_13-3_4-normal
       - build_ruby_debian_13-3_4-jemalloc
       - build_ruby_debian_13-3_4-malloctrim
@@ -1276,6 +1862,10 @@ jobs:
       - build_ruby_debian_13-3_3-normal
       - build_ruby_debian_13-3_3-jemalloc
       - build_ruby_debian_13-3_3-malloctrim
+
+      - build_ruby_debian_13-4_0_0-normal
+      - build_ruby_debian_13-4_0_0-jemalloc
+      - build_ruby_debian_13-4_0_0-malloctrim
 
       - build_ruby_debian_13-3_4_8-normal
       - build_ruby_debian_13-3_4_8-jemalloc
@@ -1325,10 +1915,28 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-13_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-13_normal
+          path: artifacts/ruby-pkg_4.0_debian-13_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-13_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-13_jemalloc
+          path: artifacts/ruby-pkg_4.0_debian-13_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-13_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0_debian-13_malloctrim
+          path: artifacts/ruby-pkg_4.0_debian-13_malloctrim
+          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -1364,6 +1972,24 @@ jobs:
         with:
           name: ruby-pkg_3.3_debian-13_malloctrim
           path: artifacts/ruby-pkg_3.3_debian-13_malloctrim
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_normal] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-13_normal
+          path: artifacts/ruby-pkg_4.0.0_debian-13_normal
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_jemalloc] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-13_jemalloc
+          path: artifacts/ruby-pkg_4.0.0_debian-13_jemalloc
+          compression-level: 0
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_malloctrim] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-pkg_4.0.0_debian-13_malloctrim
+          path: artifacts/ruby-pkg_4.0.0_debian-13_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
@@ -1416,6 +2042,15 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.build_ruby_debian_13-4_0-normal.result != 'success'
+              && (needs.build_ruby_debian_13-4_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/normal];')))
+            || (needs.build_ruby_debian_13-4_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_13-4_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/jemalloc];')))
+            || (needs.build_ruby_debian_13-4_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_13-4_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/malloctrim];')))
             || (needs.build_ruby_debian_13-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4/normal];')))
@@ -1434,6 +2069,15 @@ jobs:
             || (needs.build_ruby_debian_13-3_3-malloctrim.result != 'success'
               && (needs.build_ruby_debian_13-3_3-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3/malloctrim];')))
+            || (needs.build_ruby_debian_13-4_0_0-normal.result != 'success'
+              && (needs.build_ruby_debian_13-4_0_0-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/normal];')))
+            || (needs.build_ruby_debian_13-4_0_0-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_13-4_0_0-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/jemalloc];')))
+            || (needs.build_ruby_debian_13-4_0_0-malloctrim.result != 'success'
+              && (needs.build_ruby_debian_13-4_0_0-malloctrim.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/malloctrim];')))
             || (needs.build_ruby_debian_13-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4.8/normal];')))

--- a/.github/workflows/ci-cd-prepare.yml
+++ b/.github/workflows/ci-cd-prepare.yml
@@ -470,6 +470,40 @@ jobs:
   ### Sources ###
 
 
+  download_ruby_source_4_0_0:
+    name: Download Ruby source [4.0.0]
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    environment: test
+    if: contains(inputs.necessary_jobs, ';Download Ruby source 4.0.0;')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/login@v2
+        with:
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Download
+        run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
+        env:
+          RUBY_VERSION: 4.0.0
+
+      - name: Archive artifact
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: output
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   download_ruby_source_3_4_8:
     name: Download Ruby source [3.4.8]
     runs-on: ubuntu-24.04
@@ -930,6 +964,7 @@ jobs:
       - build_docker_image_ubuntu_22_04
       - build_docker_image_ubuntu_24_04
       - build_docker_image_utility
+      - download_ruby_source_4_0_0
       - download_ruby_source_3_4_8
       - download_ruby_source_3_3_10
       - download_ruby_source_3_2_9
@@ -1106,6 +1141,19 @@ jobs:
           path: artifacts
 
 
+      - name: Download Ruby source artifact [4.0.0] from Google Cloud
+        run: ./internal-scripts/ci-cd/download-artifact.sh
+        env:
+          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_PATH: artifacts
+          CLEAR: true
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+      - name: Archive Ruby source artifact [4.0.0] to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby-src-4.0.0
+          path: artifacts
+          compression-level: 0
       - name: Download Ruby source artifact [3.4.8] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1252,6 +1300,9 @@ jobs:
         run: 'false'
         if: |
           false
+            || (needs.download_ruby_source_4_0_0.result != 'success'
+              && (needs.download_ruby_source_4_0_0.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Download Ruby source 4.0.0;')))
             || (needs.download_ruby_source_3_4_8.result != 'success'
               && (needs.download_ruby_source_3_4_8.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Download Ruby source 3.4.8;')))

--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -68,7 +68,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -134,6 +134,135 @@ jobs:
 
 
 
+  test_centos_8-4_0-normal:
+    name: 'Test [centos-8/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_centos_8-4_0-jemalloc:
+    name: 'Test [centos-8/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_centos_8-4_0-malloctrim:
+    name: 'Test [centos-8/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
     needs:
@@ -519,6 +648,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_centos_8-4_0_0-normal:
+    name: 'Test [centos-8/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_centos_8-4_0_0-jemalloc:
+    name: 'Test [centos-8/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_centos_8-4_0_0-malloctrim:
+    name: 'Test [centos-8/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_4_8-normal:
@@ -909,6 +1167,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_debian_11-4_0-normal:
+    name: 'Test [debian-11/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_11-4_0-jemalloc:
+    name: 'Test [debian-11/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_11-4_0-malloctrim:
+    name: 'Test [debian-11/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
@@ -1294,6 +1681,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-debian-11_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_11-4_0_0-normal:
+    name: 'Test [debian-11/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_11-4_0_0-jemalloc:
+    name: 'Test [debian-11/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_11-4_0_0-malloctrim:
+    name: 'Test [debian-11/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_4_8-normal:
@@ -1684,6 +2200,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_debian_12-4_0-normal:
+    name: 'Test [debian-12/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_12-4_0-jemalloc:
+    name: 'Test [debian-12/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_12-4_0-malloctrim:
+    name: 'Test [debian-12/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
@@ -2069,6 +2714,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-debian-12_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_12-4_0_0-normal:
+    name: 'Test [debian-12/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_12-4_0_0-jemalloc:
+    name: 'Test [debian-12/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_12-4_0_0-malloctrim:
+    name: 'Test [debian-12/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_4_8-normal:
@@ -2459,6 +3233,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_debian_13-4_0-normal:
+    name: 'Test [debian-13/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_13-4_0-jemalloc:
+    name: 'Test [debian-13/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_13-4_0-malloctrim:
+    name: 'Test [debian-13/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
@@ -2715,6 +3618,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-debian-13_3.3_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_13-4_0_0-normal:
+    name: 'Test [debian-13/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_13-4_0_0-jemalloc:
+    name: 'Test [debian-13/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_debian_13-4_0_0-malloctrim:
+    name: 'Test [debian-13/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_4_8-normal:
@@ -2976,6 +4008,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_el_9-4_0-normal:
+    name: 'Test [el-9/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_el_9-4_0-jemalloc:
+    name: 'Test [el-9/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_el_9-4_0-malloctrim:
+    name: 'Test [el-9/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
     needs:
@@ -3361,6 +4522,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-el-9_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_el_9-4_0_0-normal:
+    name: 'Test [el-9/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_el_9-4_0_0-jemalloc:
+    name: 'Test [el-9/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_el_9-4_0_0-malloctrim:
+    name: 'Test [el-9/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_4_8-normal:
@@ -3751,6 +5041,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_ubuntu_22_04-4_0-normal:
+    name: 'Test [ubuntu-22.04/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_22_04-4_0-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_22_04-4_0-malloctrim:
+    name: 'Test [ubuntu-22.04/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
@@ -4136,6 +5555,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_22_04-4_0_0-normal:
+    name: 'Test [ubuntu-22.04/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_22_04-4_0_0-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_22_04-4_0_0-malloctrim:
+    name: 'Test [ubuntu-22.04/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_4_8-normal:
@@ -4526,6 +6074,135 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+  test_ubuntu_24_04-4_0-normal:
+    name: 'Test [ubuntu-24.04/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_24_04-4_0-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_24_04-4_0-malloctrim:
+    name: 'Test [ubuntu-24.04/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
@@ -4911,6 +6588,135 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_24_04-4_0_0-normal:
+    name: 'Test [ubuntu-24.04/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_24_04-4_0_0-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+  test_ubuntu_24_04-4_0_0-malloctrim:
+    name: 'Test [ubuntu-24.04/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-22.04
+    environment: test
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main'
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://apt.fullstaqruby.org
+          YUM_REPO_URL: https://yum.fullstaqruby.org
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_4_8-normal:
@@ -5312,6 +7118,9 @@ jobs:
       contents: write
     needs:
       - publish
+      - test_centos_8-4_0-normal
+      - test_centos_8-4_0-jemalloc
+      - test_centos_8-4_0-malloctrim
       - test_centos_8-3_4-normal
       - test_centos_8-3_4-jemalloc
       - test_centos_8-3_4-malloctrim
@@ -5321,6 +7130,9 @@ jobs:
       - test_centos_8-3_2-normal
       - test_centos_8-3_2-jemalloc
       - test_centos_8-3_2-malloctrim
+      - test_centos_8-4_0_0-normal
+      - test_centos_8-4_0_0-jemalloc
+      - test_centos_8-4_0_0-malloctrim
       - test_centos_8-3_4_8-normal
       - test_centos_8-3_4_8-jemalloc
       - test_centos_8-3_4_8-malloctrim
@@ -5330,6 +7142,9 @@ jobs:
       - test_centos_8-3_2_9-normal
       - test_centos_8-3_2_9-jemalloc
       - test_centos_8-3_2_9-malloctrim
+      - test_debian_11-4_0-normal
+      - test_debian_11-4_0-jemalloc
+      - test_debian_11-4_0-malloctrim
       - test_debian_11-3_4-normal
       - test_debian_11-3_4-jemalloc
       - test_debian_11-3_4-malloctrim
@@ -5339,6 +7154,9 @@ jobs:
       - test_debian_11-3_2-normal
       - test_debian_11-3_2-jemalloc
       - test_debian_11-3_2-malloctrim
+      - test_debian_11-4_0_0-normal
+      - test_debian_11-4_0_0-jemalloc
+      - test_debian_11-4_0_0-malloctrim
       - test_debian_11-3_4_8-normal
       - test_debian_11-3_4_8-jemalloc
       - test_debian_11-3_4_8-malloctrim
@@ -5348,6 +7166,9 @@ jobs:
       - test_debian_11-3_2_9-normal
       - test_debian_11-3_2_9-jemalloc
       - test_debian_11-3_2_9-malloctrim
+      - test_debian_12-4_0-normal
+      - test_debian_12-4_0-jemalloc
+      - test_debian_12-4_0-malloctrim
       - test_debian_12-3_4-normal
       - test_debian_12-3_4-jemalloc
       - test_debian_12-3_4-malloctrim
@@ -5357,6 +7178,9 @@ jobs:
       - test_debian_12-3_2-normal
       - test_debian_12-3_2-jemalloc
       - test_debian_12-3_2-malloctrim
+      - test_debian_12-4_0_0-normal
+      - test_debian_12-4_0_0-jemalloc
+      - test_debian_12-4_0_0-malloctrim
       - test_debian_12-3_4_8-normal
       - test_debian_12-3_4_8-jemalloc
       - test_debian_12-3_4_8-malloctrim
@@ -5366,18 +7190,27 @@ jobs:
       - test_debian_12-3_2_9-normal
       - test_debian_12-3_2_9-jemalloc
       - test_debian_12-3_2_9-malloctrim
+      - test_debian_13-4_0-normal
+      - test_debian_13-4_0-jemalloc
+      - test_debian_13-4_0-malloctrim
       - test_debian_13-3_4-normal
       - test_debian_13-3_4-jemalloc
       - test_debian_13-3_4-malloctrim
       - test_debian_13-3_3-normal
       - test_debian_13-3_3-jemalloc
       - test_debian_13-3_3-malloctrim
+      - test_debian_13-4_0_0-normal
+      - test_debian_13-4_0_0-jemalloc
+      - test_debian_13-4_0_0-malloctrim
       - test_debian_13-3_4_8-normal
       - test_debian_13-3_4_8-jemalloc
       - test_debian_13-3_4_8-malloctrim
       - test_debian_13-3_3_10-normal
       - test_debian_13-3_3_10-jemalloc
       - test_debian_13-3_3_10-malloctrim
+      - test_el_9-4_0-normal
+      - test_el_9-4_0-jemalloc
+      - test_el_9-4_0-malloctrim
       - test_el_9-3_4-normal
       - test_el_9-3_4-jemalloc
       - test_el_9-3_4-malloctrim
@@ -5387,6 +7220,9 @@ jobs:
       - test_el_9-3_2-normal
       - test_el_9-3_2-jemalloc
       - test_el_9-3_2-malloctrim
+      - test_el_9-4_0_0-normal
+      - test_el_9-4_0_0-jemalloc
+      - test_el_9-4_0_0-malloctrim
       - test_el_9-3_4_8-normal
       - test_el_9-3_4_8-jemalloc
       - test_el_9-3_4_8-malloctrim
@@ -5396,6 +7232,9 @@ jobs:
       - test_el_9-3_2_9-normal
       - test_el_9-3_2_9-jemalloc
       - test_el_9-3_2_9-malloctrim
+      - test_ubuntu_22_04-4_0-normal
+      - test_ubuntu_22_04-4_0-jemalloc
+      - test_ubuntu_22_04-4_0-malloctrim
       - test_ubuntu_22_04-3_4-normal
       - test_ubuntu_22_04-3_4-jemalloc
       - test_ubuntu_22_04-3_4-malloctrim
@@ -5405,6 +7244,9 @@ jobs:
       - test_ubuntu_22_04-3_2-normal
       - test_ubuntu_22_04-3_2-jemalloc
       - test_ubuntu_22_04-3_2-malloctrim
+      - test_ubuntu_22_04-4_0_0-normal
+      - test_ubuntu_22_04-4_0_0-jemalloc
+      - test_ubuntu_22_04-4_0_0-malloctrim
       - test_ubuntu_22_04-3_4_8-normal
       - test_ubuntu_22_04-3_4_8-jemalloc
       - test_ubuntu_22_04-3_4_8-malloctrim
@@ -5414,6 +7256,9 @@ jobs:
       - test_ubuntu_22_04-3_2_9-normal
       - test_ubuntu_22_04-3_2_9-jemalloc
       - test_ubuntu_22_04-3_2_9-malloctrim
+      - test_ubuntu_24_04-4_0-normal
+      - test_ubuntu_24_04-4_0-jemalloc
+      - test_ubuntu_24_04-4_0-malloctrim
       - test_ubuntu_24_04-3_4-normal
       - test_ubuntu_24_04-3_4-jemalloc
       - test_ubuntu_24_04-3_4-malloctrim
@@ -5423,6 +7268,9 @@ jobs:
       - test_ubuntu_24_04-3_2-normal
       - test_ubuntu_24_04-3_2-jemalloc
       - test_ubuntu_24_04-3_2-malloctrim
+      - test_ubuntu_24_04-4_0_0-normal
+      - test_ubuntu_24_04-4_0_0-jemalloc
+      - test_ubuntu_24_04-4_0_0-malloctrim
       - test_ubuntu_24_04-3_4_8-normal
       - test_ubuntu_24_04-3_4_8-jemalloc
       - test_ubuntu_24_04-3_4_8-malloctrim
@@ -5446,6 +7294,27 @@ jobs:
         run: 'false'
         if: needs.publish.result != 'success'
 
+      - name: Check whether 'Test [centos-8/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0-normal.result != 'success'
+          && (needs.test_centos_8-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/normal];'))
+      - name: Check whether 'Test [centos-8/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5509,6 +7378,27 @@ jobs:
           && needs.test_centos_8-3_2-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.2/malloctrim];'))
+      - name: Check whether 'Test [centos-8/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0_0-normal.result != 'success'
+          && (needs.test_centos_8-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/normal];'))
+      - name: Check whether 'Test [centos-8/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_centos_8-4_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5572,6 +7462,27 @@ jobs:
           && needs.test_centos_8-3_2_9-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-11/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0-normal.result != 'success'
+          && (needs.test_debian_11-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/normal];'))
+      - name: Check whether 'Test [debian-11/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-11/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_11-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5635,6 +7546,27 @@ jobs:
           && needs.test_debian_11-3_2-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.2/malloctrim];'))
+      - name: Check whether 'Test [debian-11/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0_0-normal.result != 'success'
+          && (needs.test_debian_11-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-11/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-11/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_11-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_11-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5698,6 +7630,27 @@ jobs:
           && needs.test_debian_11-3_2_9-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-12/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0-normal.result != 'success'
+          && (needs.test_debian_12-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/normal];'))
+      - name: Check whether 'Test [debian-12/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-12/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_12-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5761,6 +7714,27 @@ jobs:
           && needs.test_debian_12-3_2-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.2/malloctrim];'))
+      - name: Check whether 'Test [debian-12/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0_0-normal.result != 'success'
+          && (needs.test_debian_12-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-12/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-12/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_12-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_12-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5824,6 +7798,27 @@ jobs:
           && needs.test_debian_12-3_2_9-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-13/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0-normal.result != 'success'
+          && (needs.test_debian_13-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/normal];'))
+      - name: Check whether 'Test [debian-13/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-13/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_13-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5866,6 +7861,27 @@ jobs:
           && needs.test_debian_13-3_3-malloctrim.result != 'success'
           && (needs.test_debian_13-3_3-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3/malloctrim];'))
+      - name: Check whether 'Test [debian-13/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0_0-normal.result != 'success'
+          && (needs.test_debian_13-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-13/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-13/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_debian_13-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_13-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5908,6 +7924,27 @@ jobs:
           && needs.test_debian_13-3_3_10-malloctrim.result != 'success'
           && (needs.test_debian_13-3_3_10-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3.10/malloctrim];'))
+      - name: Check whether 'Test [el-9/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0-normal.result != 'success'
+          && (needs.test_el_9-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/normal];'))
+      - name: Check whether 'Test [el-9/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/jemalloc];'))
+      - name: Check whether 'Test [el-9/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0-malloctrim.result != 'success'
+          && (needs.test_el_9-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5971,6 +8008,27 @@ jobs:
           && needs.test_el_9-3_2-malloctrim.result != 'success'
           && (needs.test_el_9-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.2/malloctrim];'))
+      - name: Check whether 'Test [el-9/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0_0-normal.result != 'success'
+          && (needs.test_el_9-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/normal];'))
+      - name: Check whether 'Test [el-9/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0_0-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [el-9/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_el_9-4_0_0-malloctrim.result != 'success'
+          && (needs.test_el_9-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -6034,6 +8092,27 @@ jobs:
           && needs.test_el_9-3_2_9-malloctrim.result != 'success'
           && (needs.test_el_9-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -6097,6 +8176,27 @@ jobs:
           && needs.test_ubuntu_22_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.2/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -6160,6 +8260,27 @@ jobs:
           && needs.test_ubuntu_22_04-3_2_9-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -6223,6 +8344,27 @@ jobs:
           && needs.test_ubuntu_24_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.2/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          github.ref == 'refs/heads/main'
+          && needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -68,7 +68,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -112,6 +112,132 @@ jobs:
   ### Run tests ###
 
 
+
+  test_centos_8-4_0-normal:
+    name: 'Test [centos-8/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_centos_8-4_0-jemalloc:
+    name: 'Test [centos-8/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_centos_8-4_0-malloctrim:
+    name: 'Test [centos-8/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
@@ -488,6 +614,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-centos-8_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_centos_8-4_0_0-normal:
+    name: 'Test [centos-8/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_centos_8-4_0_0-jemalloc:
+    name: 'Test [centos-8/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_centos_8-4_0_0-malloctrim:
+    name: 'Test [centos-8/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "centos-8"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:8"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -870,6 +1122,132 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  test_debian_11-4_0-normal:
+    name: 'Test [debian-11/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_11-4_0-jemalloc:
+    name: 'Test [debian-11/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_11-4_0-malloctrim:
+    name: 'Test [debian-11/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
@@ -1245,6 +1623,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-debian-11_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_11-4_0_0-normal:
+    name: 'Test [debian-11/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_11-4_0_0-jemalloc:
+    name: 'Test [debian-11/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_11-4_0_0-malloctrim:
+    name: 'Test [debian-11/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-11"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:11"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1627,6 +2131,132 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  test_debian_12-4_0-normal:
+    name: 'Test [debian-12/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_12-4_0-jemalloc:
+    name: 'Test [debian-12/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_12-4_0-malloctrim:
+    name: 'Test [debian-12/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
@@ -2002,6 +2632,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-debian-12_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_12-4_0_0-normal:
+    name: 'Test [debian-12/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_12-4_0_0-jemalloc:
+    name: 'Test [debian-12/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_12-4_0_0-malloctrim:
+    name: 'Test [debian-12/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-12"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:12"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2384,6 +3140,132 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  test_debian_13-4_0-normal:
+    name: 'Test [debian-13/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_13-4_0-jemalloc:
+    name: 'Test [debian-13/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_13-4_0-malloctrim:
+    name: 'Test [debian-13/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
@@ -2633,6 +3515,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-debian-13_3.3_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_13-4_0_0-normal:
+    name: 'Test [debian-13/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_13-4_0_0-jemalloc:
+    name: 'Test [debian-13/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_debian_13-4_0_0-malloctrim:
+    name: 'Test [debian-13/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "debian-13"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "debian:13"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2888,6 +3896,132 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
+
+  test_el_9-4_0-normal:
+    name: 'Test [el-9/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_el_9-4_0-jemalloc:
+    name: 'Test [el-9/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_el_9-4_0-malloctrim:
+    name: 'Test [el-9/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
@@ -3264,6 +4398,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-el-9_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_el_9-4_0_0-normal:
+    name: 'Test [el-9/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_el_9-4_0_0-jemalloc:
+    name: 'Test [el-9/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_el_9-4_0_0-malloctrim:
+    name: 'Test [el-9/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "el-9"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "RPM"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "rockylinux:9"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3646,6 +4906,132 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  test_ubuntu_22_04-4_0-normal:
+    name: 'Test [ubuntu-22.04/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_22_04-4_0-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_22_04-4_0-malloctrim:
+    name: 'Test [ubuntu-22.04/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
@@ -4021,6 +5407,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_22_04-4_0_0-normal:
+    name: 'Test [ubuntu-22.04/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_22_04-4_0_0-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_22_04-4_0_0-malloctrim:
+    name: 'Test [ubuntu-22.04/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-22.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:22.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -4403,6 +5915,132 @@ jobs:
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
+  test_ubuntu_24_04-4_0-normal:
+    name: 'Test [ubuntu-24.04/4.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_24_04-4_0-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_24_04-4_0-malloctrim:
+    name: 'Test [ubuntu-24.04/4.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
@@ -4778,6 +6416,132 @@ jobs:
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.2_malloctrim
+          ARTIFACT_PATH: mark-malloctrim
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_24_04-4_0_0-normal:
+    name: 'Test [ubuntu-24.04/4.0.0/normal]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/normal];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "normal"
+          VARIANT_PACKAGE_SUFFIX: ""
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-normal && touch mark-normal/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_normal
+          ARTIFACT_PATH: mark-normal
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_24_04-4_0_0-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0.0/jemalloc]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/jemalloc];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "jemalloc"
+          VARIANT_PACKAGE_SUFFIX: "-jemalloc"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-jemalloc && touch mark-jemalloc/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_jemalloc
+          ARTIFACT_PATH: mark-jemalloc
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+  test_ubuntu_24_04-4_0_0-malloctrim:
+    name: 'Test [ubuntu-24.04/4.0.0/malloctrim]'
+    needs:
+      - publish
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/malloctrim];')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Run tests
+        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
+        env:
+          DISTRIBUTION_NAME: "ubuntu-24.04"
+          RUBY_PACKAGE_ID: "4.0.0"
+          PACKAGE_FORMAT: "DEB"
+          VARIANT_NAME: "malloctrim"
+          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
+          TEST_IMAGE_NAME: "ubuntu:24.04"
+          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
+          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
+
+      - name: Create mark file
+        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
+      - name: Mark job as done
+        run: ./internal-scripts/ci-cd/upload-artifact.sh
+        env:
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -5170,6 +6934,9 @@ jobs:
       id-token: write
     needs:
       - publish
+      - test_centos_8-4_0-normal
+      - test_centos_8-4_0-jemalloc
+      - test_centos_8-4_0-malloctrim
       - test_centos_8-3_4-normal
       - test_centos_8-3_4-jemalloc
       - test_centos_8-3_4-malloctrim
@@ -5179,6 +6946,9 @@ jobs:
       - test_centos_8-3_2-normal
       - test_centos_8-3_2-jemalloc
       - test_centos_8-3_2-malloctrim
+      - test_centos_8-4_0_0-normal
+      - test_centos_8-4_0_0-jemalloc
+      - test_centos_8-4_0_0-malloctrim
       - test_centos_8-3_4_8-normal
       - test_centos_8-3_4_8-jemalloc
       - test_centos_8-3_4_8-malloctrim
@@ -5188,6 +6958,9 @@ jobs:
       - test_centos_8-3_2_9-normal
       - test_centos_8-3_2_9-jemalloc
       - test_centos_8-3_2_9-malloctrim
+      - test_debian_11-4_0-normal
+      - test_debian_11-4_0-jemalloc
+      - test_debian_11-4_0-malloctrim
       - test_debian_11-3_4-normal
       - test_debian_11-3_4-jemalloc
       - test_debian_11-3_4-malloctrim
@@ -5197,6 +6970,9 @@ jobs:
       - test_debian_11-3_2-normal
       - test_debian_11-3_2-jemalloc
       - test_debian_11-3_2-malloctrim
+      - test_debian_11-4_0_0-normal
+      - test_debian_11-4_0_0-jemalloc
+      - test_debian_11-4_0_0-malloctrim
       - test_debian_11-3_4_8-normal
       - test_debian_11-3_4_8-jemalloc
       - test_debian_11-3_4_8-malloctrim
@@ -5206,6 +6982,9 @@ jobs:
       - test_debian_11-3_2_9-normal
       - test_debian_11-3_2_9-jemalloc
       - test_debian_11-3_2_9-malloctrim
+      - test_debian_12-4_0-normal
+      - test_debian_12-4_0-jemalloc
+      - test_debian_12-4_0-malloctrim
       - test_debian_12-3_4-normal
       - test_debian_12-3_4-jemalloc
       - test_debian_12-3_4-malloctrim
@@ -5215,6 +6994,9 @@ jobs:
       - test_debian_12-3_2-normal
       - test_debian_12-3_2-jemalloc
       - test_debian_12-3_2-malloctrim
+      - test_debian_12-4_0_0-normal
+      - test_debian_12-4_0_0-jemalloc
+      - test_debian_12-4_0_0-malloctrim
       - test_debian_12-3_4_8-normal
       - test_debian_12-3_4_8-jemalloc
       - test_debian_12-3_4_8-malloctrim
@@ -5224,18 +7006,27 @@ jobs:
       - test_debian_12-3_2_9-normal
       - test_debian_12-3_2_9-jemalloc
       - test_debian_12-3_2_9-malloctrim
+      - test_debian_13-4_0-normal
+      - test_debian_13-4_0-jemalloc
+      - test_debian_13-4_0-malloctrim
       - test_debian_13-3_4-normal
       - test_debian_13-3_4-jemalloc
       - test_debian_13-3_4-malloctrim
       - test_debian_13-3_3-normal
       - test_debian_13-3_3-jemalloc
       - test_debian_13-3_3-malloctrim
+      - test_debian_13-4_0_0-normal
+      - test_debian_13-4_0_0-jemalloc
+      - test_debian_13-4_0_0-malloctrim
       - test_debian_13-3_4_8-normal
       - test_debian_13-3_4_8-jemalloc
       - test_debian_13-3_4_8-malloctrim
       - test_debian_13-3_3_10-normal
       - test_debian_13-3_3_10-jemalloc
       - test_debian_13-3_3_10-malloctrim
+      - test_el_9-4_0-normal
+      - test_el_9-4_0-jemalloc
+      - test_el_9-4_0-malloctrim
       - test_el_9-3_4-normal
       - test_el_9-3_4-jemalloc
       - test_el_9-3_4-malloctrim
@@ -5245,6 +7036,9 @@ jobs:
       - test_el_9-3_2-normal
       - test_el_9-3_2-jemalloc
       - test_el_9-3_2-malloctrim
+      - test_el_9-4_0_0-normal
+      - test_el_9-4_0_0-jemalloc
+      - test_el_9-4_0_0-malloctrim
       - test_el_9-3_4_8-normal
       - test_el_9-3_4_8-jemalloc
       - test_el_9-3_4_8-malloctrim
@@ -5254,6 +7048,9 @@ jobs:
       - test_el_9-3_2_9-normal
       - test_el_9-3_2_9-jemalloc
       - test_el_9-3_2_9-malloctrim
+      - test_ubuntu_22_04-4_0-normal
+      - test_ubuntu_22_04-4_0-jemalloc
+      - test_ubuntu_22_04-4_0-malloctrim
       - test_ubuntu_22_04-3_4-normal
       - test_ubuntu_22_04-3_4-jemalloc
       - test_ubuntu_22_04-3_4-malloctrim
@@ -5263,6 +7060,9 @@ jobs:
       - test_ubuntu_22_04-3_2-normal
       - test_ubuntu_22_04-3_2-jemalloc
       - test_ubuntu_22_04-3_2-malloctrim
+      - test_ubuntu_22_04-4_0_0-normal
+      - test_ubuntu_22_04-4_0_0-jemalloc
+      - test_ubuntu_22_04-4_0_0-malloctrim
       - test_ubuntu_22_04-3_4_8-normal
       - test_ubuntu_22_04-3_4_8-jemalloc
       - test_ubuntu_22_04-3_4_8-malloctrim
@@ -5272,6 +7072,9 @@ jobs:
       - test_ubuntu_22_04-3_2_9-normal
       - test_ubuntu_22_04-3_2_9-jemalloc
       - test_ubuntu_22_04-3_2_9-malloctrim
+      - test_ubuntu_24_04-4_0-normal
+      - test_ubuntu_24_04-4_0-jemalloc
+      - test_ubuntu_24_04-4_0-malloctrim
       - test_ubuntu_24_04-3_4-normal
       - test_ubuntu_24_04-3_4-jemalloc
       - test_ubuntu_24_04-3_4-malloctrim
@@ -5281,6 +7084,9 @@ jobs:
       - test_ubuntu_24_04-3_2-normal
       - test_ubuntu_24_04-3_2-jemalloc
       - test_ubuntu_24_04-3_2-malloctrim
+      - test_ubuntu_24_04-4_0_0-normal
+      - test_ubuntu_24_04-4_0_0-jemalloc
+      - test_ubuntu_24_04-4_0_0-malloctrim
       - test_ubuntu_24_04-3_4_8-normal
       - test_ubuntu_24_04-3_4_8-jemalloc
       - test_ubuntu_24_04-3_4_8-malloctrim
@@ -5302,6 +7108,24 @@ jobs:
         run: 'false'
         if: needs.publish.result != 'success'
 
+      - name: Check whether 'Test [centos-8/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0-normal.result != 'success'
+          && (needs.test_centos_8-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/normal];'))
+      - name: Check whether 'Test [centos-8/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5356,6 +7180,24 @@ jobs:
           needs.test_centos_8-3_2-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.2/malloctrim];'))
+      - name: Check whether 'Test [centos-8/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0_0-normal.result != 'success'
+          && (needs.test_centos_8-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/normal];'))
+      - name: Check whether 'Test [centos-8/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0_0-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [centos-8/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_centos_8-4_0_0-malloctrim.result != 'success'
+          && (needs.test_centos_8-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5410,6 +7252,24 @@ jobs:
           needs.test_centos_8-3_2_9-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-11/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0-normal.result != 'success'
+          && (needs.test_debian_11-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/normal];'))
+      - name: Check whether 'Test [debian-11/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-11/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_11-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5464,6 +7324,24 @@ jobs:
           needs.test_debian_11-3_2-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.2/malloctrim];'))
+      - name: Check whether 'Test [debian-11/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0_0-normal.result != 'success'
+          && (needs.test_debian_11-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-11/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-11/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_11-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_11-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5518,6 +7396,24 @@ jobs:
           needs.test_debian_11-3_2_9-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-12/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0-normal.result != 'success'
+          && (needs.test_debian_12-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/normal];'))
+      - name: Check whether 'Test [debian-12/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-12/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_12-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5572,6 +7468,24 @@ jobs:
           needs.test_debian_12-3_2-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.2/malloctrim];'))
+      - name: Check whether 'Test [debian-12/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0_0-normal.result != 'success'
+          && (needs.test_debian_12-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-12/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-12/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_12-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_12-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5626,6 +7540,24 @@ jobs:
           needs.test_debian_12-3_2_9-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [debian-13/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0-normal.result != 'success'
+          && (needs.test_debian_13-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/normal];'))
+      - name: Check whether 'Test [debian-13/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/jemalloc];'))
+      - name: Check whether 'Test [debian-13/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0-malloctrim.result != 'success'
+          && (needs.test_debian_13-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5662,6 +7594,24 @@ jobs:
           needs.test_debian_13-3_3-malloctrim.result != 'success'
           && (needs.test_debian_13-3_3-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3/malloctrim];'))
+      - name: Check whether 'Test [debian-13/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0_0-normal.result != 'success'
+          && (needs.test_debian_13-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/normal];'))
+      - name: Check whether 'Test [debian-13/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0_0-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [debian-13/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_debian_13-4_0_0-malloctrim.result != 'success'
+          && (needs.test_debian_13-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5698,6 +7648,24 @@ jobs:
           needs.test_debian_13-3_3_10-malloctrim.result != 'success'
           && (needs.test_debian_13-3_3_10-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3.10/malloctrim];'))
+      - name: Check whether 'Test [el-9/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0-normal.result != 'success'
+          && (needs.test_el_9-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/normal];'))
+      - name: Check whether 'Test [el-9/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/jemalloc];'))
+      - name: Check whether 'Test [el-9/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0-malloctrim.result != 'success'
+          && (needs.test_el_9-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5752,6 +7720,24 @@ jobs:
           needs.test_el_9-3_2-malloctrim.result != 'success'
           && (needs.test_el_9-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.2/malloctrim];'))
+      - name: Check whether 'Test [el-9/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0_0-normal.result != 'success'
+          && (needs.test_el_9-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/normal];'))
+      - name: Check whether 'Test [el-9/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0_0-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [el-9/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_el_9-4_0_0-malloctrim.result != 'success'
+          && (needs.test_el_9-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5806,6 +7792,24 @@ jobs:
           needs.test_el_9-3_2_9-malloctrim.result != 'success'
           && (needs.test_el_9-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5860,6 +7864,24 @@ jobs:
           needs.test_ubuntu_22_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.2/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -5914,6 +7936,24 @@ jobs:
           needs.test_ubuntu_22_04-3_2_9-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2_9-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.2.9/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -5968,6 +8008,24 @@ jobs:
           needs.test_ubuntu_24_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.2/malloctrim];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/normal]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0_0-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/jemalloc]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/jemalloc];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.0/malloctrim]' did not fail
+        run: 'false'
+        if: |
+          needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |

--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,9 @@ ruby:
   ## NOTE: if you change an existing `full_version` value,
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
+    - minor_version: '4.0'
+      full_version: '4.0.0'
+      package_revision: '0'
     - minor_version: '3.4'
       full_version: '3.4.8'
       package_revision: '7'
@@ -24,6 +27,8 @@ ruby:
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
+    - full_version: '4.0.0'
+      package_revision: '0'
     - full_version: '3.4.8'
       package_revision: '0'
     - full_version: '3.3.10'


### PR DESCRIPTION
## Summary

- Adds Ruby 4.0.0 as a minor version package (`4.0`) and tiny version package (`4.0.0`) in `config.yml`
- Regenerates all CI/CD workflow files via `generate-ci-cd-yaml.rb`

Ref: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/

## Test plan

- [ ] CI/CD workflows generate cleanly (`./internal-scripts/generate-ci-cd-yaml.rb`)
- [ ] Ruby 4.0.0 build jobs appear for all distributions and variants
- [ ] Existing Ruby 3.2/3.3/3.4 builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)