### PR TITLE
fix: improve publish workflow disk space exhaustion

### DIFF
--- a/.github/workflows/ci-cd-publish-test-production.yml
+++ b/.github/workflows/ci-cd-publish-test-production.yml
@@ -28,8 +28,59 @@ env:
 jobs:
   ### Publish ###
 
-  publish:
-    name: Publish packages
+  publish_debs:
+    name: Publish DEB packages
+    runs-on: ubuntu-24.04
+    environment: deploy
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clean disk space
+        run: ./internal-scripts/ci-cd/publish/clean-disk-space.sh
+      - uses: azure/login@v2
+        with:
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-deploy/providers/github-ci-deploy
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Download artifacts
+        run: ./internal-scripts/ci-cd/download-artifacts.sh
+        env:
+          ARTIFACT_NAMES: |
+            common-deb
+            rbenv-deb
+            ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.3_debian-11_normal ruby-pkg_4.0.3_debian-11_jemalloc ruby-pkg_3.4.9_debian-11_normal ruby-pkg_3.4.9_debian-11_jemalloc ruby-pkg_3.3.11_debian-11_normal ruby-pkg_3.3.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_normal ruby-pkg_3.2.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.3_debian-12_normal ruby-pkg_4.0.3_debian-12_jemalloc ruby-pkg_3.4.9_debian-12_normal ruby-pkg_3.4.9_debian-12_jemalloc ruby-pkg_3.3.11_debian-12_normal ruby-pkg_3.3.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_normal ruby-pkg_3.2.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.3_debian-13_normal ruby-pkg_4.0.3_debian-13_jemalloc ruby-pkg_3.4.9_debian-13_normal ruby-pkg_3.4.9_debian-13_jemalloc ruby-pkg_3.3.11_debian-13_normal ruby-pkg_3.3.11_debian-13_jemalloc ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.3_ubuntu-22.04_normal ruby-pkg_4.0.3_ubuntu-22.04_jemalloc ruby-pkg_3.4.9_ubuntu-22.04_normal ruby-pkg_3.4.9_ubuntu-22.04_jemalloc ruby-pkg_3.3.11_ubuntu-22.04_normal ruby-pkg_3.3.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_normal ruby-pkg_3.2.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.3_ubuntu-24.04_normal ruby-pkg_4.0.3_ubuntu-24.04_jemalloc ruby-pkg_3.4.9_ubuntu-24.04_normal ruby-pkg_3.4.9_ubuntu-24.04_jemalloc ruby-pkg_3.3.11_ubuntu-24.04_normal ruby-pkg_3.3.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_normal ruby-pkg_3.2.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_malloctrim
+          ARTIFACT_PATH: pkgs
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Install Aptly
+        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
+
+      - name: Upload DEBs to repo
+        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
+        env:
+          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
+          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
+          TESTING: false
+          OVERWRITE_EXISTING: false
+          DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
+          CLEANUP: true
+
+  publish_rpms:
+    name: Publish RPM packages
     runs-on: ubuntu-24.04
     environment: deploy
     timeout-minutes: 30
@@ -64,11 +115,9 @@ jobs:
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
           ARTIFACT_NAMES: |
-            common-deb
             common-rpm
-            rbenv-deb
             rbenv-rpm
-            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.3_centos-8_normal ruby-pkg_4.0.3_centos-8_jemalloc ruby-pkg_3.4.9_centos-8_normal ruby-pkg_3.4.9_centos-8_jemalloc ruby-pkg_3.3.11_centos-8_normal ruby-pkg_3.3.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_normal ruby-pkg_3.2.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.3_debian-11_normal ruby-pkg_4.0.3_debian-11_jemalloc ruby-pkg_3.4.9_debian-11_normal ruby-pkg_3.4.9_debian-11_jemalloc ruby-pkg_3.3.11_debian-11_normal ruby-pkg_3.3.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_normal ruby-pkg_3.2.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.3_debian-12_normal ruby-pkg_4.0.3_debian-12_jemalloc ruby-pkg_3.4.9_debian-12_normal ruby-pkg_3.4.9_debian-12_jemalloc ruby-pkg_3.3.11_debian-12_normal ruby-pkg_3.3.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_normal ruby-pkg_3.2.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.3_debian-13_normal ruby-pkg_4.0.3_debian-13_jemalloc ruby-pkg_3.4.9_debian-13_normal ruby-pkg_3.4.9_debian-13_jemalloc ruby-pkg_3.3.11_debian-13_normal ruby-pkg_3.3.11_debian-13_jemalloc ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.3_el-9_normal ruby-pkg_4.0.3_el-9_jemalloc ruby-pkg_3.4.9_el-9_normal ruby-pkg_3.4.9_el-9_jemalloc ruby-pkg_3.3.11_el-9_normal ruby-pkg_3.3.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_normal ruby-pkg_3.2.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.3_ubuntu-22.04_normal ruby-pkg_4.0.3_ubuntu-22.04_jemalloc ruby-pkg_3.4.9_ubuntu-22.04_normal ruby-pkg_3.4.9_ubuntu-22.04_jemalloc ruby-pkg_3.3.11_ubuntu-22.04_normal ruby-pkg_3.3.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_normal ruby-pkg_3.2.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.3_ubuntu-24.04_normal ruby-pkg_4.0.3_ubuntu-24.04_jemalloc ruby-pkg_3.4.9_ubuntu-24.04_normal ruby-pkg_3.4.9_ubuntu-24.04_jemalloc ruby-pkg_3.3.11_ubuntu-24.04_normal ruby-pkg_3.3.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_normal ruby-pkg_3.2.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.3_centos-8_normal ruby-pkg_4.0.3_centos-8_jemalloc ruby-pkg_3.4.9_centos-8_normal ruby-pkg_3.4.9_centos-8_jemalloc ruby-pkg_3.3.11_centos-8_normal ruby-pkg_3.3.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_normal ruby-pkg_3.2.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.3_el-9_normal ruby-pkg_4.0.3_el-9_jemalloc ruby-pkg_3.4.9_el-9_normal ruby-pkg_3.4.9_el-9_jemalloc ruby-pkg_3.3.11_el-9_normal ruby-pkg_3.3.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_normal ruby-pkg_3.2.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -84,22 +133,6 @@ jobs:
         if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
         env:
           TARBALL: image.tar.zst
