### PR TITLE
Skip malloctrim variant for Ruby >= 3.3 to fix disk space issue

### DIFF
--- a/.github/workflows/ci-cd-build-packages-1.yml
+++ b/.github/workflows/ci-cd-build-packages-1.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -238,7 +238,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -289,7 +289,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -343,106 +343,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_centos_8-4_0-malloctrim:
-    name: 'Ruby [centos-8/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_centos_8-3_4-normal:
@@ -643,99 +550,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_centos_8-3_4-malloctrim:
-    name: 'Ruby [centos-8/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_centos_8-3_3-normal:
     name: 'Ruby [centos-8/3.3/normal]'
 
@@ -932,99 +746,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_centos_8-3_3-malloctrim:
-    name: 'Ruby [centos-8/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_centos_8-3_2-normal:
@@ -1318,8 +1039,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_centos_8-4_0_0-normal:
-    name: 'Ruby [centos-8/4.0.0/normal]'
+  build_ruby_centos_8-4_0_2-normal:
+    name: 'Ruby [centos-8/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -1329,7 +1050,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -1354,7 +1075,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1391,7 +1112,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
@@ -1401,18 +1122,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_centos-8_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_centos_8-4_0_0-jemalloc:
-    name: 'Ruby [centos-8/4.0.0/jemalloc]'
+  build_ruby_centos_8-4_0_2-jemalloc:
+    name: 'Ruby [centos-8/4.0.2/jemalloc]'
 
     needs: build_jemalloc_centos_8
     runs-on: ubuntu-24.04
@@ -1423,7 +1144,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -1453,7 +1174,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1496,7 +1217,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
@@ -1506,107 +1227,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_centos_8-4_0_0-malloctrim:
-    name: 'Ruby [centos-8/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_centos_8-3_4_8-normal:
@@ -1807,99 +1435,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_centos_8-3_4_8-malloctrim:
-    name: 'Ruby [centos-8/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_centos_8-3_3_10-normal:
     name: 'Ruby [centos-8/3.3.10/normal]'
 
@@ -2096,99 +1631,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_centos-8_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_centos_8-3_3_10-malloctrim:
-    name: 'Ruby [centos-8/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          ARTIFACT_NAME: 'docker-image-centos-8'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image centos-8;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/centos-8"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_centos-8_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_centos_8-3_2_9-normal:
@@ -2519,7 +1961,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2567,7 +2009,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2618,7 +2060,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2672,106 +2114,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_el-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_el_9-4_0-malloctrim:
-    name: 'Ruby [el-9/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_el_9-3_4-normal:
@@ -2972,99 +2321,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_el_9-3_4-malloctrim:
-    name: 'Ruby [el-9/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_el_9-3_3-normal:
     name: 'Ruby [el-9/3.3/normal]'
 
@@ -3261,99 +2517,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_el-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_el_9-3_3-malloctrim:
-    name: 'Ruby [el-9/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_el_9-3_2-normal:
@@ -3647,8 +2810,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_el_9-4_0_0-normal:
-    name: 'Ruby [el-9/4.0.0/normal]'
+  build_ruby_el_9-4_0_2-normal:
+    name: 'Ruby [el-9/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -3658,7 +2821,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -3683,7 +2846,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3720,7 +2883,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "el-9"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/el-9"
 
       - name: Build package
@@ -3730,18 +2893,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_el-9_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_el_9-4_0_0-jemalloc:
-    name: 'Ruby [el-9/4.0.0/jemalloc]'
+  build_ruby_el_9-4_0_2-jemalloc:
+    name: 'Ruby [el-9/4.0.2/jemalloc]'
 
     needs: build_jemalloc_el_9
     runs-on: ubuntu-24.04
@@ -3752,7 +2915,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -3782,7 +2945,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3825,7 +2988,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "el-9"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/el-9"
 
       - name: Build package
@@ -3835,107 +2998,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_el-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_el_9-4_0_0-malloctrim:
-    name: 'Ruby [el-9/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_el_9-3_4_8-normal:
@@ -4136,99 +3206,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_el_9-3_4_8-malloctrim:
-    name: 'Ruby [el-9/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_el_9-3_3_10-normal:
     name: 'Ruby [el-9/3.3.10/normal]'
 
@@ -4425,99 +3402,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_el-9_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_el_9-3_3_10-malloctrim:
-    name: 'Ruby [el-9/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          ARTIFACT_NAME: 'docker-image-el-9'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image el-9;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/el-9"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "RPM"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_el-9_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_el_9-3_2_9-normal:
@@ -4823,31 +3707,25 @@ jobs:
 
       - build_ruby_centos_8-4_0-normal
       - build_ruby_centos_8-4_0-jemalloc
-      - build_ruby_centos_8-4_0-malloctrim
 
       - build_ruby_centos_8-3_4-normal
       - build_ruby_centos_8-3_4-jemalloc
-      - build_ruby_centos_8-3_4-malloctrim
 
       - build_ruby_centos_8-3_3-normal
       - build_ruby_centos_8-3_3-jemalloc
-      - build_ruby_centos_8-3_3-malloctrim
 
       - build_ruby_centos_8-3_2-normal
       - build_ruby_centos_8-3_2-jemalloc
       - build_ruby_centos_8-3_2-malloctrim
 
-      - build_ruby_centos_8-4_0_0-normal
-      - build_ruby_centos_8-4_0_0-jemalloc
-      - build_ruby_centos_8-4_0_0-malloctrim
+      - build_ruby_centos_8-4_0_2-normal
+      - build_ruby_centos_8-4_0_2-jemalloc
 
       - build_ruby_centos_8-3_4_8-normal
       - build_ruby_centos_8-3_4_8-jemalloc
-      - build_ruby_centos_8-3_4_8-malloctrim
 
       - build_ruby_centos_8-3_3_10-normal
       - build_ruby_centos_8-3_3_10-jemalloc
-      - build_ruby_centos_8-3_3_10-malloctrim
 
       - build_ruby_centos_8-3_2_9-normal
       - build_ruby_centos_8-3_2_9-jemalloc
@@ -4857,31 +3735,25 @@ jobs:
 
       - build_ruby_el_9-4_0-normal
       - build_ruby_el_9-4_0-jemalloc
-      - build_ruby_el_9-4_0-malloctrim
 
       - build_ruby_el_9-3_4-normal
       - build_ruby_el_9-3_4-jemalloc
-      - build_ruby_el_9-3_4-malloctrim
 
       - build_ruby_el_9-3_3-normal
       - build_ruby_el_9-3_3-jemalloc
-      - build_ruby_el_9-3_3-malloctrim
 
       - build_ruby_el_9-3_2-normal
       - build_ruby_el_9-3_2-jemalloc
       - build_ruby_el_9-3_2-malloctrim
 
-      - build_ruby_el_9-4_0_0-normal
-      - build_ruby_el_9-4_0_0-jemalloc
-      - build_ruby_el_9-4_0_0-malloctrim
+      - build_ruby_el_9-4_0_2-normal
+      - build_ruby_el_9-4_0_2-jemalloc
 
       - build_ruby_el_9-3_4_8-normal
       - build_ruby_el_9-3_4_8-jemalloc
-      - build_ruby_el_9-3_4_8-malloctrim
 
       - build_ruby_el_9-3_3_10-normal
       - build_ruby_el_9-3_3_10-jemalloc
-      - build_ruby_el_9-3_3_10-malloctrim
 
       - build_ruby_el_9-3_2_9-normal
       - build_ruby_el_9-3_2_9-jemalloc
@@ -4934,7 +3806,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.2_centos-8_normal ruby-pkg_4.0.2_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.2_el-9_normal ruby-pkg_4.0.2_el-9_jemalloc ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
@@ -4950,12 +3822,6 @@ jobs:
           name: ruby-pkg_4.0_centos-8_jemalloc
           path: artifacts/ruby-pkg_4.0_centos-8_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_centos-8_malloctrim
-          path: artifacts/ruby-pkg_4.0_centos-8_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4968,12 +3834,6 @@ jobs:
           name: ruby-pkg_3.4_centos-8_jemalloc
           path: artifacts/ruby-pkg_3.4_centos-8_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.4_centos-8_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4985,12 +3845,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_centos-8_jemalloc
           path: artifacts/ruby-pkg_3.3_centos-8_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.3_centos-8_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5010,23 +3864,17 @@ jobs:
           name: ruby-pkg_3.2_centos-8_malloctrim
           path: artifacts/ruby-pkg_3.2_centos-8_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_centos-8_normal
-          path: artifacts/ruby-pkg_4.0.0_centos-8_normal
+          name: ruby-pkg_4.0.2_centos-8_normal
+          path: artifacts/ruby-pkg_4.0.2_centos-8_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_centos-8_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_centos-8_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_centos-8_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_centos-8_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_centos-8_malloctrim
+          name: ruby-pkg_4.0.2_centos-8_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_centos-8_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5040,12 +3888,6 @@ jobs:
           name: ruby-pkg_3.4.8_centos-8_jemalloc
           path: artifacts/ruby-pkg_3.4.8_centos-8_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_centos-8_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5057,12 +3899,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_centos-8_jemalloc
           path: artifacts/ruby-pkg_3.3.10_centos-8_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_centos-8_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_centos-8_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_centos-8_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_centos-8_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5094,12 +3930,6 @@ jobs:
           name: ruby-pkg_4.0_el-9_jemalloc
           path: artifacts/ruby-pkg_4.0_el-9_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_el-9_malloctrim
-          path: artifacts/ruby-pkg_4.0_el-9_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_el-9_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5112,12 +3942,6 @@ jobs:
           name: ruby-pkg_3.4_el-9_jemalloc
           path: artifacts/ruby-pkg_3.4_el-9_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_el-9_malloctrim
-          path: artifacts/ruby-pkg_3.4_el-9_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_el-9_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5129,12 +3953,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_el-9_jemalloc
           path: artifacts/ruby-pkg_3.3_el-9_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_el-9_malloctrim
-          path: artifacts/ruby-pkg_3.3_el-9_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_el-9_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5154,23 +3972,17 @@ jobs:
           name: ruby-pkg_3.2_el-9_malloctrim
           path: artifacts/ruby-pkg_3.2_el-9_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_el-9_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_el-9_normal
-          path: artifacts/ruby-pkg_4.0.0_el-9_normal
+          name: ruby-pkg_4.0.2_el-9_normal
+          path: artifacts/ruby-pkg_4.0.2_el-9_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_el-9_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_el-9_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_el-9_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_el-9_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_el-9_malloctrim
+          name: ruby-pkg_4.0.2_el-9_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_el-9_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_el-9_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5184,12 +3996,6 @@ jobs:
           name: ruby-pkg_3.4.8_el-9_jemalloc
           path: artifacts/ruby-pkg_3.4.8_el-9_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_el-9_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_el-9_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_el-9_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5201,12 +4007,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_el-9_jemalloc
           path: artifacts/ruby-pkg_3.3.10_el-9_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_el-9_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_el-9_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_el-9_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_el-9_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5250,27 +4050,18 @@ jobs:
             || (needs.build_ruby_centos_8-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_centos_8-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/jemalloc];')))
-            || (needs.build_ruby_centos_8-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0/malloctrim];')))
             || (needs.build_ruby_centos_8-3_4-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4/normal];')))
             || (needs.build_ruby_centos_8-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_centos_8-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4/malloctrim];')))
             || (needs.build_ruby_centos_8-3_3-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3/normal];')))
             || (needs.build_ruby_centos_8-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_centos_8-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3/malloctrim];')))
             || (needs.build_ruby_centos_8-3_2-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.2/normal];')))
@@ -5280,33 +4071,24 @@ jobs:
             || (needs.build_ruby_centos_8-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_centos_8-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.2/malloctrim];')))
-            || (needs.build_ruby_centos_8-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_centos_8-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/normal];')))
-            || (needs.build_ruby_centos_8-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_centos_8-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/jemalloc];')))
-            || (needs.build_ruby_centos_8-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.0/malloctrim];')))
+            || (needs.build_ruby_centos_8-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_centos_8-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.2/normal];')))
+            || (needs.build_ruby_centos_8-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_centos_8-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/4.0.2/jemalloc];')))
             || (needs.build_ruby_centos_8-3_4_8-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4.8/normal];')))
             || (needs.build_ruby_centos_8-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_centos_8-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4.8/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.4.8/malloctrim];')))
             || (needs.build_ruby_centos_8-3_3_10-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3.10/normal];')))
             || (needs.build_ruby_centos_8-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_centos_8-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3.10/jemalloc];')))