-      - name: Install Aptly
-        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
-
-      - name: Determine latest release tag
-        # Sets environment variable $LATEST_RELEASE_TAG
-        run: ./internal-scripts/ci-cd/check-version-numbers-need-changing/determine-latest-release-tag.sh
-
-      - name: Upload DEBs to repo
-        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
-        env:
-          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
-          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
-          TESTING: false
-          OVERWRITE_EXISTING: false
-          DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
-          CLEANUP: true
 
       - name: Upload RPMs to repo
         run: ./internal-scripts/ci-cd/publish/publish-rpms.rb pkgs/*/*.rpm
@@ -110,9 +143,21 @@ jobs:
           OVERWRITE_EXISTING: false
           DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
 
+  restart_web_server:
+    name: Restart web server
+    needs:
+      - publish_debs
+      - publish_rpms
+    runs-on: ubuntu-24.04
+    environment: deploy
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         id: get-id-token
-        if: github.ref == 'refs/heads/main'
         with:
           script: |
             const fs = require('fs');
@@ -125,7 +170,6 @@ jobs:
 
       - name: Restart web server
         run: ./internal-scripts/ci-cd/publish/restart-web-server.rb
-        if: github.ref == 'refs/heads/main'
         env:
           ID_TOKEN: ${{ steps.get-id-token.outputs.id_token }}
 
@@ -137,7 +181,7 @@ jobs:
   test_centos_8-4_0-normal:
     name: 'Test [centos-8/4.0/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -180,7 +224,7 @@ jobs:
   test_centos_8-4_0-jemalloc:
     name: 'Test [centos-8/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -223,7 +267,7 @@ jobs:
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -266,7 +310,7 @@ jobs:
   test_centos_8-3_4-jemalloc:
     name: 'Test [centos-8/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -309,7 +353,7 @@ jobs:
   test_centos_8-3_3-normal:
     name: 'Test [centos-8/3.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -352,7 +396,7 @@ jobs:
   test_centos_8-3_3-jemalloc:
     name: 'Test [centos-8/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -395,7 +439,7 @@ jobs:
   test_centos_8-3_2-normal:
     name: 'Test [centos-8/3.2/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -438,7 +482,7 @@ jobs:
   test_centos_8-3_2-jemalloc:
     name: 'Test [centos-8/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -481,7 +525,7 @@ jobs:
   test_centos_8-3_2-malloctrim:
     name: 'Test [centos-8/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -524,7 +568,7 @@ jobs:
   test_centos_8-4_0_3-normal:
     name: 'Test [centos-8/4.0.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -567,7 +611,7 @@ jobs:
   test_centos_8-4_0_3-jemalloc:
     name: 'Test [centos-8/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -610,7 +654,7 @@ jobs:
   test_centos_8-3_4_9-normal:
     name: 'Test [centos-8/3.4.9/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -653,7 +697,7 @@ jobs:
   test_centos_8-3_4_9-jemalloc:
     name: 'Test [centos-8/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -696,7 +740,7 @@ jobs:
   test_centos_8-3_3_11-normal:
     name: 'Test [centos-8/3.3.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -739,7 +783,7 @@ jobs:
   test_centos_8-3_3_11-jemalloc:
     name: 'Test [centos-8/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -782,7 +826,7 @@ jobs:
   test_centos_8-3_2_11-normal:
     name: 'Test [centos-8/3.2.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -825,7 +869,7 @@ jobs:
   test_centos_8-3_2_11-jemalloc:
     name: 'Test [centos-8/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -868,7 +912,7 @@ jobs:
   test_centos_8-3_2_11-malloctrim:
     name: 'Test [centos-8/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -912,7 +956,7 @@ jobs:
   test_debian_11-4_0-normal:
     name: 'Test [debian-11/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -955,7 +999,7 @@ jobs:
   test_debian_11-4_0-jemalloc:
     name: 'Test [debian-11/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -998,7 +1042,7 @@ jobs:
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1041,7 +1085,7 @@ jobs:
   test_debian_11-3_4-jemalloc:
     name: 'Test [debian-11/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1084,7 +1128,7 @@ jobs:
   test_debian_11-3_3-normal:
     name: 'Test [debian-11/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1127,7 +1171,7 @@ jobs:
   test_debian_11-3_3-jemalloc:
     name: 'Test [debian-11/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1170,7 +1214,7 @@ jobs:
   test_debian_11-3_2-normal:
     name: 'Test [debian-11/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1213,7 +1257,7 @@ jobs:
   test_debian_11-3_2-jemalloc:
     name: 'Test [debian-11/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1256,7 +1300,7 @@ jobs:
   test_debian_11-3_2-malloctrim:
     name: 'Test [debian-11/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1299,7 +1343,7 @@ jobs:
   test_debian_11-4_0_3-normal:
     name: 'Test [debian-11/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1342,7 +1386,7 @@ jobs:
   test_debian_11-4_0_3-jemalloc:
     name: 'Test [debian-11/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1385,7 +1429,7 @@ jobs:
   test_debian_11-3_4_9-normal:
     name: 'Test [debian-11/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1428,7 +1472,7 @@ jobs:
   test_debian_11-3_4_9-jemalloc:
     name: 'Test [debian-11/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1471,7 +1515,7 @@ jobs:
   test_debian_11-3_3_11-normal:
     name: 'Test [debian-11/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1514,7 +1558,7 @@ jobs:
   test_debian_11-3_3_11-jemalloc:
     name: 'Test [debian-11/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1557,7 +1601,7 @@ jobs:
   test_debian_11-3_2_11-normal:
     name: 'Test [debian-11/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1600,7 +1644,7 @@ jobs:
   test_debian_11-3_2_11-jemalloc:
     name: 'Test [debian-11/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1643,7 +1687,7 @@ jobs:
   test_debian_11-3_2_11-malloctrim:
     name: 'Test [debian-11/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1687,7 +1731,7 @@ jobs:
   test_debian_12-4_0-normal:
     name: 'Test [debian-12/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1730,7 +1774,7 @@ jobs:
   test_debian_12-4_0-jemalloc:
     name: 'Test [debian-12/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1773,7 +1817,7 @@ jobs:
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1816,7 +1860,7 @@ jobs:
   test_debian_12-3_4-jemalloc:
     name: 'Test [debian-12/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1859,7 +1903,7 @@ jobs:
   test_debian_12-3_3-normal:
     name: 'Test [debian-12/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1902,7 +1946,7 @@ jobs:
   test_debian_12-3_3-jemalloc:
     name: 'Test [debian-12/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1945,7 +1989,7 @@ jobs:
   test_debian_12-3_2-normal:
     name: 'Test [debian-12/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -1988,7 +2032,7 @@ jobs:
   test_debian_12-3_2-jemalloc:
     name: 'Test [debian-12/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2031,7 +2075,7 @@ jobs:
   test_debian_12-3_2-malloctrim:
     name: 'Test [debian-12/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2074,7 +2118,7 @@ jobs:
   test_debian_12-4_0_3-normal:
     name: 'Test [debian-12/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2117,7 +2161,7 @@ jobs:
   test_debian_12-4_0_3-jemalloc:
     name: 'Test [debian-12/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2160,7 +2204,7 @@ jobs:
   test_debian_12-3_4_9-normal:
     name: 'Test [debian-12/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2203,7 +2247,7 @@ jobs:
   test_debian_12-3_4_9-jemalloc:
     name: 'Test [debian-12/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2246,7 +2290,7 @@ jobs:
   test_debian_12-3_3_11-normal:
     name: 'Test [debian-12/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2289,7 +2333,7 @@ jobs:
   test_debian_12-3_3_11-jemalloc:
     name: 'Test [debian-12/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2332,7 +2376,7 @@ jobs:
   test_debian_12-3_2_11-normal:
     name: 'Test [debian-12/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2375,7 +2419,7 @@ jobs:
   test_debian_12-3_2_11-jemalloc:
     name: 'Test [debian-12/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2418,7 +2462,7 @@ jobs:
   test_debian_12-3_2_11-malloctrim:
     name: 'Test [debian-12/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2462,7 +2506,7 @@ jobs:
   test_debian_13-4_0-normal:
     name: 'Test [debian-13/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2505,7 +2549,7 @@ jobs:
   test_debian_13-4_0-jemalloc:
     name: 'Test [debian-13/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2548,7 +2592,7 @@ jobs:
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2591,7 +2635,7 @@ jobs:
   test_debian_13-3_4-jemalloc:
     name: 'Test [debian-13/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2634,7 +2678,7 @@ jobs:
   test_debian_13-3_3-normal:
     name: 'Test [debian-13/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2677,7 +2721,7 @@ jobs:
   test_debian_13-3_3-jemalloc:
     name: 'Test [debian-13/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2720,7 +2764,7 @@ jobs:
   test_debian_13-4_0_3-normal:
     name: 'Test [debian-13/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2763,7 +2807,7 @@ jobs:
   test_debian_13-4_0_3-jemalloc:
     name: 'Test [debian-13/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2806,7 +2850,7 @@ jobs:
   test_debian_13-3_4_9-normal:
     name: 'Test [debian-13/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2849,7 +2893,7 @@ jobs:
   test_debian_13-3_4_9-jemalloc:
     name: 'Test [debian-13/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2892,7 +2936,7 @@ jobs:
   test_debian_13-3_3_11-normal:
     name: 'Test [debian-13/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2935,7 +2979,7 @@ jobs:
   test_debian_13-3_3_11-jemalloc:
     name: 'Test [debian-13/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -2979,7 +3023,7 @@ jobs:
   test_el_9-4_0-normal:
     name: 'Test [el-9/4.0/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3022,7 +3066,7 @@ jobs:
   test_el_9-4_0-jemalloc:
     name: 'Test [el-9/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3065,7 +3109,7 @@ jobs:
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3108,7 +3152,7 @@ jobs:
   test_el_9-3_4-jemalloc:
     name: 'Test [el-9/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3151,7 +3195,7 @@ jobs:
   test_el_9-3_3-normal:
     name: 'Test [el-9/3.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3194,7 +3238,7 @@ jobs:
   test_el_9-3_3-jemalloc:
     name: 'Test [el-9/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3237,7 +3281,7 @@ jobs:
   test_el_9-3_2-normal:
     name: 'Test [el-9/3.2/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3280,7 +3324,7 @@ jobs:
   test_el_9-3_2-jemalloc:
     name: 'Test [el-9/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3323,7 +3367,7 @@ jobs:
   test_el_9-3_2-malloctrim:
     name: 'Test [el-9/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3366,7 +3410,7 @@ jobs:
   test_el_9-4_0_3-normal:
     name: 'Test [el-9/4.0.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3409,7 +3453,7 @@ jobs:
   test_el_9-4_0_3-jemalloc:
     name: 'Test [el-9/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3452,7 +3496,7 @@ jobs:
   test_el_9-3_4_9-normal:
     name: 'Test [el-9/3.4.9/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3495,7 +3539,7 @@ jobs:
   test_el_9-3_4_9-jemalloc:
     name: 'Test [el-9/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3538,7 +3582,7 @@ jobs:
   test_el_9-3_3_11-normal:
     name: 'Test [el-9/3.3.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3581,7 +3625,7 @@ jobs:
   test_el_9-3_3_11-jemalloc:
     name: 'Test [el-9/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3624,7 +3668,7 @@ jobs:
   test_el_9-3_2_11-normal:
     name: 'Test [el-9/3.2.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3667,7 +3711,7 @@ jobs:
   test_el_9-3_2_11-jemalloc:
     name: 'Test [el-9/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3710,7 +3754,7 @@ jobs:
   test_el_9-3_2_11-malloctrim:
     name: 'Test [el-9/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3754,7 +3798,7 @@ jobs:
   test_ubuntu_22_04-4_0-normal:
     name: 'Test [ubuntu-22.04/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3797,7 +3841,7 @@ jobs:
   test_ubuntu_22_04-4_0-jemalloc:
     name: 'Test [ubuntu-22.04/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3840,7 +3884,7 @@ jobs:
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3883,7 +3927,7 @@ jobs:
   test_ubuntu_22_04-3_4-jemalloc:
     name: 'Test [ubuntu-22.04/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3926,7 +3970,7 @@ jobs:
   test_ubuntu_22_04-3_3-normal:
     name: 'Test [ubuntu-22.04/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -3969,7 +4013,7 @@ jobs:
   test_ubuntu_22_04-3_3-jemalloc:
     name: 'Test [ubuntu-22.04/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4012,7 +4056,7 @@ jobs:
   test_ubuntu_22_04-3_2-normal:
     name: 'Test [ubuntu-22.04/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4055,7 +4099,7 @@ jobs:
   test_ubuntu_22_04-3_2-jemalloc:
     name: 'Test [ubuntu-22.04/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4098,7 +4142,7 @@ jobs:
   test_ubuntu_22_04-3_2-malloctrim:
     name: 'Test [ubuntu-22.04/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4141,7 +4185,7 @@ jobs:
   test_ubuntu_22_04-4_0_3-normal:
     name: 'Test [ubuntu-22.04/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4184,7 +4228,7 @@ jobs:
   test_ubuntu_22_04-4_0_3-jemalloc:
     name: 'Test [ubuntu-22.04/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4227,7 +4271,7 @@ jobs:
   test_ubuntu_22_04-3_4_9-normal:
     name: 'Test [ubuntu-22.04/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4270,7 +4314,7 @@ jobs:
   test_ubuntu_22_04-3_4_9-jemalloc:
     name: 'Test [ubuntu-22.04/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4313,7 +4357,7 @@ jobs:
   test_ubuntu_22_04-3_3_11-normal:
     name: 'Test [ubuntu-22.04/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4356,7 +4400,7 @@ jobs:
   test_ubuntu_22_04-3_3_11-jemalloc:
     name: 'Test [ubuntu-22.04/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4399,7 +4443,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-normal:
     name: 'Test [ubuntu-22.04/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4442,7 +4486,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-jemalloc:
     name: 'Test [ubuntu-22.04/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4485,7 +4529,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-malloctrim:
     name: 'Test [ubuntu-22.04/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4529,7 +4573,7 @@ jobs:
   test_ubuntu_24_04-4_0-normal:
     name: 'Test [ubuntu-24.04/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4572,7 +4616,7 @@ jobs:
   test_ubuntu_24_04-4_0-jemalloc:
     name: 'Test [ubuntu-24.04/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4615,7 +4659,7 @@ jobs:
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4658,7 +4702,7 @@ jobs:
   test_ubuntu_24_04-3_4-jemalloc:
     name: 'Test [ubuntu-24.04/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4701,7 +4745,7 @@ jobs:
   test_ubuntu_24_04-3_3-normal:
     name: 'Test [ubuntu-24.04/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4744,7 +4788,7 @@ jobs:
   test_ubuntu_24_04-3_3-jemalloc:
     name: 'Test [ubuntu-24.04/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4787,7 +4831,7 @@ jobs:
   test_ubuntu_24_04-3_2-normal:
     name: 'Test [ubuntu-24.04/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4830,7 +4874,7 @@ jobs:
   test_ubuntu_24_04-3_2-jemalloc:
     name: 'Test [ubuntu-24.04/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4873,7 +4917,7 @@ jobs:
   test_ubuntu_24_04-3_2-malloctrim:
     name: 'Test [ubuntu-24.04/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4916,7 +4960,7 @@ jobs:
   test_ubuntu_24_04-4_0_3-normal:
     name: 'Test [ubuntu-24.04/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -4959,7 +5003,7 @@ jobs:
   test_ubuntu_24_04-4_0_3-jemalloc:
     name: 'Test [ubuntu-24.04/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5002,7 +5046,7 @@ jobs:
   test_ubuntu_24_04-3_4_9-normal:
     name: 'Test [ubuntu-24.04/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5045,7 +5089,7 @@ jobs:
   test_ubuntu_24_04-3_4_9-jemalloc:
     name: 'Test [ubuntu-24.04/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5088,7 +5132,7 @@ jobs:
   test_ubuntu_24_04-3_3_11-normal:
     name: 'Test [ubuntu-24.04/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5131,7 +5175,7 @@ jobs:
   test_ubuntu_24_04-3_3_11-jemalloc:
     name: 'Test [ubuntu-24.04/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5174,7 +5218,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-normal:
     name: 'Test [ubuntu-24.04/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5217,7 +5261,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-jemalloc:
     name: 'Test [ubuntu-24.04/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5260,7 +5304,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-malloctrim:
     name: 'Test [ubuntu-24.04/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-22.04
     environment: test
     timeout-minutes: 30
@@ -5311,7 +5355,9 @@ jobs:
       id-token: write
       contents: write
     needs:
-      - publish
+      - publish_debs
+      - publish_rpms
+      - restart_web_server
       - test_centos_8-4_0-normal
       - test_centos_8-4_0-jemalloc
       - test_centos_8-3_4-normal
@@ -5442,9 +5488,19 @@ jobs:
 
       ### Check whether dependent jobs failed ###
 
-      - name: Check whether 'Publish packages' succeeded
+      - name: Check whether 'Publish DEB packages' succeeded
         run: 'false'
-        if: needs.publish.result != 'success'
+        if: needs.publish_debs.result != 'success'
+
+      - name: Check whether 'Publish RPM packages' succeeded
+        run: 'false'
+        if: needs.publish_rpms.result != 'success'
+
+      - name: Check whether 'Restart web server' did not fail
+        run: 'false'
+        if: |
+          needs.restart_web_server.result != 'success'
+          && needs.restart_web_server.result != 'skipped'
 
       - name: Check whether 'Test [centos-8/4.0/normal]' did not fail
         run: 'false'

--- a/.github/workflows/ci-cd-publish-test-production.yml.erb
+++ b/.github/workflows/ci-cd-publish-test-production.yml.erb
@@ -18,8 +18,59 @@ env:
 jobs:
   ### Publish ###
 
-  publish:
-    name: Publish packages
+  publish_debs:
+    name: Publish DEB packages
+    runs-on: ubuntu-24.04
+    environment: deploy
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clean disk space
+        run: ./internal-scripts/ci-cd/publish/clean-disk-space.sh
+      - uses: azure/login@v2
+        with:
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-deploy/providers/github-ci-deploy
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Download artifacts
+        run: ./internal-scripts/ci-cd/download-artifacts.sh
+        env:
+          ARTIFACT_NAMES: |
+            <%= common_deb_artifact_name %>
+            <%= rbenv_deb_artifact_name %>
+            <%= ruby_package_artifact_names(:DEB).join(' ') %>
+          ARTIFACT_PATH: pkgs
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Install Aptly
+        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
+
+      - name: Upload DEBs to repo
+        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
+        env:
+          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
+          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
+          TESTING: false
+          OVERWRITE_EXISTING: false
+          DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
+          CLEANUP: true
+
+  publish_rpms:
+    name: Publish RPM packages
     runs-on: ubuntu-24.04
     environment: deploy
     timeout-minutes: 30
@@ -54,11 +105,9 @@ jobs:
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
           ARTIFACT_NAMES: |
-            <%= common_deb_artifact_name %>
             <%= common_rpm_artifact_name %>
-            <%= rbenv_deb_artifact_name %>
             <%= rbenv_rpm_artifact_name %>
-            <%= ruby_package_artifact_names.join(' ') %>
+            <%= ruby_package_artifact_names(:RPM).join(' ') %>
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -74,22 +123,6 @@ jobs:
         if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
         env:
           TARBALL: image.tar.zst
-      - name: Install Aptly
-        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
-
-      - name: Determine latest release tag
-        # Sets environment variable $LATEST_RELEASE_TAG
-        run: ./internal-scripts/ci-cd/check-version-numbers-need-changing/determine-latest-release-tag.sh
-
-      - name: Upload DEBs to repo
-        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
-        env:
-          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
-          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
-          TESTING: false
-          OVERWRITE_EXISTING: false
-          DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
-          CLEANUP: true
 
       - name: Upload RPMs to repo
         run: ./internal-scripts/ci-cd/publish/publish-rpms.rb pkgs/*/*.rpm
@@ -100,9 +133,21 @@ jobs:
           OVERWRITE_EXISTING: false
           DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
 
+  restart_web_server:
+    name: Restart web server
+    needs:
+      - publish_debs
+      - publish_rpms
+    runs-on: ubuntu-24.04
+    environment: deploy
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         id: get-id-token
-        if: github.ref == 'refs/heads/main'
         with:
           script: |
             const fs = require('fs');
@@ -115,7 +160,6 @@ jobs:
 
       - name: Restart web server
         run: ./internal-scripts/ci-cd/publish/restart-web-server.rb
-        if: github.ref == 'refs/heads/main'
         env:
           ID_TOKEN: ${{ steps.get-id-token.outputs.id_token }}
 
@@ -129,7 +173,7 @@ jobs:
     test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>:
       name: 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]'
       needs:
-        - publish
+        - <%= distribution[:package_format] == :DEB ? 'publish_debs' : 'publish_rpms' %>
       runs-on: ubuntu-22.04
       environment: test
       timeout-minutes: 30
@@ -184,7 +228,9 @@ jobs:
       id-token: write
       contents: write
     needs:
-      - publish
+      - publish_debs
+      - publish_rpms
+      - restart_web_server
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
       <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
@@ -202,9 +248,19 @@ jobs:
 
       ### Check whether dependent jobs failed ###
 