-            || (needs.build_ruby_centos_8-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_centos_8-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.3.10/malloctrim];')))
             || (needs.build_ruby_centos_8-3_2_9-normal.result != 'success'
               && (needs.build_ruby_centos_8-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [centos-8/3.2.9/normal];')))
@@ -5326,27 +4108,18 @@ jobs:
             || (needs.build_ruby_el_9-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_el_9-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/jemalloc];')))
-            || (needs.build_ruby_el_9-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0/malloctrim];')))
             || (needs.build_ruby_el_9-3_4-normal.result != 'success'
               && (needs.build_ruby_el_9-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4/normal];')))
             || (needs.build_ruby_el_9-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_el_9-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4/jemalloc];')))
-            || (needs.build_ruby_el_9-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4/malloctrim];')))
             || (needs.build_ruby_el_9-3_3-normal.result != 'success'
               && (needs.build_ruby_el_9-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3/normal];')))
             || (needs.build_ruby_el_9-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_el_9-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3/jemalloc];')))
-            || (needs.build_ruby_el_9-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3/malloctrim];')))
             || (needs.build_ruby_el_9-3_2-normal.result != 'success'
               && (needs.build_ruby_el_9-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.2/normal];')))
@@ -5356,33 +4129,24 @@ jobs:
             || (needs.build_ruby_el_9-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_el_9-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.2/malloctrim];')))
-            || (needs.build_ruby_el_9-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_el_9-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/normal];')))
-            || (needs.build_ruby_el_9-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_el_9-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/jemalloc];')))
-            || (needs.build_ruby_el_9-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.0/malloctrim];')))
+            || (needs.build_ruby_el_9-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_el_9-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.2/normal];')))
+            || (needs.build_ruby_el_9-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_el_9-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/4.0.2/jemalloc];')))
             || (needs.build_ruby_el_9-3_4_8-normal.result != 'success'
               && (needs.build_ruby_el_9-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4.8/normal];')))
             || (needs.build_ruby_el_9-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_el_9-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4.8/jemalloc];')))
-            || (needs.build_ruby_el_9-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.4.8/malloctrim];')))
             || (needs.build_ruby_el_9-3_3_10-normal.result != 'success'
               && (needs.build_ruby_el_9-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3.10/normal];')))
             || (needs.build_ruby_el_9-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_el_9-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3.10/jemalloc];')))
-            || (needs.build_ruby_el_9-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_el_9-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.3.10/malloctrim];')))
             || (needs.build_ruby_el_9-3_2_9-normal.result != 'success'
               && (needs.build_ruby_el_9-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [el-9/3.2.9/normal];')))

--- a/.github/workflows/ci-cd-build-packages-2.yml
+++ b/.github/workflows/ci-cd-build-packages-2.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -238,7 +238,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -289,7 +289,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -343,106 +343,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_11-4_0-malloctrim:
-    name: 'Ruby [debian-11/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_11-3_4-normal:
@@ -643,99 +550,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_11-3_4-malloctrim:
-    name: 'Ruby [debian-11/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_11-3_3-normal:
     name: 'Ruby [debian-11/3.3/normal]'
 
@@ -932,99 +746,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_11-3_3-malloctrim:
-    name: 'Ruby [debian-11/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_11-3_2-normal:
@@ -1318,8 +1039,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_11-4_0_0-normal:
-    name: 'Ruby [debian-11/4.0.0/normal]'
+  build_ruby_debian_11-4_0_2-normal:
+    name: 'Ruby [debian-11/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -1329,7 +1050,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -1354,7 +1075,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1391,7 +1112,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
@@ -1401,18 +1122,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-11_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_11-4_0_0-jemalloc:
-    name: 'Ruby [debian-11/4.0.0/jemalloc]'
+  build_ruby_debian_11-4_0_2-jemalloc:
+    name: 'Ruby [debian-11/4.0.2/jemalloc]'
 
     needs: build_jemalloc_debian_11
     runs-on: ubuntu-24.04
@@ -1423,7 +1144,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -1453,7 +1174,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1496,7 +1217,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
@@ -1506,107 +1227,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_11-4_0_0-malloctrim:
-    name: 'Ruby [debian-11/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_11-3_4_8-normal:
@@ -1807,99 +1435,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_11-3_4_8-malloctrim:
-    name: 'Ruby [debian-11/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_11-3_3_10-normal:
     name: 'Ruby [debian-11/3.3.10/normal]'
 
@@ -2096,99 +1631,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_debian-11_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_11-3_3_10-malloctrim:
-    name: 'Ruby [debian-11/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-11'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-11;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/debian-11"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_debian-11_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_11-3_2_9-normal:
@@ -2519,7 +1961,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2567,7 +2009,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2618,7 +2060,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2672,106 +2114,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-22.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_22_04-4_0-malloctrim:
-    name: 'Ruby [ubuntu-22.04/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_22_04-3_4-normal:
@@ -2972,99 +2321,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_22_04-3_4-malloctrim:
-    name: 'Ruby [ubuntu-22.04/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_ubuntu_22_04-3_3-normal:
     name: 'Ruby [ubuntu-22.04/3.3/normal]'
 
@@ -3261,99 +2517,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_ubuntu-22.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_22_04-3_3-malloctrim:
-    name: 'Ruby [ubuntu-22.04/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_22_04-3_2-normal:
@@ -3647,8 +2810,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_22_04-4_0_0-normal:
-    name: 'Ruby [ubuntu-22.04/4.0.0/normal]'
+  build_ruby_ubuntu_22_04-4_0_2-normal:
+    name: 'Ruby [ubuntu-22.04/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -3658,7 +2821,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -3683,7 +2846,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3720,7 +2883,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "ubuntu-22.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
 
       - name: Build package
@@ -3730,18 +2893,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_ubuntu-22.04_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_22_04-4_0_0-jemalloc:
-    name: 'Ruby [ubuntu-22.04/4.0.0/jemalloc]'
+  build_ruby_ubuntu_22_04-4_0_2-jemalloc:
+    name: 'Ruby [ubuntu-22.04/4.0.2/jemalloc]'
 
     needs: build_jemalloc_ubuntu_22_04
     runs-on: ubuntu-24.04
@@ -3752,7 +2915,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -3782,7 +2945,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3825,7 +2988,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "ubuntu-22.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
 
       - name: Build package
@@ -3835,107 +2998,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_ubuntu-22.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_22_04-4_0_0-malloctrim:
-    name: 'Ruby [ubuntu-22.04/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_22_04-3_4_8-normal:
@@ -4136,99 +3206,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_22_04-3_4_8-malloctrim:
-    name: 'Ruby [ubuntu-22.04/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_ubuntu_22_04-3_3_10-normal:
     name: 'Ruby [ubuntu-22.04/3.3.10/normal]'
 
@@ -4425,99 +3402,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_ubuntu-22.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_22_04-3_3_10-malloctrim:
-    name: 'Ruby [ubuntu-22.04/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-22.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-22.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-22.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_ubuntu-22.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_22_04-3_2_9-normal:
@@ -4823,31 +3707,25 @@ jobs:
 
       - build_ruby_debian_11-4_0-normal
       - build_ruby_debian_11-4_0-jemalloc
-      - build_ruby_debian_11-4_0-malloctrim
 
       - build_ruby_debian_11-3_4-normal
       - build_ruby_debian_11-3_4-jemalloc
-      - build_ruby_debian_11-3_4-malloctrim
 
       - build_ruby_debian_11-3_3-normal
       - build_ruby_debian_11-3_3-jemalloc
-      - build_ruby_debian_11-3_3-malloctrim
 
       - build_ruby_debian_11-3_2-normal
       - build_ruby_debian_11-3_2-jemalloc
       - build_ruby_debian_11-3_2-malloctrim
 
-      - build_ruby_debian_11-4_0_0-normal
-      - build_ruby_debian_11-4_0_0-jemalloc
-      - build_ruby_debian_11-4_0_0-malloctrim
+      - build_ruby_debian_11-4_0_2-normal
+      - build_ruby_debian_11-4_0_2-jemalloc
 
       - build_ruby_debian_11-3_4_8-normal
       - build_ruby_debian_11-3_4_8-jemalloc
-      - build_ruby_debian_11-3_4_8-malloctrim
 
       - build_ruby_debian_11-3_3_10-normal
       - build_ruby_debian_11-3_3_10-jemalloc
-      - build_ruby_debian_11-3_3_10-malloctrim
 
       - build_ruby_debian_11-3_2_9-normal
       - build_ruby_debian_11-3_2_9-jemalloc
@@ -4857,31 +3735,25 @@ jobs:
 
       - build_ruby_ubuntu_22_04-4_0-normal
       - build_ruby_ubuntu_22_04-4_0-jemalloc
-      - build_ruby_ubuntu_22_04-4_0-malloctrim
 
       - build_ruby_ubuntu_22_04-3_4-normal
       - build_ruby_ubuntu_22_04-3_4-jemalloc
-      - build_ruby_ubuntu_22_04-3_4-malloctrim
 
       - build_ruby_ubuntu_22_04-3_3-normal
       - build_ruby_ubuntu_22_04-3_3-jemalloc
-      - build_ruby_ubuntu_22_04-3_3-malloctrim
 
       - build_ruby_ubuntu_22_04-3_2-normal
       - build_ruby_ubuntu_22_04-3_2-jemalloc
       - build_ruby_ubuntu_22_04-3_2-malloctrim
 
-      - build_ruby_ubuntu_22_04-4_0_0-normal
-      - build_ruby_ubuntu_22_04-4_0_0-jemalloc
-      - build_ruby_ubuntu_22_04-4_0_0-malloctrim
+      - build_ruby_ubuntu_22_04-4_0_2-normal
+      - build_ruby_ubuntu_22_04-4_0_2-jemalloc
 
       - build_ruby_ubuntu_22_04-3_4_8-normal
       - build_ruby_ubuntu_22_04-3_4_8-jemalloc
-      - build_ruby_ubuntu_22_04-3_4_8-malloctrim
 
       - build_ruby_ubuntu_22_04-3_3_10-normal
       - build_ruby_ubuntu_22_04-3_3_10-jemalloc
-      - build_ruby_ubuntu_22_04-3_3_10-malloctrim
 
       - build_ruby_ubuntu_22_04-3_2_9-normal
       - build_ruby_ubuntu_22_04-3_2_9-jemalloc
@@ -4934,7 +3806,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.2_debian-11_normal ruby-pkg_4.0.2_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.2_ubuntu-22.04_normal ruby-pkg_4.0.2_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
@@ -4950,12 +3822,6 @@ jobs:
           name: ruby-pkg_4.0_debian-11_jemalloc
           path: artifacts/ruby-pkg_4.0_debian-11_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_debian-11_malloctrim
-          path: artifacts/ruby-pkg_4.0_debian-11_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4968,12 +3834,6 @@ jobs:
           name: ruby-pkg_3.4_debian-11_jemalloc
           path: artifacts/ruby-pkg_3.4_debian-11_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_debian-11_malloctrim
-          path: artifacts/ruby-pkg_3.4_debian-11_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4985,12 +3845,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_debian-11_jemalloc
           path: artifacts/ruby-pkg_3.3_debian-11_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_debian-11_malloctrim
-          path: artifacts/ruby-pkg_3.3_debian-11_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5010,23 +3864,17 @@ jobs:
           name: ruby-pkg_3.2_debian-11_malloctrim
           path: artifacts/ruby-pkg_3.2_debian-11_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_debian-11_normal
-          path: artifacts/ruby-pkg_4.0.0_debian-11_normal
+          name: ruby-pkg_4.0.2_debian-11_normal
+          path: artifacts/ruby-pkg_4.0.2_debian-11_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-11_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_debian-11_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_debian-11_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_debian-11_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_debian-11_malloctrim
+          name: ruby-pkg_4.0.2_debian-11_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_debian-11_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5040,12 +3888,6 @@ jobs:
           name: ruby-pkg_3.4.8_debian-11_jemalloc
           path: artifacts/ruby-pkg_3.4.8_debian-11_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_debian-11_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_debian-11_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5057,12 +3899,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_debian-11_jemalloc
           path: artifacts/ruby-pkg_3.3.10_debian-11_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-11_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_debian-11_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_debian-11_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_debian-11_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5094,12 +3930,6 @@ jobs:
           name: ruby-pkg_4.0_ubuntu-22.04_jemalloc
           path: artifacts/ruby-pkg_4.0_ubuntu-22.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_4.0_ubuntu-22.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5112,12 +3942,6 @@ jobs:
           name: ruby-pkg_3.4_ubuntu-22.04_jemalloc
           path: artifacts/ruby-pkg_3.4_ubuntu-22.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_3.4_ubuntu-22.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5129,12 +3953,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_ubuntu-22.04_jemalloc
           path: artifacts/ruby-pkg_3.3_ubuntu-22.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_3.3_ubuntu-22.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5154,23 +3972,17 @@ jobs:
           name: ruby-pkg_3.2_ubuntu-22.04_malloctrim
           path: artifacts/ruby-pkg_3.2_ubuntu-22.04_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_ubuntu-22.04_normal
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_normal
+          name: ruby-pkg_4.0.2_ubuntu-22.04_normal
+          path: artifacts/ruby-pkg_4.0.2_ubuntu-22.04_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_ubuntu-22.04_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_ubuntu-22.04_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-22.04_malloctrim
+          name: ruby-pkg_4.0.2_ubuntu-22.04_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_ubuntu-22.04_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5184,12 +3996,6 @@ jobs:
           name: ruby-pkg_3.4.8_ubuntu-22.04_jemalloc
           path: artifacts/ruby-pkg_3.4.8_ubuntu-22.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_ubuntu-22.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5201,12 +4007,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_ubuntu-22.04_jemalloc
           path: artifacts/ruby-pkg_3.3.10_ubuntu-22.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_ubuntu-22.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_ubuntu-22.04_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_ubuntu-22.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_ubuntu-22.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5250,27 +4050,18 @@ jobs:
             || (needs.build_ruby_debian_11-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_debian_11-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/jemalloc];')))
-            || (needs.build_ruby_debian_11-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0/malloctrim];')))
             || (needs.build_ruby_debian_11-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4/normal];')))
             || (needs.build_ruby_debian_11-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_debian_11-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4/jemalloc];')))
-            || (needs.build_ruby_debian_11-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4/malloctrim];')))
             || (needs.build_ruby_debian_11-3_3-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3/normal];')))
             || (needs.build_ruby_debian_11-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_debian_11-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3/jemalloc];')))
-            || (needs.build_ruby_debian_11-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3/malloctrim];')))
             || (needs.build_ruby_debian_11-3_2-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.2/normal];')))
@@ -5280,33 +4071,24 @@ jobs:
             || (needs.build_ruby_debian_11-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_debian_11-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.2/malloctrim];')))
-            || (needs.build_ruby_debian_11-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_debian_11-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/normal];')))
-            || (needs.build_ruby_debian_11-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_11-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/jemalloc];')))
-            || (needs.build_ruby_debian_11-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.0/malloctrim];')))
+            || (needs.build_ruby_debian_11-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_debian_11-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.2/normal];')))
+            || (needs.build_ruby_debian_11-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_11-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/4.0.2/jemalloc];')))
             || (needs.build_ruby_debian_11-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4.8/normal];')))
             || (needs.build_ruby_debian_11-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_debian_11-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4.8/jemalloc];')))
-            || (needs.build_ruby_debian_11-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.4.8/malloctrim];')))
             || (needs.build_ruby_debian_11-3_3_10-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3.10/normal];')))
             || (needs.build_ruby_debian_11-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_debian_11-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3.10/jemalloc];')))
-            || (needs.build_ruby_debian_11-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_11-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.3.10/malloctrim];')))
             || (needs.build_ruby_debian_11-3_2_9-normal.result != 'success'
               && (needs.build_ruby_debian_11-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-11/3.2.9/normal];')))
@@ -5326,27 +4108,18 @@ jobs:
             || (needs.build_ruby_ubuntu_22_04-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_4-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4/normal];')))
             || (needs.build_ruby_ubuntu_22_04-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_3-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3/normal];')))
             || (needs.build_ruby_ubuntu_22_04-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_2-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.2/normal];')))
@@ -5356,33 +4129,24 @@ jobs:
             || (needs.build_ruby_ubuntu_22_04-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_22_04-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/normal];')))
-            || (needs.build_ruby_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.0/malloctrim];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.2/normal];')))
+            || (needs.build_ruby_ubuntu_22_04-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_22_04-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/4.0.2/jemalloc];')))
             || (needs.build_ruby_ubuntu_22_04-3_4_8-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4.8/normal];')))
             || (needs.build_ruby_ubuntu_22_04-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4.8/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.4.8/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_3_10-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3.10/normal];')))
             || (needs.build_ruby_ubuntu_22_04-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3.10/jemalloc];')))
-            || (needs.build_ruby_ubuntu_22_04-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_22_04-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.3.10/malloctrim];')))
             || (needs.build_ruby_ubuntu_22_04-3_2_9-normal.result != 'success'
               && (needs.build_ruby_ubuntu_22_04-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-22.04/3.2.9/normal];')))

--- a/.github/workflows/ci-cd-build-packages-3.yml
+++ b/.github/workflows/ci-cd-build-packages-3.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -238,7 +238,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -289,7 +289,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -343,106 +343,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_debian-12_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_12-4_0-malloctrim:
-    name: 'Ruby [debian-12/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_12-3_4-normal:
@@ -643,99 +550,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_12-3_4-malloctrim:
-    name: 'Ruby [debian-12/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_12-3_3-normal:
     name: 'Ruby [debian-12/3.3/normal]'
 
@@ -932,99 +746,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_debian-12_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_12-3_3-malloctrim:
-    name: 'Ruby [debian-12/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_12-3_2-normal:
@@ -1318,8 +1039,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_12-4_0_0-normal:
-    name: 'Ruby [debian-12/4.0.0/normal]'
+  build_ruby_debian_12-4_0_2-normal:
+    name: 'Ruby [debian-12/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -1329,7 +1050,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -1354,7 +1075,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1391,7 +1112,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-12"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-12"
 
       - name: Build package
@@ -1401,18 +1122,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-12_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_12-4_0_0-jemalloc:
-    name: 'Ruby [debian-12/4.0.0/jemalloc]'
+  build_ruby_debian_12-4_0_2-jemalloc:
+    name: 'Ruby [debian-12/4.0.2/jemalloc]'
 
     needs: build_jemalloc_debian_12
     runs-on: ubuntu-24.04
@@ -1423,7 +1144,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -1453,7 +1174,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1496,7 +1217,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-12"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-12"
 
       - name: Build package
@@ -1506,107 +1227,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-12_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_12-4_0_0-malloctrim:
-    name: 'Ruby [debian-12/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_12-3_4_8-normal:
@@ -1807,99 +1435,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_12-3_4_8-malloctrim:
-    name: 'Ruby [debian-12/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_12-3_3_10-normal:
     name: 'Ruby [debian-12/3.3.10/normal]'
 
@@ -2096,99 +1631,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_debian-12_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_12-3_3_10-malloctrim:
-    name: 'Ruby [debian-12/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-12'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-12;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/debian-12"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_debian-12_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_12-3_2_9-normal:
@@ -2519,7 +1961,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2567,7 +2009,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -2618,7 +2060,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -2672,106 +2114,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-24.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_24_04-4_0-malloctrim:
-    name: 'Ruby [ubuntu-24.04/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_24_04-3_4-normal:
@@ -2972,99 +2321,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_24_04-3_4-malloctrim:
-    name: 'Ruby [ubuntu-24.04/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_ubuntu_24_04-3_3-normal:
     name: 'Ruby [ubuntu-24.04/3.3/normal]'
 
@@ -3261,99 +2517,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3_ubuntu-24.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_24_04-3_3-malloctrim:
-    name: 'Ruby [ubuntu-24.04/3.3/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_24_04-3_2-normal:
@@ -3647,8 +2810,8 @@ jobs:
           ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_24_04-4_0_0-normal:
-    name: 'Ruby [ubuntu-24.04/4.0.0/normal]'
+  build_ruby_ubuntu_24_04-4_0_2-normal:
+    name: 'Ruby [ubuntu-24.04/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -3658,7 +2821,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/normal];')
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -3683,7 +2846,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3720,7 +2883,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "ubuntu-24.04"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
 
       - name: Build package
@@ -3730,18 +2893,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_ubuntu-24.04_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_24_04-4_0_0-jemalloc:
-    name: 'Ruby [ubuntu-24.04/4.0.0/jemalloc]'
+  build_ruby_ubuntu_24_04-4_0_2-jemalloc:
+    name: 'Ruby [ubuntu-24.04/4.0.2/jemalloc]'
 
     needs: build_jemalloc_ubuntu_24_04
     runs-on: ubuntu-24.04
@@ -3752,7 +2915,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -3782,7 +2945,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -3825,7 +2988,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "ubuntu-24.04"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
 
       - name: Build package
@@ -3835,107 +2998,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_ubuntu-24.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_24_04-4_0_0-malloctrim:
-    name: 'Ruby [ubuntu-24.04/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_24_04-3_4_8-normal:
@@ -4136,99 +3206,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_ubuntu_24_04-3_4_8-malloctrim:
-    name: 'Ruby [ubuntu-24.04/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_ubuntu_24_04-3_3_10-normal:
     name: 'Ruby [ubuntu-24.04/3.3.10/normal]'
 
@@ -4425,99 +3402,6 @@ jobs:
         env:
           ARTIFACT_NAME: "ruby-pkg_3.3.10_ubuntu-24.04_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_ubuntu_24_04-3_3_10-malloctrim:
-    name: 'Ruby [ubuntu-24.04/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          ARTIFACT_NAME: 'docker-image-ubuntu-24.04'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image ubuntu-24.04;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/ubuntu-24.04"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_ubuntu-24.04_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_ubuntu_24_04-3_2_9-normal:
@@ -4823,31 +3707,25 @@ jobs:
 
       - build_ruby_debian_12-4_0-normal
       - build_ruby_debian_12-4_0-jemalloc
-      - build_ruby_debian_12-4_0-malloctrim
 
       - build_ruby_debian_12-3_4-normal
       - build_ruby_debian_12-3_4-jemalloc
-      - build_ruby_debian_12-3_4-malloctrim
 
       - build_ruby_debian_12-3_3-normal
       - build_ruby_debian_12-3_3-jemalloc
-      - build_ruby_debian_12-3_3-malloctrim
 
       - build_ruby_debian_12-3_2-normal
       - build_ruby_debian_12-3_2-jemalloc
       - build_ruby_debian_12-3_2-malloctrim
 
-      - build_ruby_debian_12-4_0_0-normal
-      - build_ruby_debian_12-4_0_0-jemalloc
-      - build_ruby_debian_12-4_0_0-malloctrim
+      - build_ruby_debian_12-4_0_2-normal
+      - build_ruby_debian_12-4_0_2-jemalloc
 
       - build_ruby_debian_12-3_4_8-normal
       - build_ruby_debian_12-3_4_8-jemalloc
-      - build_ruby_debian_12-3_4_8-malloctrim
 
       - build_ruby_debian_12-3_3_10-normal
       - build_ruby_debian_12-3_3_10-jemalloc
-      - build_ruby_debian_12-3_3_10-malloctrim
 
       - build_ruby_debian_12-3_2_9-normal
       - build_ruby_debian_12-3_2_9-jemalloc
@@ -4857,31 +3735,25 @@ jobs:
 
       - build_ruby_ubuntu_24_04-4_0-normal
       - build_ruby_ubuntu_24_04-4_0-jemalloc
-      - build_ruby_ubuntu_24_04-4_0-malloctrim
 
       - build_ruby_ubuntu_24_04-3_4-normal
       - build_ruby_ubuntu_24_04-3_4-jemalloc
-      - build_ruby_ubuntu_24_04-3_4-malloctrim
 
       - build_ruby_ubuntu_24_04-3_3-normal
       - build_ruby_ubuntu_24_04-3_3-jemalloc
-      - build_ruby_ubuntu_24_04-3_3-malloctrim
 
       - build_ruby_ubuntu_24_04-3_2-normal
       - build_ruby_ubuntu_24_04-3_2-jemalloc
       - build_ruby_ubuntu_24_04-3_2-malloctrim
 
-      - build_ruby_ubuntu_24_04-4_0_0-normal
-      - build_ruby_ubuntu_24_04-4_0_0-jemalloc
-      - build_ruby_ubuntu_24_04-4_0_0-malloctrim
+      - build_ruby_ubuntu_24_04-4_0_2-normal
+      - build_ruby_ubuntu_24_04-4_0_2-jemalloc
 
       - build_ruby_ubuntu_24_04-3_4_8-normal
       - build_ruby_ubuntu_24_04-3_4_8-jemalloc
-      - build_ruby_ubuntu_24_04-3_4_8-malloctrim
 
       - build_ruby_ubuntu_24_04-3_3_10-normal
       - build_ruby_ubuntu_24_04-3_3_10-jemalloc
-      - build_ruby_ubuntu_24_04-3_3_10-malloctrim
 
       - build_ruby_ubuntu_24_04-3_2_9-normal
       - build_ruby_ubuntu_24_04-3_2_9-jemalloc
@@ -4934,7 +3806,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.2_debian-12_normal ruby-pkg_4.0.2_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.2_ubuntu-24.04_normal ruby-pkg_4.0.2_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
@@ -4950,12 +3822,6 @@ jobs:
           name: ruby-pkg_4.0_debian-12_jemalloc
           path: artifacts/ruby-pkg_4.0_debian-12_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_debian-12_malloctrim
-          path: artifacts/ruby-pkg_4.0_debian-12_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4968,12 +3834,6 @@ jobs:
           name: ruby-pkg_3.4_debian-12_jemalloc
           path: artifacts/ruby-pkg_3.4_debian-12_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_debian-12_malloctrim
-          path: artifacts/ruby-pkg_3.4_debian-12_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -4985,12 +3845,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_debian-12_jemalloc
           path: artifacts/ruby-pkg_3.3_debian-12_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_debian-12_malloctrim
-          path: artifacts/ruby-pkg_3.3_debian-12_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5010,23 +3864,17 @@ jobs:
           name: ruby-pkg_3.2_debian-12_malloctrim
           path: artifacts/ruby-pkg_3.2_debian-12_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_debian-12_normal
-          path: artifacts/ruby-pkg_4.0.0_debian-12_normal
+          name: ruby-pkg_4.0.2_debian-12_normal
+          path: artifacts/ruby-pkg_4.0.2_debian-12_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-12_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_debian-12_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_debian-12_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_debian-12_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_debian-12_malloctrim
+          name: ruby-pkg_4.0.2_debian-12_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_debian-12_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5040,12 +3888,6 @@ jobs:
           name: ruby-pkg_3.4.8_debian-12_jemalloc
           path: artifacts/ruby-pkg_3.4.8_debian-12_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_debian-12_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_debian-12_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5057,12 +3899,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_debian-12_jemalloc
           path: artifacts/ruby-pkg_3.3.10_debian-12_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-12_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_debian-12_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_debian-12_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_debian-12_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5094,12 +3930,6 @@ jobs:
           name: ruby-pkg_4.0_ubuntu-24.04_jemalloc
           path: artifacts/ruby-pkg_4.0_ubuntu-24.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_4.0_ubuntu-24.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5112,12 +3942,6 @@ jobs:
           name: ruby-pkg_3.4_ubuntu-24.04_jemalloc
           path: artifacts/ruby-pkg_3.4_ubuntu-24.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_3.4_ubuntu-24.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5129,12 +3953,6 @@ jobs:
         with:
           name: ruby-pkg_3.3_ubuntu-24.04_jemalloc
           path: artifacts/ruby-pkg_3.3_ubuntu-24.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_3.3_ubuntu-24.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5154,23 +3972,17 @@ jobs:
           name: ruby-pkg_3.2_ubuntu-24.04_malloctrim
           path: artifacts/ruby-pkg_3.2_ubuntu-24.04_malloctrim
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_ubuntu-24.04_normal
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_normal
+          name: ruby-pkg_4.0.2_ubuntu-24.04_normal
+          path: artifacts/ruby-pkg_4.0.2_ubuntu-24.04_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_jemalloc] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_ubuntu-24.04_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_ubuntu-24.04_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_ubuntu-24.04_malloctrim
+          name: ruby-pkg_4.0.2_ubuntu-24.04_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_ubuntu-24.04_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5184,12 +3996,6 @@ jobs:
           name: ruby-pkg_3.4.8_ubuntu-24.04_jemalloc
           path: artifacts/ruby-pkg_3.4.8_ubuntu-24.04_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_ubuntu-24.04_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -5201,12 +4007,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_ubuntu-24.04_jemalloc
           path: artifacts/ruby-pkg_3.3.10_ubuntu-24.04_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_ubuntu-24.04_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_ubuntu-24.04_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_ubuntu-24.04_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.2.9_ubuntu-24.04_normal] to Github
         uses: actions/upload-artifact@v4
@@ -5250,27 +4050,18 @@ jobs:
             || (needs.build_ruby_debian_12-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_debian_12-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/jemalloc];')))
-            || (needs.build_ruby_debian_12-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0/malloctrim];')))
             || (needs.build_ruby_debian_12-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4/normal];')))
             || (needs.build_ruby_debian_12-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_debian_12-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4/jemalloc];')))
-            || (needs.build_ruby_debian_12-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4/malloctrim];')))
             || (needs.build_ruby_debian_12-3_3-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3/normal];')))
             || (needs.build_ruby_debian_12-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_debian_12-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3/jemalloc];')))
-            || (needs.build_ruby_debian_12-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3/malloctrim];')))
             || (needs.build_ruby_debian_12-3_2-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.2/normal];')))
@@ -5280,33 +4071,24 @@ jobs:
             || (needs.build_ruby_debian_12-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_debian_12-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.2/malloctrim];')))
-            || (needs.build_ruby_debian_12-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_debian_12-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/normal];')))
-            || (needs.build_ruby_debian_12-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_12-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/jemalloc];')))
-            || (needs.build_ruby_debian_12-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.0/malloctrim];')))
+            || (needs.build_ruby_debian_12-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_debian_12-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.2/normal];')))
+            || (needs.build_ruby_debian_12-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_12-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/4.0.2/jemalloc];')))
             || (needs.build_ruby_debian_12-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4.8/normal];')))
             || (needs.build_ruby_debian_12-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_debian_12-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4.8/jemalloc];')))
-            || (needs.build_ruby_debian_12-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.4.8/malloctrim];')))
             || (needs.build_ruby_debian_12-3_3_10-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3.10/normal];')))
             || (needs.build_ruby_debian_12-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_debian_12-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3.10/jemalloc];')))
-            || (needs.build_ruby_debian_12-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_12-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.3.10/malloctrim];')))
             || (needs.build_ruby_debian_12-3_2_9-normal.result != 'success'
               && (needs.build_ruby_debian_12-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-12/3.2.9/normal];')))
@@ -5326,27 +4108,18 @@ jobs:
             || (needs.build_ruby_ubuntu_24_04-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_4-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4/normal];')))
             || (needs.build_ruby_ubuntu_24_04-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_3-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3/normal];')))
             || (needs.build_ruby_ubuntu_24_04-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_2-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_2-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.2/normal];')))
@@ -5356,33 +4129,24 @@ jobs:
             || (needs.build_ruby_ubuntu_24_04-3_2-malloctrim.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.2/malloctrim];')))
-            || (needs.build_ruby_ubuntu_24_04-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/normal];')))
-            || (needs.build_ruby_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.0/malloctrim];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.2/normal];')))
+            || (needs.build_ruby_ubuntu_24_04-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_ubuntu_24_04-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/4.0.2/jemalloc];')))
             || (needs.build_ruby_ubuntu_24_04-3_4_8-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4.8/normal];')))
             || (needs.build_ruby_ubuntu_24_04-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4.8/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.4.8/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_3_10-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3.10/normal];')))
             || (needs.build_ruby_ubuntu_24_04-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3.10/jemalloc];')))
-            || (needs.build_ruby_ubuntu_24_04-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_ubuntu_24_04-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.3.10/malloctrim];')))
             || (needs.build_ruby_ubuntu_24_04-3_2_9-normal.result != 'success'
               && (needs.build_ruby_ubuntu_24_04-3_2_9-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [ubuntu-24.04/3.2.9/normal];')))

--- a/.github/workflows/ci-cd-build-packages-4.yml
+++ b/.github/workflows/ci-cd-build-packages-4.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -179,7 +179,7 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -230,7 +230,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -284,106 +284,13 @@ jobs:
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
           RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
+          RUBY_PACKAGE_REVISION: "1"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
           ARTIFACT_NAME: "ruby-pkg_4.0_debian-13_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_13-4_0-malloctrim:
-    name: 'Ruby [debian-13/4.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_13-3_4-normal:
@@ -584,99 +491,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_13-3_4-malloctrim:
-    name: 'Ruby [debian-13/3.4/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4"
-          RUBY_PACKAGE_REVISION: "7"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_13-3_3-normal:
     name: 'Ruby [debian-13/3.3/normal]'
 
@@ -875,8 +689,8 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_13-3_3-malloctrim:
-    name: 'Ruby [debian-13/3.3/malloctrim]'
+  build_ruby_debian_13-4_0_2-normal:
+    name: 'Ruby [debian-13/4.0.2/normal]'
 
     runs-on: ubuntu-24.04
     environment: test
@@ -886,7 +700,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3/malloctrim];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.2/normal];')
       && !failure() && !cancelled()
     steps:
       
@@ -911,100 +725,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3"
-          RUBY_PACKAGE_REVISION: "10"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_13-4_0_0-normal:
-    name: 'Ruby [debian-13/4.0.0/normal]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/normal];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1041,7 +762,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-13"
           VARIANT_NAME: "normal"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-13"
 
       - name: Build package
@@ -1051,18 +772,18 @@ jobs:
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_normal"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-13_normal"
           ARTIFACT_PATH: output-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_13-4_0_0-jemalloc:
-    name: 'Ruby [debian-13/4.0.0/jemalloc]'
+  build_ruby_debian_13-4_0_2-jemalloc:
+    name: 'Ruby [debian-13/4.0.2/jemalloc]'
 
     needs: build_jemalloc_debian_13
     runs-on: ubuntu-24.04
@@ -1073,7 +794,7 @@ jobs:
       packages: read
     # Run even if a dependent job has been skipped
     if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/jemalloc];')
+      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.2/jemalloc];')
       && !failure() && !cancelled()
     steps:
       
@@ -1103,7 +824,7 @@ jobs:
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: .
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -1146,7 +867,7 @@ jobs:
         env:
           ENVIRONMENT_NAME: "debian-13"
           VARIANT_NAME: "jemalloc"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           CACHE_KEY_PREFIX: "sccache/debian-13"
 
       - name: Build package
@@ -1156,107 +877,14 @@ jobs:
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
           PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
+          RUBY_PACKAGE_VERSION_ID: "4.0.2"
           RUBY_PACKAGE_REVISION: "0"
 
       - name: Archive package artifact to Google Cloud
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_jemalloc"
+          ARTIFACT_NAME: "ruby-pkg_4.0.2_debian-13_jemalloc"
           ARTIFACT_PATH: output-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  build_ruby_debian_13-4_0_0-malloctrim:
-    name: 'Ruby [debian-13/4.0.0/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-4.0.0
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "4.0.0"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_4.0.0_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   build_ruby_debian_13-3_4_8-normal:
@@ -1457,99 +1085,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_13-3_4_8-malloctrim:
-    name: 'Ruby [debian-13/3.4.8/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4.8/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.4.8
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.4.8"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.4.8_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   build_ruby_debian_13-3_3_10-normal:
     name: 'Ruby [debian-13/3.3.10/normal]'
 
@@ -1748,99 +1283,6 @@ jobs:
           ARTIFACT_PATH: output-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  build_ruby_debian_13-3_3_10-malloctrim:
-    name: 'Ruby [debian-13/3.3.10/malloctrim]'
-
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      packages: read
-    # Run even if a dependent job has been skipped
-    if: |
-      contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3.10/malloctrim];')
-      && !failure() && !cancelled()
-    steps:
-      
-
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-      - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dump Azure connection string
-        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
-        env:
-          CONNECTION_STRING: ${{ secrets.AZURE_CI2_STORAGE_CONNECTION_STRING }}
-      - name: Fetch Ruby source
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        env:
-          ARTIFACT_NAME: ruby-src-3.3.10
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-      - name: Download Docker image necessary for building
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          ARTIFACT_NAME: 'docker-image-debian-13'
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for building
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image debian-13;')
-        env:
-          TARBALL: image.tar.zst
-
-      - name: Download Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/download-artifact.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          ARTIFACT_NAME: docker-image-utility
-          ARTIFACT_PATH: .
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Load Docker image necessary for packaging
-        run: ./internal-scripts/ci-cd/load-docker-image.sh
-        if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
-        env:
-          TARBALL: image.tar.zst
-
-      
-
-      - name: Build binaries
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
-        env:
-          ENVIRONMENT_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          CACHE_KEY_PREFIX: "sccache/debian-13"
-
-      - name: Build package
-        run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          PACKAGE_FORMAT: "DEB"
-          RUBY_PACKAGE_VERSION_ID: "3.3.10"
-          RUBY_PACKAGE_REVISION: "0"
-
-      - name: Archive package artifact to Google Cloud
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: "ruby-pkg_3.3.10_debian-13_malloctrim"
-          ARTIFACT_PATH: output-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
 
 
   ### Finalize ###
@@ -1853,27 +1295,21 @@ jobs:
 
       - build_ruby_debian_13-4_0-normal
       - build_ruby_debian_13-4_0-jemalloc
-      - build_ruby_debian_13-4_0-malloctrim
 
       - build_ruby_debian_13-3_4-normal
       - build_ruby_debian_13-3_4-jemalloc
-      - build_ruby_debian_13-3_4-malloctrim
 
       - build_ruby_debian_13-3_3-normal
       - build_ruby_debian_13-3_3-jemalloc
-      - build_ruby_debian_13-3_3-malloctrim
 
-      - build_ruby_debian_13-4_0_0-normal
-      - build_ruby_debian_13-4_0_0-jemalloc
-      - build_ruby_debian_13-4_0_0-malloctrim
+      - build_ruby_debian_13-4_0_2-normal
+      - build_ruby_debian_13-4_0_2-jemalloc
 
       - build_ruby_debian_13-3_4_8-normal
       - build_ruby_debian_13-3_4_8-jemalloc
-      - build_ruby_debian_13-3_4_8-malloctrim
 
       - build_ruby_debian_13-3_3_10-normal
       - build_ruby_debian_13-3_3_10-jemalloc
-      - build_ruby_debian_13-3_3_10-malloctrim
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1915,7 +1351,7 @@ jobs:
       - name: Download Ruby package artifacts from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
-          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim'
+          ARTIFACT_NAMES: 'ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.2_debian-13_normal ruby-pkg_4.0.2_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc'
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
@@ -1931,12 +1367,6 @@ jobs:
           name: ruby-pkg_4.0_debian-13_jemalloc
           path: artifacts/ruby-pkg_4.0_debian-13_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0_debian-13_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0_debian-13_malloctrim
-          path: artifacts/ruby-pkg_4.0_debian-13_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -1948,12 +1378,6 @@ jobs:
         with:
           name: ruby-pkg_3.4_debian-13_jemalloc
           path: artifacts/ruby-pkg_3.4_debian-13_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4_debian-13_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4_debian-13_malloctrim
-          path: artifacts/ruby-pkg_3.4_debian-13_malloctrim
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
@@ -1967,29 +1391,17 @@ jobs:
           name: ruby-pkg_3.3_debian-13_jemalloc
           path: artifacts/ruby-pkg_3.3_debian-13_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3_debian-13_malloctrim] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_3.3_debian-13_malloctrim
-          path: artifacts/ruby-pkg_3.3_debian-13_malloctrim
+          name: ruby-pkg_4.0.2_debian-13_normal
+          path: artifacts/ruby-pkg_4.0.2_debian-13_normal
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_normal] to Github
+      - name: Archive Ruby package artifact [ruby-pkg_4.0.2_debian-13_jemalloc] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-pkg_4.0.0_debian-13_normal
-          path: artifacts/ruby-pkg_4.0.0_debian-13_normal
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_jemalloc] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_debian-13_jemalloc
-          path: artifacts/ruby-pkg_4.0.0_debian-13_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_4.0.0_debian-13_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_4.0.0_debian-13_malloctrim
-          path: artifacts/ruby-pkg_4.0.0_debian-13_malloctrim
+          name: ruby-pkg_4.0.2_debian-13_jemalloc
+          path: artifacts/ruby-pkg_4.0.2_debian-13_jemalloc
           compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
@@ -2003,12 +1415,6 @@ jobs:
           name: ruby-pkg_3.4.8_debian-13_jemalloc
           path: artifacts/ruby-pkg_3.4.8_debian-13_jemalloc
           compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.4.8_debian-13_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.4.8_debian-13_malloctrim
-          path: artifacts/ruby-pkg_3.4.8_debian-13_malloctrim
-          compression-level: 0
       - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-13_normal] to Github
         uses: actions/upload-artifact@v4
         with:
@@ -2020,12 +1426,6 @@ jobs:
         with:
           name: ruby-pkg_3.3.10_debian-13_jemalloc
           path: artifacts/ruby-pkg_3.3.10_debian-13_jemalloc
-          compression-level: 0
-      - name: Archive Ruby package artifact [ruby-pkg_3.3.10_debian-13_malloctrim] to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: ruby-pkg_3.3.10_debian-13_malloctrim
-          path: artifacts/ruby-pkg_3.3.10_debian-13_malloctrim
           compression-level: 0
 
 
@@ -2048,51 +1448,33 @@ jobs:
             || (needs.build_ruby_debian_13-4_0-jemalloc.result != 'success'
               && (needs.build_ruby_debian_13-4_0-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/jemalloc];')))
-            || (needs.build_ruby_debian_13-4_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-4_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0/malloctrim];')))
             || (needs.build_ruby_debian_13-3_4-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_4-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4/normal];')))
             || (needs.build_ruby_debian_13-3_4-jemalloc.result != 'success'
               && (needs.build_ruby_debian_13-3_4-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4/jemalloc];')))
-            || (needs.build_ruby_debian_13-3_4-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-3_4-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4/malloctrim];')))
             || (needs.build_ruby_debian_13-3_3-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_3-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3/normal];')))
             || (needs.build_ruby_debian_13-3_3-jemalloc.result != 'success'
               && (needs.build_ruby_debian_13-3_3-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3/jemalloc];')))
-            || (needs.build_ruby_debian_13-3_3-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-3_3-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3/malloctrim];')))
-            || (needs.build_ruby_debian_13-4_0_0-normal.result != 'success'
-              && (needs.build_ruby_debian_13-4_0_0-normal.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/normal];')))
-            || (needs.build_ruby_debian_13-4_0_0-jemalloc.result != 'success'
-              && (needs.build_ruby_debian_13-4_0_0-jemalloc.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/jemalloc];')))
-            || (needs.build_ruby_debian_13-4_0_0-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-4_0_0-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.0/malloctrim];')))
+            || (needs.build_ruby_debian_13-4_0_2-normal.result != 'success'
+              && (needs.build_ruby_debian_13-4_0_2-normal.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.2/normal];')))
+            || (needs.build_ruby_debian_13-4_0_2-jemalloc.result != 'success'
+              && (needs.build_ruby_debian_13-4_0_2-jemalloc.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/4.0.2/jemalloc];')))
             || (needs.build_ruby_debian_13-3_4_8-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_4_8-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4.8/normal];')))
             || (needs.build_ruby_debian_13-3_4_8-jemalloc.result != 'success'
               && (needs.build_ruby_debian_13-3_4_8-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4.8/jemalloc];')))
-            || (needs.build_ruby_debian_13-3_4_8-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-3_4_8-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.4.8/malloctrim];')))
             || (needs.build_ruby_debian_13-3_3_10-normal.result != 'success'
               && (needs.build_ruby_debian_13-3_3_10-normal.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3.10/normal];')))
             || (needs.build_ruby_debian_13-3_3_10-jemalloc.result != 'success'
               && (needs.build_ruby_debian_13-3_3_10-jemalloc.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3.10/jemalloc];')))
-            || (needs.build_ruby_debian_13-3_3_10-malloctrim.result != 'success'
-              && (needs.build_ruby_debian_13-3_3_10-malloctrim.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Build Ruby [debian-13/3.3.10/malloctrim];')))

--- a/.github/workflows/ci-cd-build-packages.yml.erb
+++ b/.github/workflows/ci-cd-build-packages.yml.erb
@@ -88,7 +88,7 @@ jobs:
 
   <%- distributions.each do |distribution| %>
   <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-  <%- variants.each do |variant| -%>
+  <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
   <%- unindent(2) do %>
     build_ruby_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>:
       name: 'Ruby [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]'
@@ -218,7 +218,7 @@ jobs:
       <%- unindent(2) do %>
         - build_jemalloc_<%= slug(distribution[:name]) %>
         <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| %>
-        <%- variants.each do |variant| -%>
+        <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
         - build_ruby_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>
         <%- end -%>
         <%- end %>
@@ -300,7 +300,7 @@ jobs:
         if: |
           false
           <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-          <%- variants.each do |variant| -%>
+          <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
             || (needs.build_ruby_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>.result != 'success'
               && (needs.build_ruby_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Build Ruby [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>];')))

--- a/.github/workflows/ci-cd-prepare.yml
+++ b/.github/workflows/ci-cd-prepare.yml
@@ -470,13 +470,13 @@ jobs:
   ### Sources ###
 
 
-  download_ruby_source_4_0_0:
-    name: Download Ruby source [4.0.0]
+  download_ruby_source_4_0_2:
+    name: Download Ruby source [4.0.2]
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
     environment: test
-    if: contains(inputs.necessary_jobs, ';Download Ruby source 4.0.0;')
+    if: contains(inputs.necessary_jobs, ';Download Ruby source 4.0.2;')
     steps:
       - uses: actions/checkout@v4
       - uses: azure/login@v2
@@ -496,12 +496,12 @@ jobs:
       - name: Download
         run: ./internal-scripts/ci-cd/download-ruby-sources/download.sh
         env:
-          RUBY_VERSION: 4.0.0
+          RUBY_VERSION: 4.0.2
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: output
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   download_ruby_source_3_4_8:
@@ -964,7 +964,7 @@ jobs:
       - build_docker_image_ubuntu_22_04
       - build_docker_image_ubuntu_24_04
       - build_docker_image_utility
-      - download_ruby_source_4_0_0
+      - download_ruby_source_4_0_2
       - download_ruby_source_3_4_8
       - download_ruby_source_3_3_10
       - download_ruby_source_3_2_9
@@ -1141,17 +1141,17 @@ jobs:
           path: artifacts
 
 
-      - name: Download Ruby source artifact [4.0.0] from Google Cloud
+      - name: Download Ruby source artifact [4.0.2] from Google Cloud
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
-          ARTIFACT_NAME: ruby-src-4.0.0
+          ARTIFACT_NAME: ruby-src-4.0.2
           ARTIFACT_PATH: artifacts
           CLEAR: true
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-      - name: Archive Ruby source artifact [4.0.0] to Github
+      - name: Archive Ruby source artifact [4.0.2] to Github
         uses: actions/upload-artifact@v4
         with:
-          name: ruby-src-4.0.0
+          name: ruby-src-4.0.2
           path: artifacts
           compression-level: 0
       - name: Download Ruby source artifact [3.4.8] from Google Cloud
@@ -1300,9 +1300,9 @@ jobs:
         run: 'false'
         if: |
           false
-            || (needs.download_ruby_source_4_0_0.result != 'success'
-              && (needs.download_ruby_source_4_0_0.result != 'skipped'
-                || contains(inputs.necessary_jobs, ';Download Ruby source 4.0.0;')))
+            || (needs.download_ruby_source_4_0_2.result != 'success'
+              && (needs.download_ruby_source_4_0_2.result != 'skipped'
+                || contains(inputs.necessary_jobs, ';Download Ruby source 4.0.2;')))
             || (needs.download_ruby_source_3_4_8.result != 'success'
               && (needs.download_ruby_source_3_4_8.result != 'skipped'
                 || contains(inputs.necessary_jobs, ';Download Ruby source 3.4.8;')))

--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -68,7 +68,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.2_centos-8_normal ruby-pkg_4.0.2_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.2_debian-11_normal ruby-pkg_4.0.2_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.2_debian-12_normal ruby-pkg_4.0.2_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.2_debian-13_normal ruby-pkg_4.0.2_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.2_el-9_normal ruby-pkg_4.0.2_el-9_jemalloc ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.2_ubuntu-22.04_normal ruby-pkg_4.0.2_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.2_ubuntu-24.04_normal ruby-pkg_4.0.2_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -220,49 +220,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-8_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-4_0-malloctrim:
-    name: 'Test [centos-8/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
     needs:
@@ -349,49 +306,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-8_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-3_4-malloctrim:
-    name: 'Test [centos-8/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_3-normal:
     name: 'Test [centos-8/3.3/normal]'
     needs:
@@ -477,49 +391,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-3_3-malloctrim:
-    name: 'Test [centos-8/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_2-normal:
     name: 'Test [centos-8/3.2/normal]'
@@ -650,8 +521,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-8_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-4_0_0-normal:
-    name: 'Test [centos-8/4.0.0/normal]'
+  test_centos_8-4_0_2-normal:
+    name: 'Test [centos-8/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -659,7 +530,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -677,7 +548,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -690,11 +561,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-4_0_0-jemalloc:
-    name: 'Test [centos-8/4.0.0/jemalloc]'
+  test_centos_8-4_0_2-jemalloc:
+    name: 'Test [centos-8/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -702,7 +573,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -720,7 +591,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -733,51 +604,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-centos-8_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-4_0_0-malloctrim:
-    name: 'Test [centos-8/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_4_8-normal:
     name: 'Test [centos-8/3.4.8/normal]'
@@ -865,49 +693,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-centos-8_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-3_4_8-malloctrim:
-    name: 'Test [centos-8/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_3_10-normal:
     name: 'Test [centos-8/3.3.10/normal]'
     needs:
@@ -993,49 +778,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-centos-8_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_centos_8-3_3_10-malloctrim:
-    name: 'Test [centos-8/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-centos-8_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_centos_8-3_2_9-normal:
     name: 'Test [centos-8/3.2.9/normal]'
@@ -1253,49 +995,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-11_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-4_0-malloctrim:
-    name: 'Test [debian-11/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
@@ -1382,49 +1081,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-11_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-3_4-malloctrim:
-    name: 'Test [debian-11/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_3-normal:
     name: 'Test [debian-11/3.3/normal]'
     needs:
@@ -1510,49 +1166,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-11_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-3_3-malloctrim:
-    name: 'Test [debian-11/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_2-normal:
     name: 'Test [debian-11/3.2/normal]'
@@ -1683,8 +1296,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-11_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-4_0_0-normal:
-    name: 'Test [debian-11/4.0.0/normal]'
+  test_debian_11-4_0_2-normal:
+    name: 'Test [debian-11/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -1692,7 +1305,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -1710,7 +1323,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1723,11 +1336,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-4_0_0-jemalloc:
-    name: 'Test [debian-11/4.0.0/jemalloc]'
+  test_debian_11-4_0_2-jemalloc:
+    name: 'Test [debian-11/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -1735,7 +1348,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -1753,7 +1366,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1766,51 +1379,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-11_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-4_0_0-malloctrim:
-    name: 'Test [debian-11/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_4_8-normal:
     name: 'Test [debian-11/3.4.8/normal]'
@@ -1898,49 +1468,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-11_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-3_4_8-malloctrim:
-    name: 'Test [debian-11/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_3_10-normal:
     name: 'Test [debian-11/3.3.10/normal]'
     needs:
@@ -2026,49 +1553,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-11_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_11-3_3_10-malloctrim:
-    name: 'Test [debian-11/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-11_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_11-3_2_9-normal:
     name: 'Test [debian-11/3.2.9/normal]'
@@ -2286,49 +1770,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-12_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-4_0-malloctrim:
-    name: 'Test [debian-12/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
@@ -2415,49 +1856,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-12_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-3_4-malloctrim:
-    name: 'Test [debian-12/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_3-normal:
     name: 'Test [debian-12/3.3/normal]'
     needs:
@@ -2543,49 +1941,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-12_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-3_3-malloctrim:
-    name: 'Test [debian-12/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_2-normal:
     name: 'Test [debian-12/3.2/normal]'
@@ -2716,8 +2071,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-12_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-4_0_0-normal:
-    name: 'Test [debian-12/4.0.0/normal]'
+  test_debian_12-4_0_2-normal:
+    name: 'Test [debian-12/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -2725,7 +2080,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -2743,7 +2098,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2756,11 +2111,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-4_0_0-jemalloc:
-    name: 'Test [debian-12/4.0.0/jemalloc]'
+  test_debian_12-4_0_2-jemalloc:
+    name: 'Test [debian-12/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -2768,7 +2123,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -2786,7 +2141,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2799,51 +2154,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-12_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-4_0_0-malloctrim:
-    name: 'Test [debian-12/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_4_8-normal:
     name: 'Test [debian-12/3.4.8/normal]'
@@ -2931,49 +2243,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-12_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-3_4_8-malloctrim:
-    name: 'Test [debian-12/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_3_10-normal:
     name: 'Test [debian-12/3.3.10/normal]'
     needs:
@@ -3059,49 +2328,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-12_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_12-3_3_10-malloctrim:
-    name: 'Test [debian-12/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-12_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_12-3_2_9-normal:
     name: 'Test [debian-12/3.2.9/normal]'
@@ -3319,49 +2545,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-13_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-4_0-malloctrim:
-    name: 'Test [debian-13/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
@@ -3447,49 +2630,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-13_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-3_4-malloctrim:
-    name: 'Test [debian-13/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_3-normal:
     name: 'Test [debian-13/3.3/normal]'
@@ -3577,8 +2717,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-13_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-3_3-malloctrim:
-    name: 'Test [debian-13/3.3/malloctrim]'
+  test_debian_13-4_0_2-normal:
+    name: 'Test [debian-13/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -3586,7 +2726,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3/malloctrim];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -3604,50 +2744,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-4_0_0-normal:
-    name: 'Test [debian-13/4.0.0/normal]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/normal];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3660,11 +2757,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-4_0_0-jemalloc:
-    name: 'Test [debian-13/4.0.0/jemalloc]'
+  test_debian_13-4_0_2-jemalloc:
+    name: 'Test [debian-13/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -3672,7 +2769,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -3690,7 +2787,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3703,51 +2800,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-debian-13_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-4_0_0-malloctrim:
-    name: 'Test [debian-13/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_4_8-normal:
     name: 'Test [debian-13/3.4.8/normal]'
@@ -3835,49 +2889,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-debian-13_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-3_4_8-malloctrim:
-    name: 'Test [debian-13/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_debian_13-3_3_10-normal:
     name: 'Test [debian-13/3.3.10/normal]'
     needs:
@@ -3963,49 +2974,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-debian-13_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_debian_13-3_3_10-malloctrim:
-    name: 'Test [debian-13/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-debian-13_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_el_9-4_0-normal:
@@ -4094,49 +3062,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-el-9_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-4_0-malloctrim:
-    name: 'Test [el-9/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
     needs:
@@ -4223,49 +3148,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-el-9_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-3_4-malloctrim:
-    name: 'Test [el-9/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_3-normal:
     name: 'Test [el-9/3.3/normal]'
     needs:
@@ -4351,49 +3233,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-el-9_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-3_3-malloctrim:
-    name: 'Test [el-9/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_2-normal:
     name: 'Test [el-9/3.2/normal]'
@@ -4524,8 +3363,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-el-9_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-4_0_0-normal:
-    name: 'Test [el-9/4.0.0/normal]'
+  test_el_9-4_0_2-normal:
+    name: 'Test [el-9/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -4533,7 +3372,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -4551,7 +3390,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4564,11 +3403,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-el-9_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-4_0_0-jemalloc:
-    name: 'Test [el-9/4.0.0/jemalloc]'
+  test_el_9-4_0_2-jemalloc:
+    name: 'Test [el-9/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -4576,7 +3415,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -4594,7 +3433,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4607,51 +3446,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-el-9_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-4_0_0-malloctrim:
-    name: 'Test [el-9/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_4_8-normal:
     name: 'Test [el-9/3.4.8/normal]'
@@ -4739,49 +3535,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-el-9_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-3_4_8-malloctrim:
-    name: 'Test [el-9/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_3_10-normal:
     name: 'Test [el-9/3.3.10/normal]'
     needs:
@@ -4867,49 +3620,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-el-9_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_el_9-3_3_10-malloctrim:
-    name: 'Test [el-9/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-el-9_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_el_9-3_2_9-normal:
     name: 'Test [el-9/3.2.9/normal]'
@@ -5127,49 +3837,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-4_0-malloctrim:
-    name: 'Test [ubuntu-22.04/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
@@ -5256,49 +3923,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-3_4-malloctrim:
-    name: 'Test [ubuntu-22.04/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_3-normal:
     name: 'Test [ubuntu-22.04/3.3/normal]'
     needs:
@@ -5384,49 +4008,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-3_3-malloctrim:
-    name: 'Test [ubuntu-22.04/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_2-normal:
     name: 'Test [ubuntu-22.04/3.2/normal]'
@@ -5557,8 +4138,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-4_0_0-normal:
-    name: 'Test [ubuntu-22.04/4.0.0/normal]'
+  test_ubuntu_22_04-4_0_2-normal:
+    name: 'Test [ubuntu-22.04/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -5566,7 +4147,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -5584,7 +4165,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -5597,11 +4178,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-4_0_0-jemalloc:
-    name: 'Test [ubuntu-22.04/4.0.0/jemalloc]'
+  test_ubuntu_22_04-4_0_2-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -5609,7 +4190,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -5627,7 +4208,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -5640,51 +4221,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-4_0_0-malloctrim:
-    name: 'Test [ubuntu-22.04/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_4_8-normal:
     name: 'Test [ubuntu-22.04/3.4.8/normal]'
@@ -5772,49 +4310,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-3_4_8-malloctrim:
-    name: 'Test [ubuntu-22.04/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_3_10-normal:
     name: 'Test [ubuntu-22.04/3.3.10/normal]'
     needs:
@@ -5900,49 +4395,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_22_04-3_3_10-malloctrim:
-    name: 'Test [ubuntu-22.04/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-22.04_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_22_04-3_2_9-normal:
     name: 'Test [ubuntu-22.04/3.2.9/normal]'
@@ -6160,49 +4612,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-4_0-malloctrim:
-    name: 'Test [ubuntu-24.04/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
@@ -6289,49 +4698,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-3_4-malloctrim:
-    name: 'Test [ubuntu-24.04/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_3-normal:
     name: 'Test [ubuntu-24.04/3.3/normal]'
     needs:
@@ -6417,49 +4783,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-3_3-malloctrim:
-    name: 'Test [ubuntu-24.04/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_2-normal:
     name: 'Test [ubuntu-24.04/3.2/normal]'
@@ -6590,8 +4913,8 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.2_malloctrim
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-4_0_0-normal:
-    name: 'Test [ubuntu-24.04/4.0.0/normal]'
+  test_ubuntu_24_04-4_0_2-normal:
+    name: 'Test [ubuntu-24.04/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -6599,7 +4922,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/normal];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -6617,7 +4940,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -6630,11 +4953,11 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_normal
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-4_0_0-jemalloc:
-    name: 'Test [ubuntu-24.04/4.0.0/jemalloc]'
+  test_ubuntu_24_04-4_0_2-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-22.04
@@ -6642,7 +4965,7 @@ jobs:
     timeout-minutes: 30
     if: |
       github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/jemalloc];')
+      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -6660,7 +4983,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -6673,51 +4996,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-4_0_0-malloctrim:
-    name: 'Test [ubuntu-24.04/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_4_8-normal:
     name: 'Test [ubuntu-24.04/3.4.8/normal]'
@@ -6805,49 +5085,6 @@ jobs:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.4.8_jemalloc
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-3_4_8-malloctrim:
-    name: 'Test [ubuntu-24.04/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_3_10-normal:
     name: 'Test [ubuntu-24.04/3.3.10/normal]'
     needs:
@@ -6933,49 +5170,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-  test_ubuntu_24_04-3_3_10-malloctrim:
-    name: 'Test [ubuntu-24.04/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-22.04
-    environment: test
-    timeout-minutes: 30
-    if: |
-      github.ref == 'refs/heads/main'
-      && contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://apt.fullstaqruby.org
-          YUM_REPO_URL: https://yum.fullstaqruby.org
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-production-ubuntu-24.04_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
   test_ubuntu_24_04-3_2_9-normal:
     name: 'Test [ubuntu-24.04/3.2.9/normal]'
@@ -7120,163 +5314,121 @@ jobs:
       - publish
       - test_centos_8-4_0-normal
       - test_centos_8-4_0-jemalloc
-      - test_centos_8-4_0-malloctrim
       - test_centos_8-3_4-normal
       - test_centos_8-3_4-jemalloc
-      - test_centos_8-3_4-malloctrim
       - test_centos_8-3_3-normal
       - test_centos_8-3_3-jemalloc
-      - test_centos_8-3_3-malloctrim
       - test_centos_8-3_2-normal
       - test_centos_8-3_2-jemalloc
       - test_centos_8-3_2-malloctrim
-      - test_centos_8-4_0_0-normal
-      - test_centos_8-4_0_0-jemalloc
-      - test_centos_8-4_0_0-malloctrim
+      - test_centos_8-4_0_2-normal
+      - test_centos_8-4_0_2-jemalloc
       - test_centos_8-3_4_8-normal
       - test_centos_8-3_4_8-jemalloc
-      - test_centos_8-3_4_8-malloctrim
       - test_centos_8-3_3_10-normal
       - test_centos_8-3_3_10-jemalloc
-      - test_centos_8-3_3_10-malloctrim
       - test_centos_8-3_2_9-normal
       - test_centos_8-3_2_9-jemalloc
       - test_centos_8-3_2_9-malloctrim
       - test_debian_11-4_0-normal
       - test_debian_11-4_0-jemalloc
-      - test_debian_11-4_0-malloctrim
       - test_debian_11-3_4-normal
       - test_debian_11-3_4-jemalloc
-      - test_debian_11-3_4-malloctrim
       - test_debian_11-3_3-normal
       - test_debian_11-3_3-jemalloc
-      - test_debian_11-3_3-malloctrim
       - test_debian_11-3_2-normal
       - test_debian_11-3_2-jemalloc
       - test_debian_11-3_2-malloctrim
-      - test_debian_11-4_0_0-normal
-      - test_debian_11-4_0_0-jemalloc
-      - test_debian_11-4_0_0-malloctrim
+      - test_debian_11-4_0_2-normal
+      - test_debian_11-4_0_2-jemalloc
       - test_debian_11-3_4_8-normal
       - test_debian_11-3_4_8-jemalloc
-      - test_debian_11-3_4_8-malloctrim
       - test_debian_11-3_3_10-normal
       - test_debian_11-3_3_10-jemalloc
-      - test_debian_11-3_3_10-malloctrim
       - test_debian_11-3_2_9-normal
       - test_debian_11-3_2_9-jemalloc
       - test_debian_11-3_2_9-malloctrim
       - test_debian_12-4_0-normal
       - test_debian_12-4_0-jemalloc
-      - test_debian_12-4_0-malloctrim
       - test_debian_12-3_4-normal
       - test_debian_12-3_4-jemalloc
-      - test_debian_12-3_4-malloctrim
       - test_debian_12-3_3-normal
       - test_debian_12-3_3-jemalloc
-      - test_debian_12-3_3-malloctrim
       - test_debian_12-3_2-normal
       - test_debian_12-3_2-jemalloc
       - test_debian_12-3_2-malloctrim
-      - test_debian_12-4_0_0-normal
-      - test_debian_12-4_0_0-jemalloc
-      - test_debian_12-4_0_0-malloctrim
+      - test_debian_12-4_0_2-normal
+      - test_debian_12-4_0_2-jemalloc
       - test_debian_12-3_4_8-normal
       - test_debian_12-3_4_8-jemalloc
-      - test_debian_12-3_4_8-malloctrim
       - test_debian_12-3_3_10-normal
       - test_debian_12-3_3_10-jemalloc
-      - test_debian_12-3_3_10-malloctrim
       - test_debian_12-3_2_9-normal
       - test_debian_12-3_2_9-jemalloc
       - test_debian_12-3_2_9-malloctrim
       - test_debian_13-4_0-normal
       - test_debian_13-4_0-jemalloc
-      - test_debian_13-4_0-malloctrim
       - test_debian_13-3_4-normal
       - test_debian_13-3_4-jemalloc
-      - test_debian_13-3_4-malloctrim
       - test_debian_13-3_3-normal
       - test_debian_13-3_3-jemalloc
-      - test_debian_13-3_3-malloctrim
-      - test_debian_13-4_0_0-normal
-      - test_debian_13-4_0_0-jemalloc
-      - test_debian_13-4_0_0-malloctrim
+      - test_debian_13-4_0_2-normal
+      - test_debian_13-4_0_2-jemalloc
       - test_debian_13-3_4_8-normal
       - test_debian_13-3_4_8-jemalloc
-      - test_debian_13-3_4_8-malloctrim
       - test_debian_13-3_3_10-normal
       - test_debian_13-3_3_10-jemalloc
-      - test_debian_13-3_3_10-malloctrim
       - test_el_9-4_0-normal
       - test_el_9-4_0-jemalloc
-      - test_el_9-4_0-malloctrim
       - test_el_9-3_4-normal
       - test_el_9-3_4-jemalloc
-      - test_el_9-3_4-malloctrim
       - test_el_9-3_3-normal
       - test_el_9-3_3-jemalloc
-      - test_el_9-3_3-malloctrim
       - test_el_9-3_2-normal
       - test_el_9-3_2-jemalloc
       - test_el_9-3_2-malloctrim
-      - test_el_9-4_0_0-normal
-      - test_el_9-4_0_0-jemalloc
-      - test_el_9-4_0_0-malloctrim
+      - test_el_9-4_0_2-normal
+      - test_el_9-4_0_2-jemalloc
       - test_el_9-3_4_8-normal
       - test_el_9-3_4_8-jemalloc
-      - test_el_9-3_4_8-malloctrim
       - test_el_9-3_3_10-normal
       - test_el_9-3_3_10-jemalloc
-      - test_el_9-3_3_10-malloctrim
       - test_el_9-3_2_9-normal
       - test_el_9-3_2_9-jemalloc
       - test_el_9-3_2_9-malloctrim
       - test_ubuntu_22_04-4_0-normal
       - test_ubuntu_22_04-4_0-jemalloc
-      - test_ubuntu_22_04-4_0-malloctrim
       - test_ubuntu_22_04-3_4-normal
       - test_ubuntu_22_04-3_4-jemalloc
-      - test_ubuntu_22_04-3_4-malloctrim
       - test_ubuntu_22_04-3_3-normal
       - test_ubuntu_22_04-3_3-jemalloc
-      - test_ubuntu_22_04-3_3-malloctrim
       - test_ubuntu_22_04-3_2-normal
       - test_ubuntu_22_04-3_2-jemalloc
       - test_ubuntu_22_04-3_2-malloctrim
-      - test_ubuntu_22_04-4_0_0-normal
-      - test_ubuntu_22_04-4_0_0-jemalloc
-      - test_ubuntu_22_04-4_0_0-malloctrim
+      - test_ubuntu_22_04-4_0_2-normal
+      - test_ubuntu_22_04-4_0_2-jemalloc
       - test_ubuntu_22_04-3_4_8-normal
       - test_ubuntu_22_04-3_4_8-jemalloc
-      - test_ubuntu_22_04-3_4_8-malloctrim
       - test_ubuntu_22_04-3_3_10-normal
       - test_ubuntu_22_04-3_3_10-jemalloc
-      - test_ubuntu_22_04-3_3_10-malloctrim
       - test_ubuntu_22_04-3_2_9-normal
       - test_ubuntu_22_04-3_2_9-jemalloc
       - test_ubuntu_22_04-3_2_9-malloctrim
       - test_ubuntu_24_04-4_0-normal
       - test_ubuntu_24_04-4_0-jemalloc
-      - test_ubuntu_24_04-4_0-malloctrim
       - test_ubuntu_24_04-3_4-normal
       - test_ubuntu_24_04-3_4-jemalloc
-      - test_ubuntu_24_04-3_4-malloctrim
       - test_ubuntu_24_04-3_3-normal
       - test_ubuntu_24_04-3_3-jemalloc
-      - test_ubuntu_24_04-3_3-malloctrim
       - test_ubuntu_24_04-3_2-normal
       - test_ubuntu_24_04-3_2-jemalloc
       - test_ubuntu_24_04-3_2-malloctrim
-      - test_ubuntu_24_04-4_0_0-normal
-      - test_ubuntu_24_04-4_0_0-jemalloc
-      - test_ubuntu_24_04-4_0_0-malloctrim
+      - test_ubuntu_24_04-4_0_2-normal
+      - test_ubuntu_24_04-4_0_2-jemalloc
       - test_ubuntu_24_04-3_4_8-normal
       - test_ubuntu_24_04-3_4_8-jemalloc
-      - test_ubuntu_24_04-3_4_8-malloctrim
       - test_ubuntu_24_04-3_3_10-normal
       - test_ubuntu_24_04-3_3_10-jemalloc
-      - test_ubuntu_24_04-3_3_10-malloctrim
       - test_ubuntu_24_04-3_2_9-normal
       - test_ubuntu_24_04-3_2_9-jemalloc
       - test_ubuntu_24_04-3_2_9-malloctrim
@@ -7308,13 +5460,6 @@ jobs:
           && needs.test_centos_8-4_0-jemalloc.result != 'success'
           && (needs.test_centos_8-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-4_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7329,13 +5474,6 @@ jobs:
           && needs.test_centos_8-3_4-jemalloc.result != 'success'
           && (needs.test_centos_8-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_4-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7350,13 +5488,6 @@ jobs:
           && needs.test_centos_8-3_3-jemalloc.result != 'success'
           && (needs.test_centos_8-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_3-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7378,27 +5509,20 @@ jobs:
           && needs.test_centos_8-3_2-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-8/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-4_0_0-normal.result != 'success'
-          && (needs.test_centos_8-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/normal];'))
-      - name: Check whether 'Test [centos-8/4.0.0/jemalloc]' did not fail
+          && needs.test_centos_8-4_0_2-normal.result != 'success'
+          && (needs.test_centos_8-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.2/normal];'))
+      - name: Check whether 'Test [centos-8/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_centos_8-4_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_8-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-4_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.0/malloctrim];'))
+          && needs.test_centos_8-4_0_2-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/4.0.2/jemalloc];'))
       - name: Check whether 'Test [centos-8/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7413,13 +5537,6 @@ jobs:
           && needs.test_centos_8-3_4_8-jemalloc.result != 'success'
           && (needs.test_centos_8-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_4_8-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.4.8/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7434,13 +5551,6 @@ jobs:
           && needs.test_centos_8-3_3_10-jemalloc.result != 'success'
           && (needs.test_centos_8-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_centos_8-3_3_10-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [centos-8/3.3.10/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7476,13 +5586,6 @@ jobs:
           && needs.test_debian_11-4_0-jemalloc.result != 'success'
           && (needs.test_debian_11-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-11/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_11-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7497,13 +5600,6 @@ jobs:
           && needs.test_debian_11-3_4-jemalloc.result != 'success'
           && (needs.test_debian_11-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7518,13 +5614,6 @@ jobs:
           && needs.test_debian_11-3_3-jemalloc.result != 'success'
           && (needs.test_debian_11-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7546,27 +5635,20 @@ jobs:
           && needs.test_debian_11-3_2-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.2/malloctrim];'))
-      - name: Check whether 'Test [debian-11/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-11/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-4_0_0-normal.result != 'success'
-          && (needs.test_debian_11-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-11/4.0.0/jemalloc]' did not fail
+          && needs.test_debian_11-4_0_2-normal.result != 'success'
+          && (needs.test_debian_11-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-11/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_11-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_11-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-11/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_11-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.0/malloctrim];'))
+          && needs.test_debian_11-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-11/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7581,13 +5663,6 @@ jobs:
           && needs.test_debian_11-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_11-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7602,13 +5677,6 @@ jobs:
           && needs.test_debian_11-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_11-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_11-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-11/3.3.10/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7644,13 +5712,6 @@ jobs:
           && needs.test_debian_12-4_0-jemalloc.result != 'success'
           && (needs.test_debian_12-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-12/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_12-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7665,13 +5726,6 @@ jobs:
           && needs.test_debian_12-3_4-jemalloc.result != 'success'
           && (needs.test_debian_12-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7686,13 +5740,6 @@ jobs:
           && needs.test_debian_12-3_3-jemalloc.result != 'success'
           && (needs.test_debian_12-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7714,27 +5761,20 @@ jobs:
           && needs.test_debian_12-3_2-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.2/malloctrim];'))
-      - name: Check whether 'Test [debian-12/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-12/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_12-4_0_0-normal.result != 'success'
-          && (needs.test_debian_12-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-12/4.0.0/jemalloc]' did not fail
+          && needs.test_debian_12-4_0_2-normal.result != 'success'
+          && (needs.test_debian_12-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-12/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_12-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_12-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-12/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_12-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.0/malloctrim];'))
+          && needs.test_debian_12-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-12/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7749,13 +5789,6 @@ jobs:
           && needs.test_debian_12-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_12-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7770,13 +5803,6 @@ jobs:
           && needs.test_debian_12-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_12-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_12-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-12/3.3.10/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7812,13 +5838,6 @@ jobs:
           && needs.test_debian_13-4_0-jemalloc.result != 'success'
           && (needs.test_debian_13-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-13/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_13-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7833,13 +5852,6 @@ jobs:
           && needs.test_debian_13-3_4-jemalloc.result != 'success'
           && (needs.test_debian_13-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7854,34 +5866,20 @@ jobs:
           && needs.test_debian_13-3_3-jemalloc.result != 'success'
           && (needs.test_debian_13-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.3/malloctrim]' did not fail
+      - name: Check whether 'Test [debian-13/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_13-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3/malloctrim];'))
-      - name: Check whether 'Test [debian-13/4.0.0/normal]' did not fail
+          && needs.test_debian_13-4_0_2-normal.result != 'success'
+          && (needs.test_debian_13-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-13/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_debian_13-4_0_0-normal.result != 'success'
-          && (needs.test_debian_13-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-13/4.0.0/jemalloc]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_13-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-13/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_13-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.0/malloctrim];'))
+          && needs.test_debian_13-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-13/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7896,13 +5894,6 @@ jobs:
           && needs.test_debian_13-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_13-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7917,13 +5908,6 @@ jobs:
           && needs.test_debian_13-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_13-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_debian_13-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [debian-13/3.3.10/malloctrim];'))
       - name: Check whether 'Test [el-9/4.0/normal]' did not fail
         run: 'false'
         if: |
@@ -7938,13 +5922,6 @@ jobs:
           && needs.test_el_9-4_0-jemalloc.result != 'success'
           && (needs.test_el_9-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/jemalloc];'))
-      - name: Check whether 'Test [el-9/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-4_0-malloctrim.result != 'success'
-          && (needs.test_el_9-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7959,13 +5936,6 @@ jobs:
           && needs.test_el_9-3_4-jemalloc.result != 'success'
           && (needs.test_el_9-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-3_4-malloctrim.result != 'success'
-          && (needs.test_el_9-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4/malloctrim];'))
       - name: Check whether 'Test [el-9/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7980,13 +5950,6 @@ jobs:
           && needs.test_el_9-3_3-jemalloc.result != 'success'
           && (needs.test_el_9-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-3_3-malloctrim.result != 'success'
-          && (needs.test_el_9-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3/malloctrim];'))
       - name: Check whether 'Test [el-9/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -8008,27 +5971,20 @@ jobs:
           && needs.test_el_9-3_2-malloctrim.result != 'success'
           && (needs.test_el_9-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.2/malloctrim];'))
-      - name: Check whether 'Test [el-9/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [el-9/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_el_9-4_0_0-normal.result != 'success'
-          && (needs.test_el_9-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/normal];'))
-      - name: Check whether 'Test [el-9/4.0.0/jemalloc]' did not fail
+          && needs.test_el_9-4_0_2-normal.result != 'success'
+          && (needs.test_el_9-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.2/normal];'))
+      - name: Check whether 'Test [el-9/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_el_9-4_0_0-jemalloc.result != 'success'
-          && (needs.test_el_9-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [el-9/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-4_0_0-malloctrim.result != 'success'
-          && (needs.test_el_9-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.0/malloctrim];'))
+          && needs.test_el_9-4_0_2-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/4.0.2/jemalloc];'))
       - name: Check whether 'Test [el-9/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -8043,13 +5999,6 @@ jobs:
           && needs.test_el_9-3_4_8-jemalloc.result != 'success'
           && (needs.test_el_9-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-3_4_8-malloctrim.result != 'success'
-          && (needs.test_el_9-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.4.8/malloctrim];'))
       - name: Check whether 'Test [el-9/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -8064,13 +6013,6 @@ jobs:
           && needs.test_el_9-3_3_10-jemalloc.result != 'success'
           && (needs.test_el_9-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_el_9-3_3_10-malloctrim.result != 'success'
-          && (needs.test_el_9-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [el-9/3.3.10/malloctrim];'))
       - name: Check whether 'Test [el-9/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -8106,13 +6048,6 @@ jobs:
           && needs.test_ubuntu_22_04-4_0-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-4_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -8127,13 +6062,6 @@ jobs:
           && needs.test_ubuntu_22_04-3_4-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-3_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -8148,13 +6076,6 @@ jobs:
           && needs.test_ubuntu_22_04-3_3-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-3_3-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -8176,27 +6097,20 @@ jobs:
           && needs.test_ubuntu_22_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-22.04/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-4_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/jemalloc]' did not fail
+          && needs.test_ubuntu_22_04-4_0_2-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.2/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.0/malloctrim];'))
+          && needs.test_ubuntu_22_04-4_0_2-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/4.0.2/jemalloc];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -8211,13 +6125,6 @@ jobs:
           && needs.test_ubuntu_22_04-3_4_8-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-3_4_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.4.8/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -8232,13 +6139,6 @@ jobs:
           && needs.test_ubuntu_22_04-3_3_10-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_22_04-3_3_10-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-22.04/3.3.10/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -8274,13 +6174,6 @@ jobs:
           && needs.test_ubuntu_24_04-4_0-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-4_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -8295,13 +6188,6 @@ jobs:
           && needs.test_ubuntu_24_04-3_4-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-3_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -8316,13 +6202,6 @@ jobs:
           && needs.test_ubuntu_24_04-3_3-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-3_3-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -8344,27 +6223,20 @@ jobs:
           && needs.test_ubuntu_24_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-24.04/4.0.2/normal]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-4_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/jemalloc]' did not fail
+          && needs.test_ubuntu_24_04-4_0_2-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.2/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
           github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.0/malloctrim];'))
+          && needs.test_ubuntu_24_04-4_0_2-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/4.0.2/jemalloc];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -8379,13 +6251,6 @@ jobs:
           && needs.test_ubuntu_24_04-3_4_8-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-3_4_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.4.8/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -8400,13 +6265,6 @@ jobs:
           && needs.test_ubuntu_24_04-3_3_10-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          github.ref == 'refs/heads/main'
-          && needs.test_ubuntu_24_04-3_3_10-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against production repo [ubuntu-24.04/3.3.10/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.2.9/normal]' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-production.yml.erb
+++ b/.github/workflows/ci-cd-publish-test-production.yml.erb
@@ -124,7 +124,7 @@ jobs:
 
   <%- distributions.each do |distribution| %>
   <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-  <%- variants.each do |variant| -%>
+  <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
   <%- unindent(2) do %>
     test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>:
       name: 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]'
@@ -187,7 +187,7 @@ jobs:
       - publish
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-      <%- variants.each do |variant| -%>
+      <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
       - test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>
       <%- end -%>
       <%- end -%>
@@ -208,7 +208,7 @@ jobs:
 
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-      <%- variants.each do |variant| -%>
+      <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
       - name: Check whether 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -68,7 +68,7 @@ jobs:
             common-rpm
             rbenv-deb
             rbenv-rpm
-            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_4.0_centos-8_malloctrim ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.4_centos-8_malloctrim ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.3_centos-8_malloctrim ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.0_centos-8_normal ruby-pkg_4.0.0_centos-8_jemalloc ruby-pkg_4.0.0_centos-8_malloctrim ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_malloctrim ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_malloctrim ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_4.0_debian-11_malloctrim ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.4_debian-11_malloctrim ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.3_debian-11_malloctrim ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.0_debian-11_normal ruby-pkg_4.0.0_debian-11_jemalloc ruby-pkg_4.0.0_debian-11_malloctrim ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_malloctrim ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_malloctrim ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_4.0_debian-12_malloctrim ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.4_debian-12_malloctrim ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.3_debian-12_malloctrim ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.0_debian-12_normal ruby-pkg_4.0.0_debian-12_jemalloc ruby-pkg_4.0.0_debian-12_malloctrim ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_malloctrim ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_malloctrim ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_4.0_debian-13_malloctrim ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.4_debian-13_malloctrim ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_3.3_debian-13_malloctrim ruby-pkg_4.0.0_debian-13_normal ruby-pkg_4.0.0_debian-13_jemalloc ruby-pkg_4.0.0_debian-13_malloctrim ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_malloctrim ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_4.0_el-9_malloctrim ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.4_el-9_malloctrim ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.3_el-9_malloctrim ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.0_el-9_normal ruby-pkg_4.0.0_el-9_jemalloc ruby-pkg_4.0.0_el-9_malloctrim ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.4.8_el-9_malloctrim ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.3.10_el-9_malloctrim ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_4.0_ubuntu-22.04_malloctrim ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_malloctrim ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_malloctrim ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.0_ubuntu-22.04_normal ruby-pkg_4.0.0_ubuntu-22.04_jemalloc ruby-pkg_4.0.0_ubuntu-22.04_malloctrim ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_malloctrim ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_malloctrim ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_4.0_ubuntu-24.04_malloctrim ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_malloctrim ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_malloctrim ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.0_ubuntu-24.04_normal ruby-pkg_4.0.0_ubuntu-24.04_jemalloc ruby-pkg_4.0.0_ubuntu-24.04_malloctrim ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_malloctrim ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_malloctrim ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.2_centos-8_normal ruby-pkg_4.0.2_centos-8_jemalloc ruby-pkg_3.4.8_centos-8_normal ruby-pkg_3.4.8_centos-8_jemalloc ruby-pkg_3.3.10_centos-8_normal ruby-pkg_3.3.10_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_normal ruby-pkg_3.2.9_centos-8_jemalloc ruby-pkg_3.2.9_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.2_debian-11_normal ruby-pkg_4.0.2_debian-11_jemalloc ruby-pkg_3.4.8_debian-11_normal ruby-pkg_3.4.8_debian-11_jemalloc ruby-pkg_3.3.10_debian-11_normal ruby-pkg_3.3.10_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_normal ruby-pkg_3.2.9_debian-11_jemalloc ruby-pkg_3.2.9_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.2_debian-12_normal ruby-pkg_4.0.2_debian-12_jemalloc ruby-pkg_3.4.8_debian-12_normal ruby-pkg_3.4.8_debian-12_jemalloc ruby-pkg_3.3.10_debian-12_normal ruby-pkg_3.3.10_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_normal ruby-pkg_3.2.9_debian-12_jemalloc ruby-pkg_3.2.9_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.2_debian-13_normal ruby-pkg_4.0.2_debian-13_jemalloc ruby-pkg_3.4.8_debian-13_normal ruby-pkg_3.4.8_debian-13_jemalloc ruby-pkg_3.3.10_debian-13_normal ruby-pkg_3.3.10_debian-13_jemalloc ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.2_el-9_normal ruby-pkg_4.0.2_el-9_jemalloc ruby-pkg_3.4.8_el-9_normal ruby-pkg_3.4.8_el-9_jemalloc ruby-pkg_3.3.10_el-9_normal ruby-pkg_3.3.10_el-9_jemalloc ruby-pkg_3.2.9_el-9_normal ruby-pkg_3.2.9_el-9_jemalloc ruby-pkg_3.2.9_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.2_ubuntu-22.04_normal ruby-pkg_4.0.2_ubuntu-22.04_jemalloc ruby-pkg_3.4.8_ubuntu-22.04_normal ruby-pkg_3.4.8_ubuntu-22.04_jemalloc ruby-pkg_3.3.10_ubuntu-22.04_normal ruby-pkg_3.3.10_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_normal ruby-pkg_3.2.9_ubuntu-22.04_jemalloc ruby-pkg_3.2.9_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.2_ubuntu-24.04_normal ruby-pkg_4.0.2_ubuntu-24.04_jemalloc ruby-pkg_3.4.8_ubuntu-24.04_normal ruby-pkg_3.4.8_ubuntu-24.04_jemalloc ruby-pkg_3.3.10_ubuntu-24.04_normal ruby-pkg_3.3.10_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_normal ruby-pkg_3.2.9_ubuntu-24.04_jemalloc ruby-pkg_3.2.9_ubuntu-24.04_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -197,48 +197,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_centos_8-4_0-malloctrim:
-    name: 'Test [centos-8/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
     needs:
@@ -323,48 +281,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_centos_8-3_4-malloctrim:
-    name: 'Test [centos-8/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_centos_8-3_3-normal:
     name: 'Test [centos-8/3.3/normal]'
     needs:
@@ -447,48 +363,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-centos-8_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_centos_8-3_3-malloctrim:
-    name: 'Test [centos-8/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_centos_8-3_2-normal:
@@ -617,14 +491,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_centos_8-4_0_0-normal:
-    name: 'Test [centos-8/4.0.0/normal]'
+  test_centos_8-4_0_2-normal:
+    name: 'Test [centos-8/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -642,7 +516,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -655,18 +529,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_centos_8-4_0_0-jemalloc:
-    name: 'Test [centos-8/4.0.0/jemalloc]'
+  test_centos_8-4_0_2-jemalloc:
+    name: 'Test [centos-8/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -684,7 +558,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -697,50 +571,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-centos-8_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_centos_8-4_0_0-malloctrim:
-    name: 'Test [centos-8/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_centos_8-3_4_8-normal:
@@ -827,48 +659,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_centos_8-3_4_8-malloctrim:
-    name: 'Test [centos-8/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_centos_8-3_3_10-normal:
     name: 'Test [centos-8/3.3.10/normal]'
     needs:
@@ -951,48 +741,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-centos-8_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_centos_8-3_3_10-malloctrim:
-    name: 'Test [centos-8/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "centos-8"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:8"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-centos-8_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_centos_8-3_2_9-normal:
@@ -1206,48 +954,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_11-4_0-malloctrim:
-    name: 'Test [debian-11/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
@@ -1332,48 +1038,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_11-3_4-malloctrim:
-    name: 'Test [debian-11/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_11-3_3-normal:
     name: 'Test [debian-11/3.3/normal]'
     needs:
@@ -1456,48 +1120,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-11_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_11-3_3-malloctrim:
-    name: 'Test [debian-11/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_11-3_2-normal:
@@ -1626,14 +1248,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_11-4_0_0-normal:
-    name: 'Test [debian-11/4.0.0/normal]'
+  test_debian_11-4_0_2-normal:
+    name: 'Test [debian-11/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -1651,7 +1273,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -1664,18 +1286,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_11-4_0_0-jemalloc:
-    name: 'Test [debian-11/4.0.0/jemalloc]'
+  test_debian_11-4_0_2-jemalloc:
+    name: 'Test [debian-11/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -1693,7 +1315,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -1706,50 +1328,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-11_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_11-4_0_0-malloctrim:
-    name: 'Test [debian-11/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_11-3_4_8-normal:
@@ -1836,48 +1416,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_11-3_4_8-malloctrim:
-    name: 'Test [debian-11/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_11-3_3_10-normal:
     name: 'Test [debian-11/3.3.10/normal]'
     needs:
@@ -1960,48 +1498,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-11_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_11-3_3_10-malloctrim:
-    name: 'Test [debian-11/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-11"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:11"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-11_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_11-3_2_9-normal:
@@ -2215,48 +1711,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_12-4_0-malloctrim:
-    name: 'Test [debian-12/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
@@ -2341,48 +1795,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_12-3_4-malloctrim:
-    name: 'Test [debian-12/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_12-3_3-normal:
     name: 'Test [debian-12/3.3/normal]'
     needs:
@@ -2465,48 +1877,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-12_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_12-3_3-malloctrim:
-    name: 'Test [debian-12/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_12-3_2-normal:
@@ -2635,14 +2005,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_12-4_0_0-normal:
-    name: 'Test [debian-12/4.0.0/normal]'
+  test_debian_12-4_0_2-normal:
+    name: 'Test [debian-12/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -2660,7 +2030,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -2673,18 +2043,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_12-4_0_0-jemalloc:
-    name: 'Test [debian-12/4.0.0/jemalloc]'
+  test_debian_12-4_0_2-jemalloc:
+    name: 'Test [debian-12/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -2702,7 +2072,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -2715,50 +2085,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-12_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_12-4_0_0-malloctrim:
-    name: 'Test [debian-12/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_12-3_4_8-normal:
@@ -2845,48 +2173,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_12-3_4_8-malloctrim:
-    name: 'Test [debian-12/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_12-3_3_10-normal:
     name: 'Test [debian-12/3.3.10/normal]'
     needs:
@@ -2969,48 +2255,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-12_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_12-3_3_10-malloctrim:
-    name: 'Test [debian-12/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-12"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:12"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-12_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_12-3_2_9-normal:
@@ -3224,48 +2468,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_13-4_0-malloctrim:
-    name: 'Test [debian-13/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
@@ -3348,48 +2550,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-13_3.4_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_13-3_4-malloctrim:
-    name: 'Test [debian-13/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_13-3_3-normal:
@@ -3476,14 +2636,14 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_13-3_3-malloctrim:
-    name: 'Test [debian-13/3.3/malloctrim]'
+  test_debian_13-4_0_2-normal:
+    name: 'Test [debian-13/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3/malloctrim];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -3501,49 +2661,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_13-4_0_0-normal:
-    name: 'Test [debian-13/4.0.0/normal]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/normal];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -3556,18 +2674,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_13-4_0_0-jemalloc:
-    name: 'Test [debian-13/4.0.0/jemalloc]'
+  test_debian_13-4_0_2-jemalloc:
+    name: 'Test [debian-13/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -3585,7 +2703,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -3598,50 +2716,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-debian-13_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_13-4_0_0-malloctrim:
-    name: 'Test [debian-13/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_debian_13-3_4_8-normal:
@@ -3728,48 +2804,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_debian_13-3_4_8-malloctrim:
-    name: 'Test [debian-13/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_debian_13-3_3_10-normal:
     name: 'Test [debian-13/3.3.10/normal]'
     needs:
@@ -3852,48 +2886,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-debian-13_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_debian_13-3_3_10-malloctrim:
-    name: 'Test [debian-13/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "debian-13"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "debian:13"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-debian-13_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
 
@@ -3981,48 +2973,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_el_9-4_0-malloctrim:
-    name: 'Test [el-9/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
     needs:
@@ -4107,48 +3057,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_el_9-3_4-malloctrim:
-    name: 'Test [el-9/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_el_9-3_3-normal:
     name: 'Test [el-9/3.3/normal]'
     needs:
@@ -4231,48 +3139,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-el-9_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_el_9-3_3-malloctrim:
-    name: 'Test [el-9/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_el_9-3_2-normal:
@@ -4401,14 +3267,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_el_9-4_0_0-normal:
-    name: 'Test [el-9/4.0.0/normal]'
+  test_el_9-4_0_2-normal:
+    name: 'Test [el-9/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -4426,7 +3292,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -4439,18 +3305,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-el-9_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_el_9-4_0_0-jemalloc:
-    name: 'Test [el-9/4.0.0/jemalloc]'
+  test_el_9-4_0_2-jemalloc:
+    name: 'Test [el-9/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -4468,7 +3334,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "RPM"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -4481,50 +3347,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-el-9_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_el_9-4_0_0-malloctrim:
-    name: 'Test [el-9/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_el_9-3_4_8-normal:
@@ -4611,48 +3435,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_el_9-3_4_8-malloctrim:
-    name: 'Test [el-9/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_el_9-3_3_10-normal:
     name: 'Test [el-9/3.3.10/normal]'
     needs:
@@ -4735,48 +3517,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-el-9_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_el_9-3_3_10-malloctrim:
-    name: 'Test [el-9/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "el-9"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "RPM"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "rockylinux:9"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-el-9_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_el_9-3_2_9-normal:
@@ -4990,48 +3730,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_22_04-4_0-malloctrim:
-    name: 'Test [ubuntu-22.04/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
@@ -5116,48 +3814,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_22_04-3_4-malloctrim:
-    name: 'Test [ubuntu-22.04/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_22_04-3_3-normal:
     name: 'Test [ubuntu-22.04/3.3/normal]'
     needs:
@@ -5240,48 +3896,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_22_04-3_3-malloctrim:
-    name: 'Test [ubuntu-22.04/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_22_04-3_2-normal:
@@ -5410,14 +4024,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_22_04-4_0_0-normal:
-    name: 'Test [ubuntu-22.04/4.0.0/normal]'
+  test_ubuntu_22_04-4_0_2-normal:
+    name: 'Test [ubuntu-22.04/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -5435,7 +4049,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -5448,18 +4062,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_22_04-4_0_0-jemalloc:
-    name: 'Test [ubuntu-22.04/4.0.0/jemalloc]'
+  test_ubuntu_22_04-4_0_2-jemalloc:
+    name: 'Test [ubuntu-22.04/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -5477,7 +4091,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -5490,50 +4104,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_22_04-4_0_0-malloctrim:
-    name: 'Test [ubuntu-22.04/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_22_04-3_4_8-normal:
@@ -5620,48 +4192,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_22_04-3_4_8-malloctrim:
-    name: 'Test [ubuntu-22.04/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_22_04-3_3_10-normal:
     name: 'Test [ubuntu-22.04/3.3.10/normal]'
     needs:
@@ -5744,48 +4274,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_22_04-3_3_10-malloctrim:
-    name: 'Test [ubuntu-22.04/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-22.04"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:22.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-22.04_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_22_04-3_2_9-normal:
@@ -5999,48 +4487,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_24_04-4_0-malloctrim:
-    name: 'Test [ubuntu-24.04/4.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
@@ -6125,48 +4571,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_24_04-3_4-malloctrim:
-    name: 'Test [ubuntu-24.04/3.4/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.4"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.4_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_24_04-3_3-normal:
     name: 'Test [ubuntu-24.04/3.3/normal]'
     needs:
@@ -6249,48 +4653,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.3_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_24_04-3_3-malloctrim:
-    name: 'Test [ubuntu-24.04/3.3/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.3"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.3_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_24_04-3_2-normal:
@@ -6419,14 +4781,14 @@ jobs:
           ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_24_04-4_0_0-normal:
-    name: 'Test [ubuntu-24.04/4.0.0/normal]'
+  test_ubuntu_24_04-4_0_2-normal:
+    name: 'Test [ubuntu-24.04/4.0.2/normal]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/normal];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.2/normal];')
     permissions:
       id-token: write
     steps:
@@ -6444,7 +4806,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "normal"
           VARIANT_PACKAGE_SUFFIX: ""
@@ -6457,18 +4819,18 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_normal
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.2_normal
           ARTIFACT_PATH: mark-normal
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_24_04-4_0_0-jemalloc:
-    name: 'Test [ubuntu-24.04/4.0.0/jemalloc]'
+  test_ubuntu_24_04-4_0_2-jemalloc:
+    name: 'Test [ubuntu-24.04/4.0.2/jemalloc]'
     needs:
       - publish
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/jemalloc];')
+    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.2/jemalloc];')
     permissions:
       id-token: write
     steps:
@@ -6486,7 +4848,7 @@ jobs:
         run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
         env:
           DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
+          RUBY_PACKAGE_ID: "4.0.2"
           PACKAGE_FORMAT: "DEB"
           VARIANT_NAME: "jemalloc"
           VARIANT_PACKAGE_SUFFIX: "-jemalloc"
@@ -6499,50 +4861,8 @@ jobs:
       - name: Mark job as done
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_jemalloc
+          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.2_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_24_04-4_0_0-malloctrim:
-    name: 'Test [ubuntu-24.04/4.0.0/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "4.0.0"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_4.0.0_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_24_04-3_4_8-normal:
@@ -6629,48 +4949,6 @@ jobs:
           ARTIFACT_PATH: mark-jemalloc
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
-  test_ubuntu_24_04-3_4_8-malloctrim:
-    name: 'Test [ubuntu-24.04/3.4.8/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4.8/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.4.8"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.4.8_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
   test_ubuntu_24_04-3_3_10-normal:
     name: 'Test [ubuntu-24.04/3.3.10/normal]'
     needs:
@@ -6753,48 +5031,6 @@ jobs:
         env:
           ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.3.10_jemalloc
           ARTIFACT_PATH: mark-jemalloc
-          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
-
-  test_ubuntu_24_04-3_3_10-malloctrim:
-    name: 'Test [ubuntu-24.04/3.3.10/malloctrim]'
-    needs:
-      - publish
-    runs-on: ubuntu-24.04
-    environment: test
-    timeout-minutes: 30
-    if: contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3.10/malloctrim];')
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: '>= 363.0.0'
-
-      - name: Run tests
-        run: ./internal-scripts/ci-cd/test-packages/run-tests.sh
-        env:
-          DISTRIBUTION_NAME: "ubuntu-24.04"
-          RUBY_PACKAGE_ID: "3.3.10"
-          PACKAGE_FORMAT: "DEB"
-          VARIANT_NAME: "malloctrim"
-          VARIANT_PACKAGE_SUFFIX: "-malloctrim"
-          TEST_IMAGE_NAME: "ubuntu:24.04"
-          APT_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/apt-repo/versions/singleton/public
-          YUM_REPO_URL: https://storage.googleapis.com/${{ vars.CI_ARTIFACTS_BUCKET }}/${{ env.CI_ARTIFACTS_RUN_NUMBER }}/yum-repo/versions/singleton/public
-
-      - name: Create mark file
-        run: mkdir mark-malloctrim && touch mark-malloctrim/done.txt
-      - name: Mark job as done
-        run: ./internal-scripts/ci-cd/upload-artifact.sh
-        env:
-          ARTIFACT_NAME: tested-against-test-ubuntu-24.04_3.3.10_malloctrim
-          ARTIFACT_PATH: mark-malloctrim
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
   test_ubuntu_24_04-3_2_9-normal:
@@ -6936,163 +5172,121 @@ jobs:
       - publish
       - test_centos_8-4_0-normal
       - test_centos_8-4_0-jemalloc
-      - test_centos_8-4_0-malloctrim
       - test_centos_8-3_4-normal
       - test_centos_8-3_4-jemalloc
-      - test_centos_8-3_4-malloctrim
       - test_centos_8-3_3-normal
       - test_centos_8-3_3-jemalloc
-      - test_centos_8-3_3-malloctrim
       - test_centos_8-3_2-normal
       - test_centos_8-3_2-jemalloc
       - test_centos_8-3_2-malloctrim
-      - test_centos_8-4_0_0-normal
-      - test_centos_8-4_0_0-jemalloc
-      - test_centos_8-4_0_0-malloctrim
+      - test_centos_8-4_0_2-normal
+      - test_centos_8-4_0_2-jemalloc
       - test_centos_8-3_4_8-normal
       - test_centos_8-3_4_8-jemalloc
-      - test_centos_8-3_4_8-malloctrim
       - test_centos_8-3_3_10-normal
       - test_centos_8-3_3_10-jemalloc
-      - test_centos_8-3_3_10-malloctrim
       - test_centos_8-3_2_9-normal
       - test_centos_8-3_2_9-jemalloc
       - test_centos_8-3_2_9-malloctrim
       - test_debian_11-4_0-normal
       - test_debian_11-4_0-jemalloc
-      - test_debian_11-4_0-malloctrim
       - test_debian_11-3_4-normal
       - test_debian_11-3_4-jemalloc
-      - test_debian_11-3_4-malloctrim
       - test_debian_11-3_3-normal
       - test_debian_11-3_3-jemalloc
-      - test_debian_11-3_3-malloctrim
       - test_debian_11-3_2-normal
       - test_debian_11-3_2-jemalloc
       - test_debian_11-3_2-malloctrim
-      - test_debian_11-4_0_0-normal
-      - test_debian_11-4_0_0-jemalloc
-      - test_debian_11-4_0_0-malloctrim
+      - test_debian_11-4_0_2-normal
+      - test_debian_11-4_0_2-jemalloc
       - test_debian_11-3_4_8-normal
       - test_debian_11-3_4_8-jemalloc
-      - test_debian_11-3_4_8-malloctrim
       - test_debian_11-3_3_10-normal
       - test_debian_11-3_3_10-jemalloc
-      - test_debian_11-3_3_10-malloctrim
       - test_debian_11-3_2_9-normal
       - test_debian_11-3_2_9-jemalloc
       - test_debian_11-3_2_9-malloctrim
       - test_debian_12-4_0-normal
       - test_debian_12-4_0-jemalloc
-      - test_debian_12-4_0-malloctrim
       - test_debian_12-3_4-normal
       - test_debian_12-3_4-jemalloc
-      - test_debian_12-3_4-malloctrim
       - test_debian_12-3_3-normal
       - test_debian_12-3_3-jemalloc
-      - test_debian_12-3_3-malloctrim
       - test_debian_12-3_2-normal
       - test_debian_12-3_2-jemalloc
       - test_debian_12-3_2-malloctrim
-      - test_debian_12-4_0_0-normal
-      - test_debian_12-4_0_0-jemalloc
-      - test_debian_12-4_0_0-malloctrim
+      - test_debian_12-4_0_2-normal
+      - test_debian_12-4_0_2-jemalloc
       - test_debian_12-3_4_8-normal
       - test_debian_12-3_4_8-jemalloc
-      - test_debian_12-3_4_8-malloctrim
       - test_debian_12-3_3_10-normal
       - test_debian_12-3_3_10-jemalloc
-      - test_debian_12-3_3_10-malloctrim
       - test_debian_12-3_2_9-normal
       - test_debian_12-3_2_9-jemalloc
       - test_debian_12-3_2_9-malloctrim
       - test_debian_13-4_0-normal
       - test_debian_13-4_0-jemalloc
-      - test_debian_13-4_0-malloctrim
       - test_debian_13-3_4-normal
       - test_debian_13-3_4-jemalloc
-      - test_debian_13-3_4-malloctrim
       - test_debian_13-3_3-normal
       - test_debian_13-3_3-jemalloc
-      - test_debian_13-3_3-malloctrim
-      - test_debian_13-4_0_0-normal
-      - test_debian_13-4_0_0-jemalloc
-      - test_debian_13-4_0_0-malloctrim
+      - test_debian_13-4_0_2-normal
+      - test_debian_13-4_0_2-jemalloc
       - test_debian_13-3_4_8-normal
       - test_debian_13-3_4_8-jemalloc
-      - test_debian_13-3_4_8-malloctrim
       - test_debian_13-3_3_10-normal
       - test_debian_13-3_3_10-jemalloc
-      - test_debian_13-3_3_10-malloctrim
       - test_el_9-4_0-normal
       - test_el_9-4_0-jemalloc
-      - test_el_9-4_0-malloctrim
       - test_el_9-3_4-normal
       - test_el_9-3_4-jemalloc
-      - test_el_9-3_4-malloctrim
       - test_el_9-3_3-normal
       - test_el_9-3_3-jemalloc
-      - test_el_9-3_3-malloctrim
       - test_el_9-3_2-normal
       - test_el_9-3_2-jemalloc
       - test_el_9-3_2-malloctrim
-      - test_el_9-4_0_0-normal
-      - test_el_9-4_0_0-jemalloc
-      - test_el_9-4_0_0-malloctrim
+      - test_el_9-4_0_2-normal
+      - test_el_9-4_0_2-jemalloc
       - test_el_9-3_4_8-normal
       - test_el_9-3_4_8-jemalloc
-      - test_el_9-3_4_8-malloctrim
       - test_el_9-3_3_10-normal
       - test_el_9-3_3_10-jemalloc
-      - test_el_9-3_3_10-malloctrim
       - test_el_9-3_2_9-normal
       - test_el_9-3_2_9-jemalloc
       - test_el_9-3_2_9-malloctrim
       - test_ubuntu_22_04-4_0-normal
       - test_ubuntu_22_04-4_0-jemalloc
-      - test_ubuntu_22_04-4_0-malloctrim
       - test_ubuntu_22_04-3_4-normal
       - test_ubuntu_22_04-3_4-jemalloc
-      - test_ubuntu_22_04-3_4-malloctrim
       - test_ubuntu_22_04-3_3-normal
       - test_ubuntu_22_04-3_3-jemalloc
-      - test_ubuntu_22_04-3_3-malloctrim
       - test_ubuntu_22_04-3_2-normal
       - test_ubuntu_22_04-3_2-jemalloc
       - test_ubuntu_22_04-3_2-malloctrim
-      - test_ubuntu_22_04-4_0_0-normal
-      - test_ubuntu_22_04-4_0_0-jemalloc
-      - test_ubuntu_22_04-4_0_0-malloctrim
+      - test_ubuntu_22_04-4_0_2-normal
+      - test_ubuntu_22_04-4_0_2-jemalloc
       - test_ubuntu_22_04-3_4_8-normal
       - test_ubuntu_22_04-3_4_8-jemalloc
-      - test_ubuntu_22_04-3_4_8-malloctrim
       - test_ubuntu_22_04-3_3_10-normal
       - test_ubuntu_22_04-3_3_10-jemalloc
-      - test_ubuntu_22_04-3_3_10-malloctrim
       - test_ubuntu_22_04-3_2_9-normal
       - test_ubuntu_22_04-3_2_9-jemalloc
       - test_ubuntu_22_04-3_2_9-malloctrim
       - test_ubuntu_24_04-4_0-normal
       - test_ubuntu_24_04-4_0-jemalloc
-      - test_ubuntu_24_04-4_0-malloctrim
       - test_ubuntu_24_04-3_4-normal
       - test_ubuntu_24_04-3_4-jemalloc
-      - test_ubuntu_24_04-3_4-malloctrim
       - test_ubuntu_24_04-3_3-normal
       - test_ubuntu_24_04-3_3-jemalloc
-      - test_ubuntu_24_04-3_3-malloctrim
       - test_ubuntu_24_04-3_2-normal
       - test_ubuntu_24_04-3_2-jemalloc
       - test_ubuntu_24_04-3_2-malloctrim
-      - test_ubuntu_24_04-4_0_0-normal
-      - test_ubuntu_24_04-4_0_0-jemalloc
-      - test_ubuntu_24_04-4_0_0-malloctrim
+      - test_ubuntu_24_04-4_0_2-normal
+      - test_ubuntu_24_04-4_0_2-jemalloc
       - test_ubuntu_24_04-3_4_8-normal
       - test_ubuntu_24_04-3_4_8-jemalloc
-      - test_ubuntu_24_04-3_4_8-malloctrim
       - test_ubuntu_24_04-3_3_10-normal
       - test_ubuntu_24_04-3_3_10-jemalloc
-      - test_ubuntu_24_04-3_3_10-malloctrim
       - test_ubuntu_24_04-3_2_9-normal
       - test_ubuntu_24_04-3_2_9-jemalloc
       - test_ubuntu_24_04-3_2_9-malloctrim
@@ -7120,12 +5314,6 @@ jobs:
           needs.test_centos_8-4_0-jemalloc.result != 'success'
           && (needs.test_centos_8-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-4_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7138,12 +5326,6 @@ jobs:
           needs.test_centos_8-3_4-jemalloc.result != 'success'
           && (needs.test_centos_8-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-3_4-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7156,12 +5338,6 @@ jobs:
           needs.test_centos_8-3_3-jemalloc.result != 'success'
           && (needs.test_centos_8-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-3_3-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7180,24 +5356,18 @@ jobs:
           needs.test_centos_8-3_2-malloctrim.result != 'success'
           && (needs.test_centos_8-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.2/malloctrim];'))
-      - name: Check whether 'Test [centos-8/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [centos-8/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-4_0_0-normal.result != 'success'
-          && (needs.test_centos_8-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/normal];'))
-      - name: Check whether 'Test [centos-8/4.0.0/jemalloc]' did not fail
+          needs.test_centos_8-4_0_2-normal.result != 'success'
+          && (needs.test_centos_8-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.2/normal];'))
+      - name: Check whether 'Test [centos-8/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_centos_8-4_0_0-jemalloc.result != 'success'
-          && (needs.test_centos_8-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [centos-8/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-4_0_0-malloctrim.result != 'success'
-          && (needs.test_centos_8-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.0/malloctrim];'))
+          needs.test_centos_8-4_0_2-jemalloc.result != 'success'
+          && (needs.test_centos_8-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/4.0.2/jemalloc];'))
       - name: Check whether 'Test [centos-8/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7210,12 +5380,6 @@ jobs:
           needs.test_centos_8-3_4_8-jemalloc.result != 'success'
           && (needs.test_centos_8-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-3_4_8-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.4.8/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7228,12 +5392,6 @@ jobs:
           needs.test_centos_8-3_3_10-jemalloc.result != 'success'
           && (needs.test_centos_8-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [centos-8/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_centos_8-3_3_10-malloctrim.result != 'success'
-          && (needs.test_centos_8-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [centos-8/3.3.10/malloctrim];'))
       - name: Check whether 'Test [centos-8/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7264,12 +5422,6 @@ jobs:
           needs.test_debian_11-4_0-jemalloc.result != 'success'
           && (needs.test_debian_11-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-11/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_11-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7282,12 +5434,6 @@ jobs:
           needs.test_debian_11-3_4-jemalloc.result != 'success'
           && (needs.test_debian_11-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7300,12 +5446,6 @@ jobs:
           needs.test_debian_11-3_3-jemalloc.result != 'success'
           && (needs.test_debian_11-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7324,24 +5464,18 @@ jobs:
           needs.test_debian_11-3_2-malloctrim.result != 'success'
           && (needs.test_debian_11-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.2/malloctrim];'))
-      - name: Check whether 'Test [debian-11/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-11/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-4_0_0-normal.result != 'success'
-          && (needs.test_debian_11-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-11/4.0.0/jemalloc]' did not fail
+          needs.test_debian_11-4_0_2-normal.result != 'success'
+          && (needs.test_debian_11-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-11/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_11-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_11-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-11/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_11-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.0/malloctrim];'))
+          needs.test_debian_11-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_11-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-11/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7354,12 +5488,6 @@ jobs:
           needs.test_debian_11-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_11-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7372,12 +5500,6 @@ jobs:
           needs.test_debian_11-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_11-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-11/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_11-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_11-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-11/3.3.10/malloctrim];'))
       - name: Check whether 'Test [debian-11/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7408,12 +5530,6 @@ jobs:
           needs.test_debian_12-4_0-jemalloc.result != 'success'
           && (needs.test_debian_12-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-12/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_12-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7426,12 +5542,6 @@ jobs:
           needs.test_debian_12-3_4-jemalloc.result != 'success'
           && (needs.test_debian_12-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7444,12 +5554,6 @@ jobs:
           needs.test_debian_12-3_3-jemalloc.result != 'success'
           && (needs.test_debian_12-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7468,24 +5572,18 @@ jobs:
           needs.test_debian_12-3_2-malloctrim.result != 'success'
           && (needs.test_debian_12-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.2/malloctrim];'))
-      - name: Check whether 'Test [debian-12/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [debian-12/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_12-4_0_0-normal.result != 'success'
-          && (needs.test_debian_12-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-12/4.0.0/jemalloc]' did not fail
+          needs.test_debian_12-4_0_2-normal.result != 'success'
+          && (needs.test_debian_12-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-12/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_12-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_12-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-12/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_12-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.0/malloctrim];'))
+          needs.test_debian_12-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_12-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-12/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7498,12 +5596,6 @@ jobs:
           needs.test_debian_12-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_12-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7516,12 +5608,6 @@ jobs:
           needs.test_debian_12-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_12-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-12/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_12-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_12-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-12/3.3.10/malloctrim];'))
       - name: Check whether 'Test [debian-12/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7552,12 +5638,6 @@ jobs:
           needs.test_debian_13-4_0-jemalloc.result != 'success'
           && (needs.test_debian_13-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/jemalloc];'))
-      - name: Check whether 'Test [debian-13/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-4_0-malloctrim.result != 'success'
-          && (needs.test_debian_13-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7570,12 +5650,6 @@ jobs:
           needs.test_debian_13-3_4-jemalloc.result != 'success'
           && (needs.test_debian_13-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-3_4-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7588,30 +5662,18 @@ jobs:
           needs.test_debian_13-3_3-jemalloc.result != 'success'
           && (needs.test_debian_13-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.3/malloctrim]' did not fail
+      - name: Check whether 'Test [debian-13/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_13-3_3-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3/malloctrim];'))
-      - name: Check whether 'Test [debian-13/4.0.0/normal]' did not fail
+          needs.test_debian_13-4_0_2-normal.result != 'success'
+          && (needs.test_debian_13-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.2/normal];'))
+      - name: Check whether 'Test [debian-13/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_debian_13-4_0_0-normal.result != 'success'
-          && (needs.test_debian_13-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/normal];'))
-      - name: Check whether 'Test [debian-13/4.0.0/jemalloc]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-4_0_0-jemalloc.result != 'success'
-          && (needs.test_debian_13-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [debian-13/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-4_0_0-malloctrim.result != 'success'
-          && (needs.test_debian_13-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.0/malloctrim];'))
+          needs.test_debian_13-4_0_2-jemalloc.result != 'success'
+          && (needs.test_debian_13-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/4.0.2/jemalloc];'))
       - name: Check whether 'Test [debian-13/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7624,12 +5686,6 @@ jobs:
           needs.test_debian_13-3_4_8-jemalloc.result != 'success'
           && (needs.test_debian_13-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-3_4_8-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.4.8/malloctrim];'))
       - name: Check whether 'Test [debian-13/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7642,12 +5698,6 @@ jobs:
           needs.test_debian_13-3_3_10-jemalloc.result != 'success'
           && (needs.test_debian_13-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [debian-13/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_debian_13-3_3_10-malloctrim.result != 'success'
-          && (needs.test_debian_13-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [debian-13/3.3.10/malloctrim];'))
       - name: Check whether 'Test [el-9/4.0/normal]' did not fail
         run: 'false'
         if: |
@@ -7660,12 +5710,6 @@ jobs:
           needs.test_el_9-4_0-jemalloc.result != 'success'
           && (needs.test_el_9-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/jemalloc];'))
-      - name: Check whether 'Test [el-9/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-4_0-malloctrim.result != 'success'
-          && (needs.test_el_9-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0/malloctrim];'))
       - name: Check whether 'Test [el-9/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7678,12 +5722,6 @@ jobs:
           needs.test_el_9-3_4-jemalloc.result != 'success'
           && (needs.test_el_9-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-3_4-malloctrim.result != 'success'
-          && (needs.test_el_9-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4/malloctrim];'))
       - name: Check whether 'Test [el-9/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7696,12 +5734,6 @@ jobs:
           needs.test_el_9-3_3-jemalloc.result != 'success'
           && (needs.test_el_9-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-3_3-malloctrim.result != 'success'
-          && (needs.test_el_9-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3/malloctrim];'))
       - name: Check whether 'Test [el-9/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7720,24 +5752,18 @@ jobs:
           needs.test_el_9-3_2-malloctrim.result != 'success'
           && (needs.test_el_9-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.2/malloctrim];'))
-      - name: Check whether 'Test [el-9/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [el-9/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_el_9-4_0_0-normal.result != 'success'
-          && (needs.test_el_9-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/normal];'))
-      - name: Check whether 'Test [el-9/4.0.0/jemalloc]' did not fail
+          needs.test_el_9-4_0_2-normal.result != 'success'
+          && (needs.test_el_9-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.2/normal];'))
+      - name: Check whether 'Test [el-9/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_el_9-4_0_0-jemalloc.result != 'success'
-          && (needs.test_el_9-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [el-9/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-4_0_0-malloctrim.result != 'success'
-          && (needs.test_el_9-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.0/malloctrim];'))
+          needs.test_el_9-4_0_2-jemalloc.result != 'success'
+          && (needs.test_el_9-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/4.0.2/jemalloc];'))
       - name: Check whether 'Test [el-9/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7750,12 +5776,6 @@ jobs:
           needs.test_el_9-3_4_8-jemalloc.result != 'success'
           && (needs.test_el_9-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-3_4_8-malloctrim.result != 'success'
-          && (needs.test_el_9-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.4.8/malloctrim];'))
       - name: Check whether 'Test [el-9/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7768,12 +5788,6 @@ jobs:
           needs.test_el_9-3_3_10-jemalloc.result != 'success'
           && (needs.test_el_9-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [el-9/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_el_9-3_3_10-malloctrim.result != 'success'
-          && (needs.test_el_9-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [el-9/3.3.10/malloctrim];'))
       - name: Check whether 'Test [el-9/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7804,12 +5818,6 @@ jobs:
           needs.test_ubuntu_22_04-4_0-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-4_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7822,12 +5830,6 @@ jobs:
           needs.test_ubuntu_22_04-3_4-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-3_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7840,12 +5842,6 @@ jobs:
           needs.test_ubuntu_22_04-3_3-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-3_3-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -7864,24 +5860,18 @@ jobs:
           needs.test_ubuntu_22_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_22_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-22.04/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_22_04-4_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/jemalloc]' did not fail
+          needs.test_ubuntu_22_04-4_0_2-normal.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.2/normal];'))
+      - name: Check whether 'Test [ubuntu-22.04/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.0/malloctrim];'))
+          needs.test_ubuntu_22_04-4_0_2-jemalloc.result != 'success'
+          && (needs.test_ubuntu_22_04-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/4.0.2/jemalloc];'))
       - name: Check whether 'Test [ubuntu-22.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -7894,12 +5884,6 @@ jobs:
           needs.test_ubuntu_22_04-3_4_8-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-3_4_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.4.8/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -7912,12 +5896,6 @@ jobs:
           needs.test_ubuntu_22_04-3_3_10-jemalloc.result != 'success'
           && (needs.test_ubuntu_22_04-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-22.04/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_22_04-3_3_10-malloctrim.result != 'success'
-          && (needs.test_ubuntu_22_04-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-22.04/3.3.10/malloctrim];'))
       - name: Check whether 'Test [ubuntu-22.04/3.2.9/normal]' did not fail
         run: 'false'
         if: |
@@ -7948,12 +5926,6 @@ jobs:
           needs.test_ubuntu_24_04-4_0-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-4_0-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-4_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4/normal]' did not fail
         run: 'false'
         if: |
@@ -7966,12 +5938,6 @@ jobs:
           needs.test_ubuntu_24_04-3_4-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_4-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.4/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-3_4-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_4-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.3/normal]' did not fail
         run: 'false'
         if: |
@@ -7984,12 +5950,6 @@ jobs:
           needs.test_ubuntu_24_04-3_3-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_3-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.3/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-3_3-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_3-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.2/normal]' did not fail
         run: 'false'
         if: |
@@ -8008,24 +5968,18 @@ jobs:
           needs.test_ubuntu_24_04-3_2-malloctrim.result != 'success'
           && (needs.test_ubuntu_24_04-3_2-malloctrim.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.2/malloctrim];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/normal]' did not fail
+      - name: Check whether 'Test [ubuntu-24.04/4.0.2/normal]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_24_04-4_0_0-normal.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-normal.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/normal];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/jemalloc]' did not fail
+          needs.test_ubuntu_24_04-4_0_2-normal.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_2-normal.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.2/normal];'))
+      - name: Check whether 'Test [ubuntu-24.04/4.0.2/jemalloc]' did not fail
         run: 'false'
         if: |
-          needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-jemalloc.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/4.0.0/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-4_0_0-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.0/malloctrim];'))
+          needs.test_ubuntu_24_04-4_0_2-jemalloc.result != 'success'
+          && (needs.test_ubuntu_24_04-4_0_2-jemalloc.result != 'skipped'
+            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/4.0.2/jemalloc];'))
       - name: Check whether 'Test [ubuntu-24.04/3.4.8/normal]' did not fail
         run: 'false'
         if: |
@@ -8038,12 +5992,6 @@ jobs:
           needs.test_ubuntu_24_04-3_4_8-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_4_8-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4.8/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.4.8/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-3_4_8-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_4_8-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.4.8/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.3.10/normal]' did not fail
         run: 'false'
         if: |
@@ -8056,12 +6004,6 @@ jobs:
           needs.test_ubuntu_24_04-3_3_10-jemalloc.result != 'success'
           && (needs.test_ubuntu_24_04-3_3_10-jemalloc.result != 'skipped'
             || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3.10/jemalloc];'))
-      - name: Check whether 'Test [ubuntu-24.04/3.3.10/malloctrim]' did not fail
-        run: 'false'
-        if: |
-          needs.test_ubuntu_24_04-3_3_10-malloctrim.result != 'success'
-          && (needs.test_ubuntu_24_04-3_3_10-malloctrim.result != 'skipped'
-            || contains(inputs.necessary_jobs, ';Test against test repo [ubuntu-24.04/3.3.10/malloctrim];'))
       - name: Check whether 'Test [ubuntu-24.04/3.2.9/normal]' did not fail
         run: 'false'
         if: |

--- a/.github/workflows/ci-cd-publish-test-test.yml.erb
+++ b/.github/workflows/ci-cd-publish-test-test.yml.erb
@@ -103,7 +103,7 @@ jobs:
 
   <%- distributions.each do |distribution| %>
   <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-  <%- variants.each do |variant| -%>
+  <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
   <%- unindent(2) do %>
     test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>:
       name: 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]'
@@ -163,7 +163,7 @@ jobs:
       - publish
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-      <%- variants.each do |variant| -%>
+      <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
       - test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>
       <%- end -%>
       <%- end -%>
@@ -182,7 +182,7 @@ jobs:
 
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
-      <%- variants.each do |variant| -%>
+      <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
       - name: Check whether 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]' did not fail
         run: 'false'
         if: |

--- a/config.yml
+++ b/config.yml
@@ -12,8 +12,8 @@ ruby:
   ## then be sure to bump the corresponding `package_revision`!
   minor_version_packages:
     - minor_version: '4.0'
-      full_version: '4.0.0'
-      package_revision: '0'
+      full_version: '4.0.2'
+      package_revision: '1'
     - minor_version: '3.4'
       full_version: '3.4.8'
       package_revision: '7'
@@ -27,7 +27,7 @@ ruby:
   ## (Optional)
   ## Which tiny Ruby version packages to build.
   tiny_version_packages:
-    - full_version: '4.0.0'
+    - full_version: '4.0.2'
       package_revision: '0'
     - full_version: '3.4.8'
       package_revision: '0'
@@ -87,6 +87,16 @@ variants:
   normal: true
   jemalloc: true
   malloctrim: true
+
+## (Optional)
+## Excludes certain variants from certain Ruby minor versions.
+## Ruby >= 3.3 natively includes malloc_trim, so the malloctrim variant is unnecessary.
+variant_exclusions:
+  - variant: malloctrim
+    ruby_minor_versions:
+      - '3.3'
+      - '3.4'
+      - '4.0'
 
 ## (Required if variants.jemalloc is true)
 ## Version of Jemalloc to compile against.

--- a/internal-scripts/ci-cd/determine-necessary-jobs/determine-necessary-jobs.rb
+++ b/internal-scripts/ci-cd/determine-necessary-jobs/determine-necessary-jobs.rb
@@ -77,7 +77,7 @@ class App
 
     distributions.each do |distribution|
       ruby_package_versions_for_distro(distribution).each do |ruby_package_version|
-        variants.each do |variant|
+        variants_for_ruby_version(ruby_package_version).each do |variant|
           determine_necessary_job("Build Ruby [#{distribution[:name]}/#{ruby_package_version[:id]}/#{variant[:name]}]") do
             artifact_absent?(ruby_package_artifact_name(ruby_package_version, distribution, variant))
           end
@@ -88,7 +88,7 @@ class App
 
     distributions.each do |distribution|
       ruby_package_versions_for_distro(distribution).each do |ruby_package_version|
-        variants.each do |variant|
+        variants_for_ruby_version(ruby_package_version).each do |variant|
           determine_necessary_job("Test against test repo [#{distribution[:name]}/#{ruby_package_version[:id]}/#{variant[:name]}]") do
             artifact_absent?("tested-against-test-#{distribution[:name]}_#{ruby_package_version[:id]}_#{variant[:name]}")
           end
@@ -98,7 +98,7 @@ class App
 
     distributions.each do |distribution|
       ruby_package_versions_for_distro(distribution).each do |ruby_package_version|
-        variants.each do |variant|
+        variants_for_ruby_version(ruby_package_version).each do |variant|
           determine_necessary_job("Test against production repo [#{distribution[:name]}/#{ruby_package_version[:id]}/#{variant[:name]}]") do
             artifact_absent?("tested-against-production-#{distribution[:name]}_#{ruby_package_version[:id]}_#{variant[:name]}")
           end

--- a/lib/ci_workflow_support.rb
+++ b/lib/ci_workflow_support.rb
@@ -224,6 +224,16 @@ module CiWorkflowSupport
   end
 
 
+  def variants_for_ruby_version(ruby_package_version)
+    ruby_minor_version = ruby_package_version[:minor_version] || infer_ruby_minor_version_from_full_version(ruby_package_version[:full_version])
+    exclusions = config[:variant_exclusions] || []
+    variants.reject do |variant|
+      exclusions.any? do |exclusion|
+        exclusion[:variant] == variant[:name] && exclusion[:ruby_minor_versions].include?(ruby_minor_version)
+      end
+    end
+  end
+
   def ruby_source_versions
     @ruby_source_versions ||= begin
       result = []
@@ -302,7 +312,7 @@ module CiWorkflowSupport
     result = []
     distributions.each do |distribution|
       ruby_package_versions_for_distro(distribution).each do |ruby_package_version|
-        variants.each do |variant|
+        variants_for_ruby_version(ruby_package_version).each do |variant|
           result << ruby_package_artifact_name(ruby_package_version, distribution, variant)
         end
       end


### PR DESCRIPTION
Problem

PR #183 adds Ruby 4.0.0 but CI fails during the "Publish packages" step with "no space left on device". Adding a 4th Ruby minor version (4.0) to the build
matrix increases the total number of packages beyond the GitHub Actions runner's disk capacity.

As @FooBarWidget noted in https://github.com/fullstaq-ruby/server-edition/pull/183#issuecomment-3696141679, one viable short-term workaround is:

▎ We can remove the malloctrim variant for Ruby >= 3.3 since Ruby natively has it.

Ruby 3.3+ includes malloc_trim support natively, making the separate malloctrim variant unnecessary for those versions.

Solution

Introduces a variant_exclusions configuration option in config.yml, following the same pattern as the existing distribution_exclusions. This allows declaring
per-version variant exclusions declaratively in config without code changes:

variant_exclusions:
  - variant: malloctrim
    ruby_minor_versions:
      - '3.3'
      - '3.4'
      - '4.0'

A new variants_for_ruby_version(ruby_package_version) method in ci_workflow_support.rb filters variants based on these exclusions. All ERB templates and the
determine-necessary-jobs.rb script now use this method instead of the global variants list when iterating over Ruby version × variant combinations.

Impact

- Build jobs reduced from 162 → 120 (26% reduction, 42 fewer jobs)
- Fewer packages built, downloaded, and published during the publish step
- Directly addresses the disk space exhaustion that blocks this PR's CI
- malloctrim variant is preserved for Ruby 3.2 (and 3.2.9) where it still provides value

Files changed

- `config.yml` — Added `variant_exclusions` section
- `lib/ci_workflow_support.rb` — Added `variants_for_ruby_version()` method; updated `ruby_package_artifact_names` to use it
- `ci-cd-build-packages.yml.erb` — Use per-version variant filtering
- `ci-cd-publish-test-test.yml.erb` — Use per-version variant filtering
- `ci-cd-publish-test-production.yml.erb` — Use per-version variant filtering
- `determine-necessary-jobs.rb` — Use per-version variant filtering
- Generated `.yml` files — Regenerated (8,545 lines removed)
- Targets Ruby 4.0.2 (latest patch release) instead of 4.0.0

Testing

- All modified Ruby files pass syntax checks
- YAML generation succeeds and is idempotent
- Verified malloctrim jobs appear only for Ruby 3.2/3.2.9 across all distributions
- Verified Ruby 4.0/4.0.2 jobs exist with normal and jemalloc variants only
- No local unit test suite exists in this repo; integration tests run in CI

Notes

- This is a short-term fix as discussed in #183. The long-term solution would be to decouple APT repo management from local disk (as @FooBarWidget described).
- Users who installed the malloctrim variant for Ruby >= 3.3 won't get auto-upgrades for that variant, but this is an acceptable tradeoff since the
functionality is built into Ruby itself.
- The variant_exclusions feature is extensible — future exclusions (e.g., if jemalloc is dropped for certain versions) can be added to config.yml without any
code changes.