-      - name: Check whether 'Publish packages' succeeded
+      - name: Check whether 'Publish DEB packages' succeeded
         run: 'false'
-        if: needs.publish.result != 'success'
+        if: needs.publish_debs.result != 'success'
+
+      - name: Check whether 'Publish RPM packages' succeeded
+        run: 'false'
+        if: needs.publish_rpms.result != 'success'
+
+      - name: Check whether 'Restart web server' did not fail
+        run: 'false'
+        if: |
+          needs.restart_web_server.result != 'success'
+          && needs.restart_web_server.result != 'skipped'
 
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>

--- a/.github/workflows/ci-cd-publish-test-test.yml
+++ b/.github/workflows/ci-cd-publish-test-test.yml
@@ -28,8 +28,58 @@ env:
 jobs:
   ### Publish ###
 
-  publish:
-    name: Publish packages
+  publish_debs:
+    name: Publish DEB packages
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clean disk space
+        run: ./internal-scripts/ci-cd/publish/clean-disk-space.sh
+      - uses: azure/login@v2
+        with:
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Download artifacts
+        run: ./internal-scripts/ci-cd/download-artifacts.sh
+        env:
+          ARTIFACT_NAMES: |
+            common-deb
+            rbenv-deb
+            ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.3_debian-11_normal ruby-pkg_4.0.3_debian-11_jemalloc ruby-pkg_3.4.9_debian-11_normal ruby-pkg_3.4.9_debian-11_jemalloc ruby-pkg_3.3.11_debian-11_normal ruby-pkg_3.3.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_normal ruby-pkg_3.2.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.3_debian-12_normal ruby-pkg_4.0.3_debian-12_jemalloc ruby-pkg_3.4.9_debian-12_normal ruby-pkg_3.4.9_debian-12_jemalloc ruby-pkg_3.3.11_debian-12_normal ruby-pkg_3.3.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_normal ruby-pkg_3.2.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.3_debian-13_normal ruby-pkg_4.0.3_debian-13_jemalloc ruby-pkg_3.4.9_debian-13_normal ruby-pkg_3.4.9_debian-13_jemalloc ruby-pkg_3.3.11_debian-13_normal ruby-pkg_3.3.11_debian-13_jemalloc ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.3_ubuntu-22.04_normal ruby-pkg_4.0.3_ubuntu-22.04_jemalloc ruby-pkg_3.4.9_ubuntu-22.04_normal ruby-pkg_3.4.9_ubuntu-22.04_jemalloc ruby-pkg_3.3.11_ubuntu-22.04_normal ruby-pkg_3.3.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_normal ruby-pkg_3.2.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.3_ubuntu-24.04_normal ruby-pkg_4.0.3_ubuntu-24.04_jemalloc ruby-pkg_3.4.9_ubuntu-24.04_normal ruby-pkg_3.4.9_ubuntu-24.04_jemalloc ruby-pkg_3.3.11_ubuntu-24.04_normal ruby-pkg_3.3.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_normal ruby-pkg_3.2.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_malloctrim
+          ARTIFACT_PATH: pkgs
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Install Aptly
+        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
+
+      - name: Upload DEBs to repo
+        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
+        env:
+          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
+          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
+          TESTING: true
+          OVERWRITE_EXISTING: false
+          CLEANUP: true
+
+  publish_rpms:
+    name: Publish RPM packages
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -64,11 +114,9 @@ jobs:
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
           ARTIFACT_NAMES: |
-            common-deb
             common-rpm
-            rbenv-deb
             rbenv-rpm
-            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.3_centos-8_normal ruby-pkg_4.0.3_centos-8_jemalloc ruby-pkg_3.4.9_centos-8_normal ruby-pkg_3.4.9_centos-8_jemalloc ruby-pkg_3.3.11_centos-8_normal ruby-pkg_3.3.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_normal ruby-pkg_3.2.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_malloctrim ruby-pkg_4.0_debian-11_normal ruby-pkg_4.0_debian-11_jemalloc ruby-pkg_3.4_debian-11_normal ruby-pkg_3.4_debian-11_jemalloc ruby-pkg_3.3_debian-11_normal ruby-pkg_3.3_debian-11_jemalloc ruby-pkg_3.2_debian-11_normal ruby-pkg_3.2_debian-11_jemalloc ruby-pkg_3.2_debian-11_malloctrim ruby-pkg_4.0.3_debian-11_normal ruby-pkg_4.0.3_debian-11_jemalloc ruby-pkg_3.4.9_debian-11_normal ruby-pkg_3.4.9_debian-11_jemalloc ruby-pkg_3.3.11_debian-11_normal ruby-pkg_3.3.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_normal ruby-pkg_3.2.11_debian-11_jemalloc ruby-pkg_3.2.11_debian-11_malloctrim ruby-pkg_4.0_debian-12_normal ruby-pkg_4.0_debian-12_jemalloc ruby-pkg_3.4_debian-12_normal ruby-pkg_3.4_debian-12_jemalloc ruby-pkg_3.3_debian-12_normal ruby-pkg_3.3_debian-12_jemalloc ruby-pkg_3.2_debian-12_normal ruby-pkg_3.2_debian-12_jemalloc ruby-pkg_3.2_debian-12_malloctrim ruby-pkg_4.0.3_debian-12_normal ruby-pkg_4.0.3_debian-12_jemalloc ruby-pkg_3.4.9_debian-12_normal ruby-pkg_3.4.9_debian-12_jemalloc ruby-pkg_3.3.11_debian-12_normal ruby-pkg_3.3.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_normal ruby-pkg_3.2.11_debian-12_jemalloc ruby-pkg_3.2.11_debian-12_malloctrim ruby-pkg_4.0_debian-13_normal ruby-pkg_4.0_debian-13_jemalloc ruby-pkg_3.4_debian-13_normal ruby-pkg_3.4_debian-13_jemalloc ruby-pkg_3.3_debian-13_normal ruby-pkg_3.3_debian-13_jemalloc ruby-pkg_4.0.3_debian-13_normal ruby-pkg_4.0.3_debian-13_jemalloc ruby-pkg_3.4.9_debian-13_normal ruby-pkg_3.4.9_debian-13_jemalloc ruby-pkg_3.3.11_debian-13_normal ruby-pkg_3.3.11_debian-13_jemalloc ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.3_el-9_normal ruby-pkg_4.0.3_el-9_jemalloc ruby-pkg_3.4.9_el-9_normal ruby-pkg_3.4.9_el-9_jemalloc ruby-pkg_3.3.11_el-9_normal ruby-pkg_3.3.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_normal ruby-pkg_3.2.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_malloctrim ruby-pkg_4.0_ubuntu-22.04_normal ruby-pkg_4.0_ubuntu-22.04_jemalloc ruby-pkg_3.4_ubuntu-22.04_normal ruby-pkg_3.4_ubuntu-22.04_jemalloc ruby-pkg_3.3_ubuntu-22.04_normal ruby-pkg_3.3_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_normal ruby-pkg_3.2_ubuntu-22.04_jemalloc ruby-pkg_3.2_ubuntu-22.04_malloctrim ruby-pkg_4.0.3_ubuntu-22.04_normal ruby-pkg_4.0.3_ubuntu-22.04_jemalloc ruby-pkg_3.4.9_ubuntu-22.04_normal ruby-pkg_3.4.9_ubuntu-22.04_jemalloc ruby-pkg_3.3.11_ubuntu-22.04_normal ruby-pkg_3.3.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_normal ruby-pkg_3.2.11_ubuntu-22.04_jemalloc ruby-pkg_3.2.11_ubuntu-22.04_malloctrim ruby-pkg_4.0_ubuntu-24.04_normal ruby-pkg_4.0_ubuntu-24.04_jemalloc ruby-pkg_3.4_ubuntu-24.04_normal ruby-pkg_3.4_ubuntu-24.04_jemalloc ruby-pkg_3.3_ubuntu-24.04_normal ruby-pkg_3.3_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_normal ruby-pkg_3.2_ubuntu-24.04_jemalloc ruby-pkg_3.2_ubuntu-24.04_malloctrim ruby-pkg_4.0.3_ubuntu-24.04_normal ruby-pkg_4.0.3_ubuntu-24.04_jemalloc ruby-pkg_3.4.9_ubuntu-24.04_normal ruby-pkg_3.4.9_ubuntu-24.04_jemalloc ruby-pkg_3.3.11_ubuntu-24.04_normal ruby-pkg_3.3.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_normal ruby-pkg_3.2.11_ubuntu-24.04_jemalloc ruby-pkg_3.2.11_ubuntu-24.04_malloctrim
+            ruby-pkg_4.0_centos-8_normal ruby-pkg_4.0_centos-8_jemalloc ruby-pkg_3.4_centos-8_normal ruby-pkg_3.4_centos-8_jemalloc ruby-pkg_3.3_centos-8_normal ruby-pkg_3.3_centos-8_jemalloc ruby-pkg_3.2_centos-8_normal ruby-pkg_3.2_centos-8_jemalloc ruby-pkg_3.2_centos-8_malloctrim ruby-pkg_4.0.3_centos-8_normal ruby-pkg_4.0.3_centos-8_jemalloc ruby-pkg_3.4.9_centos-8_normal ruby-pkg_3.4.9_centos-8_jemalloc ruby-pkg_3.3.11_centos-8_normal ruby-pkg_3.3.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_normal ruby-pkg_3.2.11_centos-8_jemalloc ruby-pkg_3.2.11_centos-8_malloctrim ruby-pkg_4.0_el-9_normal ruby-pkg_4.0_el-9_jemalloc ruby-pkg_3.4_el-9_normal ruby-pkg_3.4_el-9_jemalloc ruby-pkg_3.3_el-9_normal ruby-pkg_3.3_el-9_jemalloc ruby-pkg_3.2_el-9_normal ruby-pkg_3.2_el-9_jemalloc ruby-pkg_3.2_el-9_malloctrim ruby-pkg_4.0.3_el-9_normal ruby-pkg_4.0.3_el-9_jemalloc ruby-pkg_3.4.9_el-9_normal ruby-pkg_3.4.9_el-9_jemalloc ruby-pkg_3.3.11_el-9_normal ruby-pkg_3.3.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_normal ruby-pkg_3.2.11_el-9_jemalloc ruby-pkg_3.2.11_el-9_malloctrim
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -84,21 +132,6 @@ jobs:
         if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
         env:
           TARBALL: image.tar.zst
-      - name: Install Aptly
-        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
-
-      - name: Determine latest release tag
-        # Sets environment variable $LATEST_RELEASE_TAG
-        run: ./internal-scripts/ci-cd/check-version-numbers-need-changing/determine-latest-release-tag.sh
-
-      - name: Upload DEBs to repo
-        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
-        env:
-          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
-          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
-          TESTING: true
-          OVERWRITE_EXISTING: false
-          CLEANUP: true
 
       - name: Upload RPMs to repo
         run: ./internal-scripts/ci-cd/publish/publish-rpms.rb pkgs/*/*.rpm
@@ -116,7 +149,7 @@ jobs:
   test_centos_8-4_0-normal:
     name: 'Test [centos-8/4.0/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -158,7 +191,7 @@ jobs:
   test_centos_8-4_0-jemalloc:
     name: 'Test [centos-8/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -200,7 +233,7 @@ jobs:
   test_centos_8-3_4-normal:
     name: 'Test [centos-8/3.4/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -242,7 +275,7 @@ jobs:
   test_centos_8-3_4-jemalloc:
     name: 'Test [centos-8/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -284,7 +317,7 @@ jobs:
   test_centos_8-3_3-normal:
     name: 'Test [centos-8/3.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -326,7 +359,7 @@ jobs:
   test_centos_8-3_3-jemalloc:
     name: 'Test [centos-8/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -368,7 +401,7 @@ jobs:
   test_centos_8-3_2-normal:
     name: 'Test [centos-8/3.2/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -410,7 +443,7 @@ jobs:
   test_centos_8-3_2-jemalloc:
     name: 'Test [centos-8/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -452,7 +485,7 @@ jobs:
   test_centos_8-3_2-malloctrim:
     name: 'Test [centos-8/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -494,7 +527,7 @@ jobs:
   test_centos_8-4_0_3-normal:
     name: 'Test [centos-8/4.0.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -536,7 +569,7 @@ jobs:
   test_centos_8-4_0_3-jemalloc:
     name: 'Test [centos-8/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -578,7 +611,7 @@ jobs:
   test_centos_8-3_4_9-normal:
     name: 'Test [centos-8/3.4.9/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -620,7 +653,7 @@ jobs:
   test_centos_8-3_4_9-jemalloc:
     name: 'Test [centos-8/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -662,7 +695,7 @@ jobs:
   test_centos_8-3_3_11-normal:
     name: 'Test [centos-8/3.3.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -704,7 +737,7 @@ jobs:
   test_centos_8-3_3_11-jemalloc:
     name: 'Test [centos-8/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -746,7 +779,7 @@ jobs:
   test_centos_8-3_2_11-normal:
     name: 'Test [centos-8/3.2.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -788,7 +821,7 @@ jobs:
   test_centos_8-3_2_11-jemalloc:
     name: 'Test [centos-8/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -830,7 +863,7 @@ jobs:
   test_centos_8-3_2_11-malloctrim:
     name: 'Test [centos-8/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -873,7 +906,7 @@ jobs:
   test_debian_11-4_0-normal:
     name: 'Test [debian-11/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -915,7 +948,7 @@ jobs:
   test_debian_11-4_0-jemalloc:
     name: 'Test [debian-11/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -957,7 +990,7 @@ jobs:
   test_debian_11-3_4-normal:
     name: 'Test [debian-11/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -999,7 +1032,7 @@ jobs:
   test_debian_11-3_4-jemalloc:
     name: 'Test [debian-11/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1041,7 +1074,7 @@ jobs:
   test_debian_11-3_3-normal:
     name: 'Test [debian-11/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1083,7 +1116,7 @@ jobs:
   test_debian_11-3_3-jemalloc:
     name: 'Test [debian-11/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1125,7 +1158,7 @@ jobs:
   test_debian_11-3_2-normal:
     name: 'Test [debian-11/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1167,7 +1200,7 @@ jobs:
   test_debian_11-3_2-jemalloc:
     name: 'Test [debian-11/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1209,7 +1242,7 @@ jobs:
   test_debian_11-3_2-malloctrim:
     name: 'Test [debian-11/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1251,7 +1284,7 @@ jobs:
   test_debian_11-4_0_3-normal:
     name: 'Test [debian-11/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1293,7 +1326,7 @@ jobs:
   test_debian_11-4_0_3-jemalloc:
     name: 'Test [debian-11/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1335,7 +1368,7 @@ jobs:
   test_debian_11-3_4_9-normal:
     name: 'Test [debian-11/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1377,7 +1410,7 @@ jobs:
   test_debian_11-3_4_9-jemalloc:
     name: 'Test [debian-11/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1419,7 +1452,7 @@ jobs:
   test_debian_11-3_3_11-normal:
     name: 'Test [debian-11/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1461,7 +1494,7 @@ jobs:
   test_debian_11-3_3_11-jemalloc:
     name: 'Test [debian-11/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1503,7 +1536,7 @@ jobs:
   test_debian_11-3_2_11-normal:
     name: 'Test [debian-11/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1545,7 +1578,7 @@ jobs:
   test_debian_11-3_2_11-jemalloc:
     name: 'Test [debian-11/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1587,7 +1620,7 @@ jobs:
   test_debian_11-3_2_11-malloctrim:
     name: 'Test [debian-11/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1630,7 +1663,7 @@ jobs:
   test_debian_12-4_0-normal:
     name: 'Test [debian-12/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1672,7 +1705,7 @@ jobs:
   test_debian_12-4_0-jemalloc:
     name: 'Test [debian-12/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1714,7 +1747,7 @@ jobs:
   test_debian_12-3_4-normal:
     name: 'Test [debian-12/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1756,7 +1789,7 @@ jobs:
   test_debian_12-3_4-jemalloc:
     name: 'Test [debian-12/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1798,7 +1831,7 @@ jobs:
   test_debian_12-3_3-normal:
     name: 'Test [debian-12/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1840,7 +1873,7 @@ jobs:
   test_debian_12-3_3-jemalloc:
     name: 'Test [debian-12/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1882,7 +1915,7 @@ jobs:
   test_debian_12-3_2-normal:
     name: 'Test [debian-12/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1924,7 +1957,7 @@ jobs:
   test_debian_12-3_2-jemalloc:
     name: 'Test [debian-12/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -1966,7 +1999,7 @@ jobs:
   test_debian_12-3_2-malloctrim:
     name: 'Test [debian-12/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2008,7 +2041,7 @@ jobs:
   test_debian_12-4_0_3-normal:
     name: 'Test [debian-12/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2050,7 +2083,7 @@ jobs:
   test_debian_12-4_0_3-jemalloc:
     name: 'Test [debian-12/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2092,7 +2125,7 @@ jobs:
   test_debian_12-3_4_9-normal:
     name: 'Test [debian-12/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2134,7 +2167,7 @@ jobs:
   test_debian_12-3_4_9-jemalloc:
     name: 'Test [debian-12/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2176,7 +2209,7 @@ jobs:
   test_debian_12-3_3_11-normal:
     name: 'Test [debian-12/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2218,7 +2251,7 @@ jobs:
   test_debian_12-3_3_11-jemalloc:
     name: 'Test [debian-12/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2260,7 +2293,7 @@ jobs:
   test_debian_12-3_2_11-normal:
     name: 'Test [debian-12/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2302,7 +2335,7 @@ jobs:
   test_debian_12-3_2_11-jemalloc:
     name: 'Test [debian-12/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2344,7 +2377,7 @@ jobs:
   test_debian_12-3_2_11-malloctrim:
     name: 'Test [debian-12/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2387,7 +2420,7 @@ jobs:
   test_debian_13-4_0-normal:
     name: 'Test [debian-13/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2429,7 +2462,7 @@ jobs:
   test_debian_13-4_0-jemalloc:
     name: 'Test [debian-13/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2471,7 +2504,7 @@ jobs:
   test_debian_13-3_4-normal:
     name: 'Test [debian-13/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2513,7 +2546,7 @@ jobs:
   test_debian_13-3_4-jemalloc:
     name: 'Test [debian-13/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2555,7 +2588,7 @@ jobs:
   test_debian_13-3_3-normal:
     name: 'Test [debian-13/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2597,7 +2630,7 @@ jobs:
   test_debian_13-3_3-jemalloc:
     name: 'Test [debian-13/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2639,7 +2672,7 @@ jobs:
   test_debian_13-4_0_3-normal:
     name: 'Test [debian-13/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2681,7 +2714,7 @@ jobs:
   test_debian_13-4_0_3-jemalloc:
     name: 'Test [debian-13/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2723,7 +2756,7 @@ jobs:
   test_debian_13-3_4_9-normal:
     name: 'Test [debian-13/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2765,7 +2798,7 @@ jobs:
   test_debian_13-3_4_9-jemalloc:
     name: 'Test [debian-13/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2807,7 +2840,7 @@ jobs:
   test_debian_13-3_3_11-normal:
     name: 'Test [debian-13/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2849,7 +2882,7 @@ jobs:
   test_debian_13-3_3_11-jemalloc:
     name: 'Test [debian-13/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2892,7 +2925,7 @@ jobs:
   test_el_9-4_0-normal:
     name: 'Test [el-9/4.0/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2934,7 +2967,7 @@ jobs:
   test_el_9-4_0-jemalloc:
     name: 'Test [el-9/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -2976,7 +3009,7 @@ jobs:
   test_el_9-3_4-normal:
     name: 'Test [el-9/3.4/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3018,7 +3051,7 @@ jobs:
   test_el_9-3_4-jemalloc:
     name: 'Test [el-9/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3060,7 +3093,7 @@ jobs:
   test_el_9-3_3-normal:
     name: 'Test [el-9/3.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3102,7 +3135,7 @@ jobs:
   test_el_9-3_3-jemalloc:
     name: 'Test [el-9/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3144,7 +3177,7 @@ jobs:
   test_el_9-3_2-normal:
     name: 'Test [el-9/3.2/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3186,7 +3219,7 @@ jobs:
   test_el_9-3_2-jemalloc:
     name: 'Test [el-9/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3228,7 +3261,7 @@ jobs:
   test_el_9-3_2-malloctrim:
     name: 'Test [el-9/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3270,7 +3303,7 @@ jobs:
   test_el_9-4_0_3-normal:
     name: 'Test [el-9/4.0.3/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3312,7 +3345,7 @@ jobs:
   test_el_9-4_0_3-jemalloc:
     name: 'Test [el-9/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3354,7 +3387,7 @@ jobs:
   test_el_9-3_4_9-normal:
     name: 'Test [el-9/3.4.9/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3396,7 +3429,7 @@ jobs:
   test_el_9-3_4_9-jemalloc:
     name: 'Test [el-9/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3438,7 +3471,7 @@ jobs:
   test_el_9-3_3_11-normal:
     name: 'Test [el-9/3.3.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3480,7 +3513,7 @@ jobs:
   test_el_9-3_3_11-jemalloc:
     name: 'Test [el-9/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3522,7 +3555,7 @@ jobs:
   test_el_9-3_2_11-normal:
     name: 'Test [el-9/3.2.11/normal]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3564,7 +3597,7 @@ jobs:
   test_el_9-3_2_11-jemalloc:
     name: 'Test [el-9/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3606,7 +3639,7 @@ jobs:
   test_el_9-3_2_11-malloctrim:
     name: 'Test [el-9/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_rpms
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3649,7 +3682,7 @@ jobs:
   test_ubuntu_22_04-4_0-normal:
     name: 'Test [ubuntu-22.04/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3691,7 +3724,7 @@ jobs:
   test_ubuntu_22_04-4_0-jemalloc:
     name: 'Test [ubuntu-22.04/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3733,7 +3766,7 @@ jobs:
   test_ubuntu_22_04-3_4-normal:
     name: 'Test [ubuntu-22.04/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3775,7 +3808,7 @@ jobs:
   test_ubuntu_22_04-3_4-jemalloc:
     name: 'Test [ubuntu-22.04/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3817,7 +3850,7 @@ jobs:
   test_ubuntu_22_04-3_3-normal:
     name: 'Test [ubuntu-22.04/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3859,7 +3892,7 @@ jobs:
   test_ubuntu_22_04-3_3-jemalloc:
     name: 'Test [ubuntu-22.04/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3901,7 +3934,7 @@ jobs:
   test_ubuntu_22_04-3_2-normal:
     name: 'Test [ubuntu-22.04/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3943,7 +3976,7 @@ jobs:
   test_ubuntu_22_04-3_2-jemalloc:
     name: 'Test [ubuntu-22.04/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -3985,7 +4018,7 @@ jobs:
   test_ubuntu_22_04-3_2-malloctrim:
     name: 'Test [ubuntu-22.04/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4027,7 +4060,7 @@ jobs:
   test_ubuntu_22_04-4_0_3-normal:
     name: 'Test [ubuntu-22.04/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4069,7 +4102,7 @@ jobs:
   test_ubuntu_22_04-4_0_3-jemalloc:
     name: 'Test [ubuntu-22.04/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4111,7 +4144,7 @@ jobs:
   test_ubuntu_22_04-3_4_9-normal:
     name: 'Test [ubuntu-22.04/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4153,7 +4186,7 @@ jobs:
   test_ubuntu_22_04-3_4_9-jemalloc:
     name: 'Test [ubuntu-22.04/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4195,7 +4228,7 @@ jobs:
   test_ubuntu_22_04-3_3_11-normal:
     name: 'Test [ubuntu-22.04/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4237,7 +4270,7 @@ jobs:
   test_ubuntu_22_04-3_3_11-jemalloc:
     name: 'Test [ubuntu-22.04/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4279,7 +4312,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-normal:
     name: 'Test [ubuntu-22.04/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4321,7 +4354,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-jemalloc:
     name: 'Test [ubuntu-22.04/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4363,7 +4396,7 @@ jobs:
   test_ubuntu_22_04-3_2_11-malloctrim:
     name: 'Test [ubuntu-22.04/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4406,7 +4439,7 @@ jobs:
   test_ubuntu_24_04-4_0-normal:
     name: 'Test [ubuntu-24.04/4.0/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4448,7 +4481,7 @@ jobs:
   test_ubuntu_24_04-4_0-jemalloc:
     name: 'Test [ubuntu-24.04/4.0/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4490,7 +4523,7 @@ jobs:
   test_ubuntu_24_04-3_4-normal:
     name: 'Test [ubuntu-24.04/3.4/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4532,7 +4565,7 @@ jobs:
   test_ubuntu_24_04-3_4-jemalloc:
     name: 'Test [ubuntu-24.04/3.4/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4574,7 +4607,7 @@ jobs:
   test_ubuntu_24_04-3_3-normal:
     name: 'Test [ubuntu-24.04/3.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4616,7 +4649,7 @@ jobs:
   test_ubuntu_24_04-3_3-jemalloc:
     name: 'Test [ubuntu-24.04/3.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4658,7 +4691,7 @@ jobs:
   test_ubuntu_24_04-3_2-normal:
     name: 'Test [ubuntu-24.04/3.2/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4700,7 +4733,7 @@ jobs:
   test_ubuntu_24_04-3_2-jemalloc:
     name: 'Test [ubuntu-24.04/3.2/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4742,7 +4775,7 @@ jobs:
   test_ubuntu_24_04-3_2-malloctrim:
     name: 'Test [ubuntu-24.04/3.2/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4784,7 +4817,7 @@ jobs:
   test_ubuntu_24_04-4_0_3-normal:
     name: 'Test [ubuntu-24.04/4.0.3/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4826,7 +4859,7 @@ jobs:
   test_ubuntu_24_04-4_0_3-jemalloc:
     name: 'Test [ubuntu-24.04/4.0.3/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4868,7 +4901,7 @@ jobs:
   test_ubuntu_24_04-3_4_9-normal:
     name: 'Test [ubuntu-24.04/3.4.9/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4910,7 +4943,7 @@ jobs:
   test_ubuntu_24_04-3_4_9-jemalloc:
     name: 'Test [ubuntu-24.04/3.4.9/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4952,7 +4985,7 @@ jobs:
   test_ubuntu_24_04-3_3_11-normal:
     name: 'Test [ubuntu-24.04/3.3.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -4994,7 +5027,7 @@ jobs:
   test_ubuntu_24_04-3_3_11-jemalloc:
     name: 'Test [ubuntu-24.04/3.3.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -5036,7 +5069,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-normal:
     name: 'Test [ubuntu-24.04/3.2.11/normal]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -5078,7 +5111,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-jemalloc:
     name: 'Test [ubuntu-24.04/3.2.11/jemalloc]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -5120,7 +5153,7 @@ jobs:
   test_ubuntu_24_04-3_2_11-malloctrim:
     name: 'Test [ubuntu-24.04/3.2.11/malloctrim]'
     needs:
-      - publish
+      - publish_debs
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -5169,7 +5202,8 @@ jobs:
     permissions:
       id-token: write
     needs:
-      - publish
+      - publish_debs
+      - publish_rpms
       - test_centos_8-4_0-normal
       - test_centos_8-4_0-jemalloc
       - test_centos_8-3_4-normal
@@ -5298,9 +5332,13 @@ jobs:
 
       ### Check whether dependent jobs failed ###
 
-      - name: Check whether 'Publish packages' succeeded
+      - name: Check whether 'Publish DEB packages' succeeded
         run: 'false'
-        if: needs.publish.result != 'success'
+        if: needs.publish_debs.result != 'success'
+
+      - name: Check whether 'Publish RPM packages' succeeded
+        run: 'false'
+        if: needs.publish_rpms.result != 'success'
 
       - name: Check whether 'Test [centos-8/4.0/normal]' did not fail
         run: 'false'

--- a/.github/workflows/ci-cd-publish-test-test.yml.erb
+++ b/.github/workflows/ci-cd-publish-test-test.yml.erb
@@ -18,8 +18,58 @@ env:
 jobs:
   ### Publish ###
 
-  publish:
-    name: Publish packages
+  publish_debs:
+    name: Publish DEB packages
+    runs-on: ubuntu-24.04
+    environment: test
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Clean disk space
+        run: ./internal-scripts/ci-cd/publish/clean-disk-space.sh
+      - uses: azure/login@v2
+        with:
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: ${{ vars.GCLOUD_PROJECT_ID }}
+          workload_identity_provider: projects/${{ vars.GCLOUD_PROJECT_NUM }}/locations/global/workloadIdentityPools/github-ci-test/providers/github-ci-test
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: '>= 363.0.0'
+
+      - name: Download artifacts
+        run: ./internal-scripts/ci-cd/download-artifacts.sh
+        env:
+          ARTIFACT_NAMES: |
+            <%= common_deb_artifact_name %>
+            <%= rbenv_deb_artifact_name %>
+            <%= ruby_package_artifact_names(:DEB).join(' ') %>
+          ARTIFACT_PATH: pkgs
+          CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
+
+      - name: Install Aptly
+        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
+
+      - name: Upload DEBs to repo
+        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
+        env:
+          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
+          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
+          TESTING: true
+          OVERWRITE_EXISTING: false
+          CLEANUP: true
+
+  publish_rpms:
+    name: Publish RPM packages
     runs-on: ubuntu-24.04
     environment: test
     timeout-minutes: 30
@@ -54,11 +104,9 @@ jobs:
         run: ./internal-scripts/ci-cd/download-artifacts.sh
         env:
           ARTIFACT_NAMES: |
-            <%= common_deb_artifact_name %>
             <%= common_rpm_artifact_name %>
-            <%= rbenv_deb_artifact_name %>
             <%= rbenv_rpm_artifact_name %>
-            <%= ruby_package_artifact_names.join(' ') %>
+            <%= ruby_package_artifact_names(:RPM).join(' ') %>
           ARTIFACT_PATH: pkgs
           CI_ARTIFACTS_BUCKET: ${{ vars.CI_ARTIFACTS_BUCKET }}
 
@@ -74,21 +122,6 @@ jobs:
         if: contains(inputs.necessary_jobs, ';Use locally-built Docker image utility;')
         env:
           TARBALL: image.tar.zst
-      - name: Install Aptly
-        run: ./internal-scripts/ci-cd/publish/install-aptly.sh
-
-      - name: Determine latest release tag
-        # Sets environment variable $LATEST_RELEASE_TAG
-        run: ./internal-scripts/ci-cd/check-version-numbers-need-changing/determine-latest-release-tag.sh
-
-      - name: Upload DEBs to repo
-        run: ./internal-scripts/ci-cd/publish/publish-debs.rb pkgs/*/*.deb
-        env:
-          PRODUCTION_REPO_BUCKET_NAME: fsruby-server-edition-apt-repo
-          CI_ARTIFACTS_BUCKET_NAME: ${{ vars.CI_ARTIFACTS_BUCKET }}
-          TESTING: true
-          OVERWRITE_EXISTING: false
-          CLEANUP: true
 
       - name: Upload RPMs to repo
         run: ./internal-scripts/ci-cd/publish/publish-rpms.rb pkgs/*/*.rpm
@@ -108,7 +141,7 @@ jobs:
     test_<%= slug(distribution[:name]) %>-<%= slug(ruby_package_version[:id]) %>-<%= slug(variant[:name]) %>:
       name: 'Test [<%= distribution[:name] %>/<%= ruby_package_version[:id] %>/<%= variant[:name] %>]'
       needs:
-        - publish
+        - <%= distribution[:package_format] == :DEB ? 'publish_debs' : 'publish_rpms' %>
       runs-on: ubuntu-24.04
       environment: test
       timeout-minutes: 30
@@ -160,7 +193,8 @@ jobs:
     permissions:
       id-token: write
     needs:
-      - publish
+      - publish_debs
+      - publish_rpms
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>
       <%- variants_for_ruby_version(ruby_package_version).each do |variant| -%>
@@ -176,9 +210,13 @@ jobs:
 
       ### Check whether dependent jobs failed ###
 
-      - name: Check whether 'Publish packages' succeeded
+      - name: Check whether 'Publish DEB packages' succeeded
         run: 'false'
-        if: needs.publish.result != 'success'
+        if: needs.publish_debs.result != 'success'
+
+      - name: Check whether 'Publish RPM packages' succeeded
+        run: 'false'
+        if: needs.publish_rpms.result != 'success'
 
       <%- distributions.each do |distribution| -%>
       <%- ruby_package_versions_for_distro(distribution).each do |ruby_package_version| -%>

--- a/internal-scripts/ci-cd/download-artifacts.sh
+++ b/internal-scripts/ci-cd/download-artifacts.sh
@@ -16,7 +16,7 @@ CI_ARTIFACTS_RUN_NUMBER=${CI_ARTIFACTS_RUN_NUMBER:-$GITHUB_RUN_NUMBER}
 CLEAR=${CLEAR:-false}
 TMPDIR=${TMPDIR:-/tmp}
 
-function cleanup()
+function _cleanup()
 {
     if [[ -n "$WORK_DIR" ]]; then
         rm -rf "$WORK_DIR"
@@ -48,4 +48,5 @@ echo "--> Extracting artifacts"
 for ARTIFACT_NAME in $ARTIFACT_NAMES; do
     mkdir -p "$ARTIFACT_PATH/$ARTIFACT_NAME"
     zstd -d < "$WORK_DIR/$ARTIFACT_NAME.tar.zst" | tar -C "$ARTIFACT_PATH/$ARTIFACT_NAME" -xf -
+    rm -f "$WORK_DIR/$ARTIFACT_NAME.tar.zst"
 done

--- a/lib/ci_workflow_support.rb
+++ b/lib/ci_workflow_support.rb
@@ -308,9 +308,10 @@ module CiWorkflowSupport
     "ruby-pkg_#{ruby_package_version[:id]}_#{distribution[:name]}_#{variant[:name]}"
   end
 
-  def ruby_package_artifact_names
+  def ruby_package_artifact_names(package_format = nil)
     result = []
     distributions.each do |distribution|
+      next if package_format && distribution[:package_format] != package_format
       ruby_package_versions_for_distro(distribution).each do |ruby_package_version|
         variants_for_ruby_version(ruby_package_version).each do |variant|
           result << ruby_package_artifact_name(ruby_package_version, distribution, variant)


### PR DESCRIPTION
## Summary

The publish workflow runs out of disk space on GitHub Actions ubuntu-24.04
runners, blocking PR #183 (Ruby 4.0.0) and future Ruby version additions.

This PR addresses the issue with two changes:

- **Fix `_cleanup` hook in `download-artifacts.sh`** — the script defined its
  own `cleanup()` which overrode the library's version (registered via
  `trap cleanup EXIT` in `library.sh`), breaking the standard cleanup chain.
  Renamed to `_cleanup()` to participate in the hook mechanism correctly.
  Also added per-file deletion of compressed artifacts after extraction to
  reduce peak disk usage during the download phase.

- **Split the single publish job into `publish_debs` and `publish_rpms`** — each
  runs on its own runner, downloading only its format's packages. This reduces
  input artifact disk usage per job, though the dominant disk cost remains the
  repository state (all historical packages). DEB tests depend on `publish_debs`,
  RPM tests depend on `publish_rpms`. In the production workflow,
  `restart_web_server` is extracted into its own job that waits for both.

Note: this is a incremental improvement. The major disk space interventions
are tracked in #190.

## Test plan

- [ ] Verify generated YAML is up-to-date (re-run `./internal-scripts/generate-ci-cd-yaml.rb`, confirm no diff)
- [ ] CI passes on this branch (publish jobs complete without disk exhaustion)
- [ ] Rebase PR #183 on top of this and confirm it also passes